### PR TITLE
I've added two operations to HList: remove and sublist

### DIFF
--- a/src/test/scala/shapeless/hlist.scala
+++ b/src/test/scala/shapeless/hlist.scala
@@ -699,18 +699,18 @@ class HListTests {
   }
 
   @Test
-  def testSublist {
+  def testRemoveAll {
     val l = 1 :: true :: "foo" :: HNil
 
-    val li = l.sublist[Int :: HNil]
+    val li = l.removeAll[Int :: HNil]
     typed[(Int :: HNil, Boolean :: String :: HNil)](li)
     assertEquals((1 :: HNil, true :: "foo" :: HNil), li)
 
-    val lb = l.sublist[Boolean :: HNil]
+    val lb = l.removeAll[Boolean :: HNil]
     typed[(Boolean :: HNil, Int :: String :: HNil)](lb)
     assertEquals((true :: HNil, 1 :: "foo" :: HNil), lb)
 
-    val lbi = l.sublist[Boolean :: Int :: HNil]
+    val lbi = l.removeAll[Boolean :: Int :: HNil]
     typed[(Boolean :: Int :: HNil, String :: HNil)](lbi)
     assertEquals((true :: 1 :: HNil, "foo" :: HNil), lbi)
   }


### PR DESCRIPTION
hlist.remove[U] is the same as select[U] but it also returns the remainder of the hlist with U removed.
hlist.sublist[SL] is a generalisation of remove, it returns a sublist\* from a hlist, plus the remainder.

(\* 'sublist' may not be the best term, as the types in SL don't need to be contiguous in hlist)

eg.

(1 :: true :: "foo" :: HNil).remove[Boolean] should be === (true, 1 :: "foo" :: HNil)
(1 :: true :: "foo" :: HNil).sublist[String :: Boolean :: HNil) should be === ("foo" :: true :: HNil, 1 :: HNil)

I've also been experimenting with creating an arbitrarily nested map (**)
Map[K1, Map[K2, Map[K3, V]]] === NMap[K1 :: K2 :: K3 :: HNil, V]

(**) It's not really a map since lookup operations iterate over every key !

I actually want it to be cheap to get any sub-nested map, regardless of key order, and am reading
"Using Space-filling Curves for Multi-dimensional Indexing" (www.dcs.bbk.ac.uk/TriStarp/pubs/bncod17.pdf) to figure out if that's possible.
