### PR TITLE
Improve HList Prepend with special handling for HNil

### DIFF
--- a/core/src/main/scala/shapeless/hlist.scala
+++ b/core/src/main/scala/shapeless/hlist.scala
@@ -1603,7 +1603,19 @@ trait PrependAux[P <: HList, S <: HList, Out <: HList] {
   def apply(prefix : P, suffix : S) : Out
 }
 
-object Prepend {
+trait LowPriorityPrepend {
+  implicit def hnilPrepend1[P <: HNil, S <: HList] = new Prepend[P, S] {
+    type Out = S
+    def apply(prefix: P, suffix: S) = suffix
+  }
+}
+
+object Prepend extends LowPriorityPrepend {
+  implicit def hnilPrepend2[P <: HList, S <: HNil] = new Prepend[P, S] {
+    type Out = P
+    def apply(prefix: P, suffix: S) = prefix
+  }
+
   implicit def prepend[P <: HList, S <: HList, Out0 <: HList](implicit prepend : PrependAux[P, S, Out0]) =
     new Prepend[P, S] {
       type Out = Out0
@@ -1635,8 +1647,20 @@ trait ReversePrepend[P <: HList, S <: HList] {
 trait ReversePrependAux[P <: HList, S <: HList, Out <: HList] {
   def apply(prefix : P, suffix : S) : Out
 }
+
+trait LowPriorityReversePrepend {
+  implicit def hnilReversePrepend1[P <: HNil, S <: HList] = new ReversePrepend[P, S] {
+    type Out = S
+    def apply(prefix: P, suffix: S) = suffix
+  }
+}
   
-object ReversePrepend {
+object ReversePrepend extends LowPriorityReversePrepend {
+  implicit def hnilReversePrepend2[P <: HList, S <: HNil](implicit rv: Reverse[P]) = new ReversePrepend[P, S] {
+    type Out = rv.Out
+    def apply(prefix: P, suffix: S) = prefix.reverse
+  }
+
   implicit def reversePrepend[P <: HList, S <: HList, Out0 <: HList]
     (implicit prepend : ReversePrependAux[P, S, Out0]) =
       new ReversePrepend[P, S] {

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -235,6 +235,20 @@ class HListTests {
     val pabp = ap reverse_::: bp
     typed[PABP](pabp)
     assertEquals(p :: a :: b :: p :: HNil, pabp)
+
+    // must compile without requiring an implicit Prepend
+    def prependWithHNil[L <: HList](list: L) = HNil ::: list
+    def prependToHNil[L <: HList](list: L) = list ::: HNil
+    assertEquals(prependWithHNil(ap), ap)
+    assertEquals(prependToHNil(ap), ap)
+    assertEquals(HNil ::: HNil, HNil)
+
+    // must compile without requiring an implicit ReversePrepend
+    def reversePrependWithHNil[L <: HList](list: L) = HNil reverse_::: list
+    def reversePrependToHNil[L <: HList: Reverse](list: L) = list reverse_::: HNil
+    assertEquals(reversePrependWithHNil(ap), ap)
+    assertEquals(reversePrependToHNil(ap), ap.reverse)
+    assertEquals(HNil reverse_::: HNil, HNil)
   }
     
   @Test


### PR DESCRIPTION
I came across a use case in my application that required an implicit `Prepend` where it shouldn't be needed. Since I'm trying to limit implicit parameters to only the cases where they are really necessary (they complicate the design of my DSL) I propose this small patch.

Essentially my patch makes the following two methods compile, where the compiler currently requires an implicit `Prepend` parameter.

``` scala
def prependWithHNil[L <: HList](list: L) = HNil ::: list
def prependToHNil[L <: HList](list: L) = list ::: HNil
```
