### PR TITLE
Simple publishing for 2.10.0-RC1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -96,6 +96,7 @@ object ShapelessBuild extends Build {
         v =>
           Seq("2.10.0-M6", "2.10.0-M7") ++ (if (v.endsWith("-SNAPSHOT")) Seq("2.10.0-SNAPSHOT") else Seq())
       },
+      scalaBinaryVersion <<= scalaVersion(sV => if (CrossVersion.isStable(sV)) CrossVersion.binaryScalaVersion(sV) else sV),
 
       scalacOptions       := Seq(
         "-feature",


### PR DESCRIPTION
Here are some changes which should simplify releasing a shapeless version for scala 2.10.0-RC1.
