### PR TITLE
New subtype unifier type class

### DIFF
--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -346,16 +346,16 @@ class HListTests {
   }
 
   @Test
-  def testNormalizer {
+  def testSubtypeUnifier {
     val fruits : Apple :: Pear :: Fruit :: HNil = a :: p :: f :: HNil
-    typed[Fruit :: Fruit :: Fruit :: HNil](fruits.normalize[Fruit])
-    typed[Apple :: Pear :: Fruit :: HNil](fruits.normalize[Apple])
-    assertEquals(a :: p :: f :: HNil, fruits.normalize[Fruit].filter[Fruit])
+    typed[Fruit :: Fruit :: Fruit :: HNil](fruits.unifySubtypes[Fruit])
+    typed[Apple :: Pear :: Fruit :: HNil](fruits.unifySubtypes[Apple])
+    assertEquals(a :: p :: f :: HNil, fruits.unifySubtypes[Fruit].filter[Fruit])
 
     val stuff : Apple :: String :: Pear :: HNil = a :: "foo" :: p :: HNil
-    typed[Fruit :: String :: Fruit :: HNil](stuff.normalize[Fruit])
+    typed[Fruit :: String :: Fruit :: HNil](stuff.unifySubtypes[Fruit])
     assertEquals(HNil, stuff.filter[Fruit])
-    assertEquals(a :: p :: HNil, stuff.normalize[Fruit].filter[Fruit])
+    assertEquals(a :: p :: HNil, stuff.unifySubtypes[Fruit].filter[Fruit])
   }
 
   @Test


### PR DESCRIPTION
Added a `SubtypeUnifier` type class to support the kind of normalization discussed [here](https://groups.google.com/d/msg/shapeless-dev/HvV63toSBNM/Nv0DsuBLJzEJ).

Also added a constraint to one of the implicits that creates `FilterAux` instances to avoid creating invalid instances like this:

``` scala
implicitly[FilterAux[Foo :: Foo :: HNil, Foo, Foo :: HNil]]
```

Together these two changes allow us to solve [this problem](https://groups.google.com/d/msg/shapeless-dev/HvV63toSBNM/K84lmwSsYzwJ) very concisely: 

``` scala
import shapeless._

implicit class Uniqueable[L <: HList](l: L) {
  def unique[A](implicit ev: FilterAux[L, A, A :: HNil]) = ev(l).head
}

class Foo; class Bar extends Foo

// These two compile:
(1 :: new Bar :: new Foo :: "a" :: HNil).unique[Bar]
(1 :: new Bar :: new Foo :: "a" :: HNil).unique[Foo]
```

But if we want to be sure that there's a unique `Foo` (including subtypes of `Foo`), we can write the following:

``` scala
(1 :: new Bar :: new Foo :: "a" :: HNil).unifySubtypes[Foo].unique[Foo]
```

And we'll get a compiler error, as desired.
