### PR TITLE
Add OSGi metadata to core jar

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,6 +19,7 @@ import Keys._
 import Build.data
 
 import com.typesafe.sbteclipse.plugin.EclipsePlugin.{ EclipseKeys, EclipseCreateSrc }
+import com.typesafe.sbt.osgi.SbtOsgi._
 
 object ShapelessBuild extends Build {
   
@@ -45,7 +46,7 @@ object ShapelessBuild extends Build {
     Project(
       id = "shapeless-core", 
       base = file("core"),
-      settings = commonSettings ++ Publishing.settings ++ Seq(
+      settings = commonSettings ++ Publishing.settings ++ osgiSettings ++ Seq(
         moduleName := "shapeless",
         
         managedSourceDirectories in Test := Nil,
@@ -66,7 +67,13 @@ object ShapelessBuild extends Build {
           },
           
         mappings in (Compile, packageSrc) <++=
-          (mappings in (Compile, packageSrc) in LocalProject("shapeless-examples"))
+          (mappings in (Compile, packageSrc) in LocalProject("shapeless-examples")),
+
+        OsgiKeys.exportPackage := Seq("shapeless.*;version=${Bundle-Version}"),
+
+        OsgiKeys.importPackage := Seq("""scala.*;version="$<range;[==,=+);$<@>>""""),
+
+        OsgiKeys.additionalHeaders := Map("-removeheaders" -> "Include-Resource,Private-Package")
       )
     )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.5.0")
+
 scalacOptions += "-deprecation"


### PR DESCRIPTION
This PR adds OSGi metadata to the shapeless core JAR utilizing https://github.com/sbt/sbt-osgi/, which allows OSGi users to deploy Shapeless directly without having to manually modify the manifest. There is no impact to non-OSGi users.

The resulting manifest looks like:

```
Export-Package: 
  shapeless.test
    uses
      scala.reflect.macros
      scala.reflect.api
      scala.runtime
      scala.collection.mutable
      scala.reflect
      scala
    version: 1.2.5.SNAPSHOT
  shapeless
    uses
      scala
      scala.collection
      scala.collection.mutable
      scala.reflect
      scala.runtime
      scala.collection.immutable
      scala.collection.generic
      scala.util
      scala.sys
    version: 1.2.5.SNAPSHOT
Bundle-Version: 
  1.2.5.SNAPSHOT
Manifest-Version: 
  1.0
Tool: 
  Bnd-1.50.0
Bundle-Name: 
  com.chuusai.shapeless.core
Bnd-LastModified: 
  1367345629055
Created-By: 
  1.6.0_45 (Apple Inc.)
Bundle-ManifestVersion: 
  2
Import-Package: 
  scala
    version: [2.10,2.11)
  scala.collection
    version: [2.10,2.11)
  scala.collection.generic
    version: [2.10,2.11)
  scala.collection.immutable
    version: [2.10,2.11)
  scala.collection.mutable
    version: [2.10,2.11)
  scala.reflect
    version: [2.10,2.11)
  scala.reflect.api
    version: [2.10,2.11)
  scala.reflect.macros
    version: [2.10,2.11)
  scala.runtime
    version: [2.10,2.11)
  scala.sys
    version: [2.10,2.11)
  scala.util
    version: [2.10,2.11)
Bundle-SymbolicName: 
  com.chuusai.shapeless.core
```
