### PR TITLE
More descriptive compilation failure message for invalid record access

### DIFF
--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -29,6 +29,7 @@ package record {
    * 
    * @author Miles Sabin
    */
+  @annotation.implicitNotFound(msg = "No field ${K} in record ${L}")
   trait Selector[L <: HList, K] {
     type Out
     def apply(l : L): Out
@@ -115,6 +116,7 @@ package record {
    * 
    * @author Miles Sabin
    */
+  @annotation.implicitNotFound(msg = "No field ${K} in record ${L}")
   trait Remover[L <: HList, K] extends DepFn1[L]
 
   trait LowPriorityRemover {


### PR DESCRIPTION
```
scala> val r = ("name" ->> "Joe") :: ("age" ->> 13) :: HNil
scala> r get "bzzzt"
error: No field String("bzzzt") in record ...
```

instead of

```
error: could not find implicit value for parameter selector ...
```
