### PR TITLE
Avoid SIP-18 warning under 2.11.0-SNAPSHOT

### DIFF
--- a/examples/src/main/scala/shapeless/examples/staging.scala
+++ b/examples/src/main/scala/shapeless/examples/staging.scala
@@ -65,6 +65,7 @@ object StagedTypeClassExample extends App {
   import scala.reflect.runtime.currentMirror
   import scala.tools.reflect.Eval
   import ReflectionUtils._
+  import language.existentials
 
   trait TupleConsumer[A, B] {
     def apply(t : (A, B)) : String


### PR DESCRIPTION
A new SIP-18 warning has entered the arena of staging.scala.

It arises from the fix for SI-7753 typing this application:

```
def mkExpr[T : TypeTag](mirror: Mirror)(tree : Tree) : mirror.universe.Expr[T] =
val consumeExpr = mkExpr[String](currentMirror)(consumeTree)
```

Because `currentMirror` isn't a stable value, we now use an
uses an existential to capture the argument type and the stability.

This runs afoul of SIP-18:

```
[info] [error] /localhome/jenkinsdbuild/workspace/Community-2.11.x-retronym/dbuild-0.7.1-M1/target-0.7.1-M1/project-builds/shapeless-fbbb9950ee5796e84406e391a287c38710f0fa1d/examples/src/main/scala/shapeless/examples/staging.scala:111: inferred existential type mirror.universe.Expr[String] forSome { val mirror: reflect.runtime.universe.Mirror }, which cannot be expressed by wildcards,  should be enabled
[info] [error] by making the implicit value scala.language.existentials visible.
[info] [error] This can be achieved by adding the import clause 'import scala.language.existentials'
[info] [error] or by setting the compiler option -language:existentials.
[info] [error] See the Scala docs for value scala.language.existentials for a discussion
[info] [error] why the feature should be explicitly enabled.
[info] [error]     val consumeExpr = mkExpr[String](currentMirror)(consumeTree)
[info] [error]
```

This commit disables the warning with a feature import.

Review by @milessabin
