### PR TITLE
mark the dependency to scala-compiler as provided

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -68,7 +68,7 @@ object ShapelessBuild extends Build {
         
         libraryDependencies <++= scalaVersion { sv =>
           Seq(
-            "org.scala-lang" % "scala-compiler" % sv,
+            "org.scala-lang" % "scala-reflect" % sv % "provided",
             "com.novocode" % "junit-interface" % "0.7" % "test"
         )},
         
@@ -123,7 +123,8 @@ object ShapelessBuild extends Build {
     settings = commonSettings ++ Seq(
       libraryDependencies <++= scalaVersion { sv =>
         Seq(
-          "org.scala-lang" % "scala-compiler" % sv,
+          // needs compiler for `scala.tools.reflect.Eval`
+          "org.scala-lang" % "scala-compiler" % sv % "provided",
           "com.novocode" % "junit-interface" % "0.7" % "test"
       )},
 


### PR DESCRIPTION
We've got a [report](https://groups.google.com/forum/#!topic/parboiled-user/78UkvcNkeAg) that parboiled2 fetches in all of the scala-compiler and it turned out that it was a transitive dependency from shapeless2:

```
[info] default:test-pb2_2.10:0.1-SNAPSHOT [S]
[info]   +-org.parboiled:parboiled_2.10:2.0-M2 [S]
[info]     +-com.chuusai:shapeless_2.10.3:2.0.0-M1 [S]
[info]     | +-org.scala-lang:scala-compiler:2.10.3 [S]
[info]     |   +-org.scala-lang:scala-reflect:2.10.3 [S]
[info]     |   
[info]     +-org.scala-lang:scala-reflect:2.10.3 [S]
[info]     
```

It seems the dependency is only needed during compilation and only to "scala-reflect".
