### PR TITLE
Made witness implicits available without extra import.

### DIFF
--- a/core/src/main/scala/shapeless/nat.scala
+++ b/core/src/main/scala/shapeless/nat.scala
@@ -65,18 +65,6 @@ object Nat extends Nats {
 
   def toInt(n : Nat)(implicit toIntN : ToInt[n.N]) = toIntN()
 
-  implicit val witness0: Witness.Aux[_0] =
-    new Witness {
-      type T = _0
-      val value = _0
-    }
-
-  implicit def witnessN[P <: Nat]: Witness.Aux[Succ[P]] =
-    new Witness {
-      type T = Succ[P]
-      val value = new Succ[P]()
-    }
-
   implicit def materialize(i: Int): Nat = macro NatMacros.materializeSingleton
 }
 

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -35,6 +35,18 @@ object Witness {
   implicit def apply[T]: Witness.Aux[T] = macro SingletonTypeMacros.materializeImpl[T]
 
   implicit def apply[T](t: T): Witness.Lt[T] = macro SingletonTypeMacros.convertImpl[T]
+
+  implicit val witness0: Witness.Aux[_0] =
+    new Witness {
+      type T = _0
+      val value = Nat._0
+    }
+
+  implicit def witnessN[P <: Nat]: Witness.Aux[Succ[P]] =
+    new Witness {
+      type T = Succ[P]
+      val value = new Succ[P]()
+    }
 }
 
 trait WitnessWith[TC[_]] extends Witness {


### PR DESCRIPTION
Previously it was necessary to import `Nat._` in order for e.g. `hlist.length` to compile.
