### PR TITLE
Support for Witness in Lens

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14 Lars Hupel, Miles Sabin 
+ * Copyright (c) 2012-14 Lars Hupel, Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,8 @@ trait LowPriorityLabelledGeneric {
 object LabelledGeneric extends LowPriorityLabelledGeneric {
   // Refinement for products, here we can provide the calling context with
   // a proof that the resulting Repr is a record
+  type Aux[T, Out0] = LabelledGeneric[T]{ type Repr = Out0 }
+
   implicit def product[T <: Product]: LabelledGeneric[T] = macro GenericMacros.materializeLabelledForProduct[T]
 }
 
@@ -395,7 +397,7 @@ object GenericMacros {
           resName
         )
       }
-      
+
       def outerTypeConstructor: Type =
         (if(labelled) typeOf[LabelledGeneric[_]] else typeOf[Generic[_]]).typeConstructor
 


### PR DESCRIPTION
This PR makes it possible to use field names in Lens:

``` scala
case class Address(street : String, city : String, postcode : String)
case class Person(name : String, age : Int, address : Address)

val address = Address("Southover Street", "Brighton", "BN2 9UA")
val person = Person("Joe Grey", 37, address)

val streetLens   = Lens[Person] >> 'address >> 'street

streetLens.get(person) //  res0: String = Southover Street
streetLens.set(person)("Ewart St") // res1: Person = Person(Joe Grey,37,Address(Ewart St,Brighton,BN2 9UA))
```
