### PR TITLE
Support selectDynamic access to records

### DIFF
--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -18,6 +18,7 @@ package shapeless
 package syntax
 
 import scala.language.dynamics
+import tag.@@
 
 /**
  * Record operations on `HList`'s with field-like elements.
@@ -25,7 +26,7 @@ import scala.language.dynamics
  * @author Miles Sabin
  */
 final class RecordOps[L <: HList](l : L) {
-  import record._
+  import shapeless.record._
   import ops.record._
 
   /**
@@ -92,7 +93,7 @@ final class RecordOps[L <: HList](l : L) {
   /**
    * Returns a wrapped version of this record that provides `selectDynamic` access to fields.
    */
-  def dynamic: DynamicRecordOps[L] = DynamicRecordOps(l)
+  def record: DynamicRecordOps[L] = DynamicRecordOps(l)
 }
 
 /**
@@ -104,7 +105,7 @@ final case class DynamicRecordOps[L <: HList](l : L) extends Dynamic {
   import ops.record.Selector
 
   /**
-   * Allows dynamic-style access to fields of the record whose keys are strings.
+   * Allows dynamic-style access to fields of the record whose keys are Symbols.
    */
-  def selectDynamic(key: String)(implicit selector: Selector[L, key.type]): selector.Out = selector(l)
+  def selectDynamic(key: String)(implicit selector: Selector[L, Symbol @@ key.type]): selector.Out = selector(l)
 }

--- a/core/src/main/scala/shapeless/syntax/unions.scala
+++ b/core/src/main/scala/shapeless/syntax/unions.scala
@@ -17,13 +17,16 @@
 package shapeless
 package syntax
 
+import scala.language.dynamics
+import tag.@@
+
 /**
  * Discriminated union operations on `Coproducts`'s with field-like elements.
  * 
  * @author Miles Sabin
  */
 final class UnionOps[C <: Coproduct](c : C) {
-  import union._
+  import shapeless.union._
   import ops.union._
 
   /**
@@ -41,5 +44,23 @@ final class UnionOps[C <: Coproduct](c : C) {
    * using CoproductOps#at instead of `CoproductOps#apply`.
    */
   def apply(k: Witness)(implicit selector : Selector[C, k.T]): selector.Out = selector(c)
+
+  /**
+   * Returns a wrapped version of this union that provides `selectDynamic` access to fields.
+   */
+  def union: DynamicUnionOps[C] = DynamicUnionOps(c)
 }
 
+/**
+ * Discriminated union wrapper providing `selectDynamic` access to fields.
+ * 
+ * @author Cody Allen
+ */
+final case class DynamicUnionOps[C <: Coproduct](c : C) extends Dynamic {
+  import ops.union.Selector
+
+  /**
+   * Allows dynamic-style access to fields of the union whose keys are Symbols.
+   */
+  def selectDynamic(key: String)(implicit selector: Selector[C, Symbol @@ key.type]): selector.Out = selector(c)
+}

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -555,8 +555,8 @@ class RecordTests {
 
   @Test
   def testSelectDynamic {
-    val r = ("foo" ->> 23) :: ("bar" ->> true) :: HNil
-    val d = r.dynamic
+    val r = ('foo ->> 23) :: ('bar ->> true) :: HNil
+    val d = r.record
 
     val v1 = d.foo
     typed[Int](v1)

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -50,4 +50,41 @@ class UnionTests {
       u1.get('foo)
     """)
   }
+
+  @Test
+  def testSelectDynamic {
+    val schema = RecordType.like('i ->> 23 :: 's ->> "foo" :: 'b ->> true :: HNil)
+    type U = schema.Union
+    val u1 = Coproduct[U]('i ->> 23).union
+    val u2 = Coproduct[U]('s ->> "foo").union
+    val u3 = Coproduct[U]('b ->> true).union
+    
+    val v1 = u1.i
+    typed[Option[Int]](v1)
+    assertEquals(Some(23), v1)
+
+    val n1 = u1.s
+    typed[Option[String]](n1)
+    assertEquals(None, n1)
+
+    val v2 = u2.s
+    typed[Option[String]](v2)
+    assertEquals(Some("foo"), v2)
+
+    val n2 = u2.b
+    typed[Option[Boolean]](n2)
+    assertEquals(None, n2)
+
+    val v3 = u3.b
+    typed[Option[Boolean]](v3)
+    assertEquals(Some(true), v3)
+
+    /*
+     * illTyped gives a false positive here, but `u1.foo` does in fact fail to compile
+     * however, it fails in a weird way: 
+     *   Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$,
+     *   class scala.reflect.internal.Types$ErrorType$] TypeRef? false
+     */
+    //illTyped("u1.foo")
+  }
 }


### PR DESCRIPTION
Adds a `dynamic` method to `RecordOps` that returns a wrapped version of
the record that provides `selectDynamic` access to fields whose keys are
strings.

I'm not particularly attached to the way this is set up.
- Declaring an `Ops` class as the return type for a method that isn't an implicit conversion feels wrong. I do think that `selectDynamic` access should be opt-in and not automatically attached to records, though.
- While this uses `selectDynamic`, this is all statically verified at compile-time, so `dynamic` might not be the best name.
- Due to my anal retentive nature, the special case of `l` returning the underlying `HList` as opposed to falling through to `selectDynamic` bothers me a bit. It seems like there should be some way of getting back to the underlying record though.

It was a simple and small enough change that it seemed best to just throw together a pull request for discussion.
