### PR TITLE
Changes/fixes in ToArray implementation

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -578,54 +578,29 @@ object hlist {
    * Type class supporting conversion of this `HList` to an `Array` with elements typed as the least upper bound
    * of the types of the elements of this `HList`.
    * 
-   * @author Miles Sabin
+   * @author Miles Sabin, Alexandre Archambault
    */
-  trait ToArray[-L <: HList, Lub] {
-    def apply(len : Int, l : L, i : Int) : Array[Lub]
+  trait ToArray[L <: HList, +Lub] {
+    import scala.reflect.ClassTag
+    def apply[T : ClassTag](len : Int, l : L, i : Int, f: Lub => T) : Array[T]
   }
 
-  trait LowPriorityToArray {
-    implicit def hlistToArrayAnyRef[L <: HList]: ToArray[L, Any] =
-      new ToArray[L, Any] {
-        def apply(len: Int, l : L, i : Int) : Array[Any] = {
-          val arr = Array[Any](len)
-          
-          @tailrec
-          def loop(l : HList, i: Int): Unit = l match {
-            case hd :: tl => arr(i) = hd ; loop(tl, i+1)  
-            case _ =>
-          }
-          loop(l, 0)
-          arr
-        }
-      }
-  }
-
-  object ToArray extends LowPriorityToArray {
+  object ToArray {
     def apply[L <: HList, Lub](implicit toArray: ToArray[L, Lub]) = toArray
 
     import scala.reflect.ClassTag
     
-    implicit def hnilToArray[T : ClassTag] : ToArray[HNil, T] =
-      new ToArray[HNil, T] {
-        def apply(len : Int, l : HNil, i : Int) = Array.ofDim[T](len)
+    implicit def hnilToArray[L <: HNil, Lub] : ToArray[L, Lub] =
+      new ToArray[L, Lub] {
+        def apply[T : ClassTag](len : Int, l : L, i : Int, f : Lub => T) = Array.ofDim[T](len)
       }
-    
-    implicit def hsingleToArray[T : ClassTag] : ToArray[T :: HNil, T] =
-      new ToArray[T :: HNil, T] {
-        def apply(len : Int, l : T :: HNil, i : Int) = {
-          val arr = Array.ofDim[T](len)
-          arr(i) = l.head
-          arr
-        }
-      }
-    
-    implicit def hlistToArray[H1, H2, T <: HList, L]
-      (implicit u : Lub[H1, H2, L], tta : ToArray[H2 :: T, L]): ToArray[H1 :: H2 :: T, L] =
-        new ToArray[H1 :: H2 :: T, L] {
-          def apply(len : Int, l : H1 :: H2 :: T, i : Int) = {
-            val arr = tta(len, l.tail, i+1)
-            arr(i) = u.left(l.head)
+
+    implicit def hlistToArray[H, T <: HList, LT, L]
+      (implicit tta : ToArray[T, LT], u : Lub[H, LT, L]) : ToArray[H :: T, L] =
+        new ToArray[H :: T, L] {
+          def apply[LLub : ClassTag](len : Int, l : H :: T, i : Int, f : L => LLub) = {
+            val arr = tta[LLub](len, l.tail, i+1, f compose u.right) 
+            arr(i) = f(u.left(l.head))
             arr
           }
         }

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -17,6 +17,8 @@
 package shapeless
 package ops
 
+import scala.reflect.ClassTag
+
 object tuple {
   import shapeless.ops.{ hlist => hl }
 
@@ -839,7 +841,7 @@ object tuple {
 
     type Aux[T, Lub, Out0] = ToArray[T, Lub] { type Out = Out0 }
     
-    implicit def toArray[T, L <: HList, Lub]
+    implicit def toArray[T, L <: HList, Lub : ClassTag]
       (implicit gen: Generic.Aux[T, L], toArray: hl.ToArray[L, Lub]): Aux[T, Lub, Array[Lub]] =
         new ToArray[T, Lub] {
           type Out = Array[Lub]

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -18,6 +18,7 @@ package shapeless
 package syntax
 
 import scala.annotation.tailrec
+import scala.reflect.ClassTag
 
 /**
  * Carrier for `HList` operations.
@@ -448,7 +449,7 @@ final class HListOps[L <: HList](l : L) {
    * particular, the inferred type will be too precise (ie. `Product with Serializable with CC` for a typical case class
    * `CC`) which interacts badly with the invariance of `Array`s.
    */
-  def toArray[Lub](implicit toArray : ToArray[L, Lub]) : Array[Lub] = toArray(runtimeLength, l, 0)
+  def toArray[Lub : ClassTag](implicit toArray : ToArray[L, Lub]) : Array[Lub] = toArray[Lub](runtimeLength, l, 0, identity)
 
   /**
    * Converts this `HList` of values into a record with the provided keys.

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -79,6 +79,7 @@ class HListTests {
   val cs: Ctv[String] = new Ctv[String] {}
   val cd: Ctv[Double] = new Ctv[Double] {}
   val cicscicicdList = ci :: cs :: ci :: ci :: cd :: Nil
+  val cicscicicdArray = Array(ci, cs, ci, ci, cd)
   val cicscicicd: CICSCICICD = ci :: cs :: ci :: ci :: cd :: HNil
 
   trait M[T]
@@ -88,6 +89,7 @@ class HListTests {
   val ms: M[String] = new M[String] {}
   val md: M[Double] = new M[Double] {}
   val mimsmimimdList = mi :: ms :: mi :: mi :: md :: Nil
+  val mimsmimimdArray = Array(mi, ms, mi, mi, md)
   val mimsmimimd: MIMSMIMIMD = mi :: ms :: mi :: mi :: md :: HNil
 
   import language.existentials
@@ -576,6 +578,10 @@ class HListTests {
     def assertArrayEquals2[T](arr1 : Array[T], arr2 : Array[T]) =
       assertArrayEquals(arr1.asInstanceOf[Array[Object]], arr1.asInstanceOf[Array[Object]])
     
+    val emptySizedArray = HNil.toArray
+    typed[Array[Nothing]](emptySizedArray)
+    assertArrayEquals2(Array[Nothing](), emptySizedArray)
+    
     val fruits1 = apap.toArray[Fruit]
     typed[Array[Fruit]](fruits1)
     assertArrayEquals2(Array[Fruit](a, p, a, p), fruits1)
@@ -611,6 +617,18 @@ class HListTests {
     val moreStuff = (a :: "foo" :: p :: HNil).toArray[AnyRef]
     typed[Array[AnyRef]](moreStuff)
     assertArrayEquals2(Array[AnyRef](a, "foo", p), moreStuff)
+
+    def equalInferredTypes[A,B](a: A, b: B)(implicit eq: A =:= B) {}
+
+    val ctv = cicscicicd.toArray
+    equalInferredTypes(cicscicicdArray, ctv)
+    typed[Array[Ctv[Int with String with Double]]](ctv)
+    assertArrayEquals2(cicscicicdArray, ctv)
+
+    val m = mimsmimimd.toArray
+    equalInferredTypes(mimsmimimdArray, m)
+    typed[Array[M[_ >: Int with String with Double]]](m)
+    assertArrayEquals2(mimsmimimdArray, m)
   }
   
   @Test


### PR DESCRIPTION
This PR makes more use cases of calling .toArray on an HList compile or return an array with the right Lub (see the added tests).

It changes the current ToArray implicits so that they look similar to my proposed implementation of ToList implicits (https://github.com/milessabin/shapeless/pull/103). In order to make the implementation as concise as ToList, I had to add a variance annotation on the Lub type, and make some slight changes to the apply method's signature. I also removed the unused type variance annotation on L.

This implementation of toArray looks more concise and clean to me. (Only 2 implicits instead of 4, a ClassTag is required only for the Lub and only so when .toArray is called, ...)
