### PR TITLE
ToTraversable

### DIFF
--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -811,17 +811,20 @@ object tuple {
    *
    * @author Alexandre Archambault
    */
-  trait ToTraversable[T, M[_]] extends DepFn1[T]
+  trait ToTraversable[T, M[_]] extends DepFn1[T] {
+    type Lub
+    type Out = M[Lub]
+  }
 
   object ToTraversable {
     def apply[T, M[_]](implicit toTraversable: ToTraversable[T, M]) = toTraversable
 
-    type Aux[T, M[_], Out0] = ToTraversable[T, M] { type Out = Out0 }
+    type Aux[T, M[_], Lub0] = ToTraversable[T, M] { type Lub = Lub0 }
 
-    implicit def toTraversable[T, L <: HList, M[_]]
-      (implicit gen: Generic.Aux[T, L], toTraversable: hl.ToTraversable[L, M]): Aux[T, M, toTraversable.Out] =
+    implicit def toTraversable[T, L <: HList, M[_], Lub]
+      (implicit gen: Generic.Aux[T, L], toTraversable: hl.ToTraversable.Aux[L, M, Lub]): Aux[T, M, Lub] =
         new ToTraversable[T, M] {
-          type Out = toTraversable.Out
+          type Lub = toTraversable.Lub
           def apply(t: T) = gen.to(t).to[M]
         }
   }
@@ -830,20 +833,20 @@ object tuple {
    * Type class supporting conversion of this tuple to a `List` with elements typed as the least upper bound
    * of the types of the elements of this tuple.
    * 
+   * Provided for backward compatibility.
+   * 
    * @author Miles Sabin
    */
   trait ToList[T, Lub] extends DepFn1[T]
 
   object ToList {
-    def apply[T, Lub](implicit toList: ToList[T, Lub]) = toList
-
     type Aux[T, Lub, Out0] = ToList[T, Lub] { type Out = Out0 }
     
     implicit def toList[T, L <: HList, Lub]
-      (implicit gen: Generic.Aux[T, L], toList: hl.ToList[L, Lub]): Aux[T, Lub, List[Lub]] =
+      (implicit toTraversable: ToTraversable.Aux[T, List, Lub]): Aux[T, Lub, List[Lub]] =
         new ToList[T, Lub] {
           type Out = List[Lub]
-          def apply(t: T): Out = gen.to(t).toList[Lub]
+          def apply(t: T) = toTraversable(t)
         }
   }
 
@@ -851,20 +854,20 @@ object tuple {
    * Type class supporting conversion of this tuple to an `Array` with elements typed as the least upper bound
    * of the types of the elements of this tuple.
    * 
+   * Provided for backward compatibility.
+   *
    * @author Miles Sabin
    */
   trait ToArray[T, Lub] extends DepFn1[T]
 
   object ToArray {
-    def apply[T, Lub](implicit toArray: ToArray[T, Lub]) = toArray
-
     type Aux[T, Lub, Out0] = ToArray[T, Lub] { type Out = Out0 }
     
     implicit def toArray[T, L <: HList, Lub]
-      (implicit gen: Generic.Aux[T, L], toArray: hl.ToArray[L, Lub]): Aux[T, Lub, Array[Lub]] =
+      (implicit toTraversable: ToTraversable.Aux[T, Array, Lub]): Aux[T, Lub, Array[Lub]] =
         new ToArray[T, Lub] {
           type Out = Array[Lub]
-          def apply(t: T): Out = gen.to(t).toArray[Lub]
+          def apply(t: T) = toTraversable(t)
         }
   }
 

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -454,7 +454,7 @@ final class HListOps[L <: HList](l : L) {
    * Converts this `HList` to an ordinary `List` of elements typed as the least upper bound of the types of the elements
    * of this `HList`.
    */
-  def toList[Lub](implicit toList : ToList[L, Lub]) : List[Lub] = toList(l)
+  def toList[Lub](implicit toTraversableAux : ToTraversable.Aux[L, List, Lub]) : toTraversableAux.Out = toTraversableAux(l)
   
   /**
    * Converts this `HList` to an `Array` of elements typed as the least upper bound of the types of the elements
@@ -464,7 +464,7 @@ final class HListOps[L <: HList](l : L) {
    * particular, the inferred type will be too precise (ie. `Product with Serializable with CC` for a typical case class
    * `CC`) which interacts badly with the invariance of `Array`s.
    */
-  def toArray[Lub](implicit toArray : ToArray[L, Lub]) : Array[Lub] = toArray(runtimeLength, l, 0)
+  def toArray[Lub](implicit toTraversableAux : ToTraversable.Aux[L, Array, Lub]) : toTraversableAux.Out = toTraversableAux(l)
 
   /**
    * Converts this `HList` to a - sized - `M` of elements typed as the least upper bound of the types of the elements

--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -400,7 +400,7 @@ final class TupleOps[T](t: T) {
    * Converts this tuple to a `List` of elements typed as the least upper bound of the types of the elements
    * of this tuple.
    */
-  def toList[Lub](implicit toList : ToList[T, Lub]) : toList.Out = toList(t)
+  def toList[Lub](implicit toTraversable : ToTraversable.Aux[T, List, Lub]) : toTraversable.Out = toTraversable(t)
   
   /**
    * Converts this tuple to an `Array` of elements typed as the least upper bound of the types of the elements
@@ -410,7 +410,7 @@ final class TupleOps[T](t: T) {
    * particular, the inferred type will be too precise (ie. `Product with Serializable with CC` for a typical case class
    * `CC`) which interacts badly with the invariance of `Array`s.
    */
-  def toArray[Lub](implicit toArray : ToArray[T, Lub]) : toArray.Out = toArray(t)
+  def toArray[Lub](implicit toTraversable : ToTraversable.Aux[T, Array, Lub]) : toTraversable.Out = toTraversable(t)
   
   /**
    * Converts this tuple to a `M` of elements typed as the least upper bound of the types of the elements

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -866,10 +866,9 @@ class HListTests {
     def assertArrayEquals2[T](arr1 : Array[T], arr2 : Array[T]) =
       assertArrayEquals(arr1.asInstanceOf[Array[Object]], arr1.asInstanceOf[Array[Object]])
     
-    // Pass with .to[Array], but not .toArray yet
-    // val empty = HNil.toArray
-    // typed[Array[Nothing]](empty)
-    // assertArrayEquals2(Array[Nothing](), empty)
+    val empty = HNil.toArray
+    typed[Array[Nothing]](empty)
+    assertArrayEquals2(Array[Nothing](), empty)
 
     val fruits1 = apap.toArray[Fruit]
     typed[Array[Fruit]](fruits1)
@@ -908,36 +907,32 @@ class HListTests {
     assertArrayEquals2(Array[AnyRef](a, "foo", p), moreStuff)
 
 
-    // def equalInferredTypes[A,B](a: A, b: B)(implicit eq: A =:= B) {}
+    def equalInferredTypes[A,B](a: A, b: B)(implicit eq: A =:= B) {}
 
-    // Do not pass yet
-    // val ctv = cicscicicd.toArray
-    // equalInferredTypes(cicscicicdArray, ctv)
-    // typed[Array[Ctv[Int with String with Double]]](ctv)
-    // assertArrayEquals2(cicscicicdArray, ctv)
+    val ctv = cicscicicd.toArray
+    equalInferredTypes(cicscicicdArray, ctv)
+    typed[Array[Ctv[Int with String with Double]]](ctv)
+    assertArrayEquals2(cicscicicdArray, ctv)
 
-    // Do not pass yet
-    // val m = mimsmimimd.toArray
-    // equalInferredTypes(mimsmimimdArray, m)
-    // typed[Array[M[_ >: Int with String with Double]]](m)
-    // assertArrayEquals2(mimsmimimdArray, m)
+    val m = mimsmimimd.toArray
+    equalInferredTypes(mimsmimimdArray, m)
+    typed[Array[M[_ >: Int with String with Double]]](m)
+    assertArrayEquals2(mimsmimimdArray, m)
 
     val mWithEx = mimsmimemd.toArray[M[_]]
     //  equalType(mimsmimemdArray, mWithEx)
     typed[Array[M[_]]](mWithEx)
     assertArrayEquals2(mimsmimemdArray, mWithEx)
 
-    // Do not pass yet
-    // val m2 = m2im2sm2im2im2d.toArray
-    // equalInferredTypes(m2im2sm2im2im2dArray, m2)
-    // typed[Array[M2[_ >: Int with String with Double, Unit]]](m2)
-    // assertArrayEquals2(m2im2sm2im2im2dArray, m2)
+    val m2 = m2im2sm2im2im2d.toArray
+    equalInferredTypes(m2im2sm2im2im2dArray, m2)
+    typed[Array[M2[_ >: Int with String with Double, Unit]]](m2)
+    assertArrayEquals2(m2im2sm2im2im2dArray, m2)
 
-    // Do not pass yet
-    // val m2e = m2eim2esm2eim2eem2ed.toArray
-    // // equalType(m2eim2esm2eim2eem2edList, m2e)
-    // typed[Array[M2[_ >: Int with String with Double, _]]](m2e)
-    // assertArrayEquals2(m2im2sm2im2im2dArray.map(x => x : Any), m2e.map(x => x : Any))
+    val m2e = m2eim2esm2eim2eem2ed.toArray
+    // equalType(m2eim2esm2eim2eem2edList, m2e)
+    typed[Array[M2[_ >: Int with String with Double, _]]](m2e)
+    assertArrayEquals2(m2im2sm2im2im2dArray.map(x => x : Any), m2e.map(x => x : Any))
   }
   
   @Test

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -649,36 +649,33 @@ class TupleTests {
     assertArrayEquals2(Array[AnyRef](a, "foo", p), moreStuff)
 
 
-    // def equalInferredTypes[A,B](a: A, b: B)(implicit eq: A =:= B) {}
+    def equalInferredTypes[A,B](a: A, b: B)(implicit eq: A =:= B) {}
 
-    // Do not pass yet
-    // val ctv = cicscicicd.toArray
-    // equalInferredTypes(cicscicicdArray, ctv)
-    // typed[Array[Ctv[Int with String with Double]]](ctv)
-    // assertArrayEquals2(cicscicicdArray, ctv)
+    val ctv = cicscicicd.toArray
+    equalInferredTypes(cicscicicdArray, ctv)
+    typed[Array[Ctv[Int with String with Double]]](ctv)
+    assertArrayEquals2(cicscicicdArray, ctv)
 
-    // Do not pass yet
-    // val m = mimsmimimd.toArray
-    // equalInferredTypes(mimsmimimdArray, m)
-    // typed[Array[M[_ >: Int with String with Double]]](m)
-    // assertArrayEquals2(mimsmimimdArray, m)
+    val m = mimsmimimd.toArray
+    equalInferredTypes(mimsmimimdArray, m)
+    typed[Array[M[_ >: Int with String with Double]]](m)
+    assertArrayEquals2(mimsmimimdArray, m)
 
     val mWithEx = mimsmimemd.toArray[M[_]]
     //  equalType(mimsmimemdArray, mWithEx)
     typed[Array[M[_]]](mWithEx)
     assertArrayEquals2(mimsmimemdArray, mWithEx)
 
-    // Do not pass yet
-    // val m2 = m2im2sm2im2im2d.toArray
-    // equalInferredTypes(m2im2sm2im2im2dArray, m2)
-    // typed[Array[M2[_ >: Int with String with Double, Unit]]](m2)
-    // assertArrayEquals2(m2im2sm2im2im2dArray, m2)
+    val m2 = m2im2sm2im2im2d.toArray
+    equalInferredTypes(m2im2sm2im2im2dArray, m2)
+    typed[Array[M2[_ >: Int with String with Double, Unit]]](m2)
+    assertArrayEquals2(m2im2sm2im2im2dArray, m2)
 
-    // Do not pass yet
-    // val m2e = m2eim2esm2eim2eem2ed.toArray
-    // // equalType(m2eim2esm2eim2eem2edList, m2e)
+    val m2e = m2eim2esm2eim2eem2ed.toArray
+    // equalType(m2eim2esm2eim2eem2edList, m2e)
     // typed[Array[M2[_ >: Int with String with Double, _]]](m2e)
-    // assertArrayEquals2(m2im2sm2im2im2dArray.map(x => x : Any), m2e.map(x => x : Any))
+    // The line above compiles when mimsmimemd is an HList, not when it is a tuple...
+    assertArrayEquals2(m2im2sm2im2im2dArray.map(x => x : Any), m2e.map(x => x : Any))
   }
   
   @Test


### PR DESCRIPTION
[Only the last two commits are relevant, they rely on some elements of the first four, that are also in https://github.com/milessabin/shapeless/pull/114].

This PR mainly adds a .to[M] method on HLists (and tuples). It allows one to write things like:
val hl = a :: b :: c :: ... :: HNil
val l = hl.to[List] // List[some Lub type], should be the same type as the one inferred for List(a, b, c, ...)
val ar = hl.to[Array] // Same thing with Array - note that it also works with non covariant containers
// Also works with IndexedSeq, Set, ...

This method is added by the first relevant (actually fifth) commit of this PR.

If one wants to supply a Lub instead of the one found by the implicit ToTraversable used by .to[M], the methods .toList[Lub] and .toArray[Lub] are still there, and their implementation relies on the same implicits as ".to[M]" (change made by the second - or sixth - commit)

val lt = hl.toArray[SomeClass]

(Obviously, supplying a Lub to .toArray and .toList is not mandatory, and .toArray and .toList should be synonymous to .to[List] and .to[Array])
