### PR TITLE
added RecordOps.getField to extract full field (key->value) (Fixes issue #53)

### DIFF
--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -49,7 +49,7 @@ final class RecordOps[L <: HList](l : L) {
    * Returns the value associated with the singleton typed key k. Only available if this record has a field with
    * with keyType equal to the singleton type k.T.
    */
-  def getField(k: Witness)(implicit selector : Selector[L, k.T]): FieldType[k.T, selector.Out] = field[k.T](selector(l))
+  def fieldAt(k: Witness)(implicit selector : Selector[L, k.T]): FieldType[k.T, selector.Out] = field[k.T](selector(l))
 
   /**
    * Updates or adds to this record a field with key type F and value type F#valueType.

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -86,14 +86,14 @@ class RecordTests {
   }
 
   @Test
-  def testGetField {
+  def testFieldAt {
     val r1 =
       (intField1    ->>  "toto") ::
       (boolField1   ->>  true)   ::
       HNil
 
-    val v1 = r1.getField(intField1)
-    val v2 = r1.getField(boolField1)
+    val v1 = r1.fieldAt(intField1)
+    val v2 = r1.fieldAt(boolField1)
     typed[FieldType[intField1.type, String]](v1)
     typed[FieldType[boolField1.type, Boolean]](v2)
     assertEquals("toto", v1)


### PR DESCRIPTION
- Fixing issue https://github.com/milessabin/shapeless/issues/53
- called the function `getField` instead of `field` to prevent collision with `field[K]` function
- added a simple test
