### PR TITLE
Fixes/changes in Unify implementation

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -465,31 +465,38 @@ object hlist {
   /**
    * Type class supporting unification of this `HList`. 
    * 
-   * @author Miles Sabin
+   * @author Alexandre Archambault
    */
-  trait Unifier[L <: HList] extends DepFn1[L] { type Out <: HList }
+  trait Unifier[L <: HList, Lub] extends DepFn1[L] {
+    type OutT[UB] <: HList
+    def unify[UB](l: L, f: Lub => UB): OutT[UB]
 
+    type Out = OutT[Lub]
+    def apply(l: L): Out = unify[Lub](l, identity)
+  }
   object Unifier {
-    def apply[L <: HList](implicit unifier: Unifier[L]): Aux[L, unifier.Out] = unifier
+    def apply[L <: HList, Lub](implicit unifier: Unifier[L, Lub]): unifier.type = unifier
 
-    type Aux[L <: HList, Out0 <: HList] = Unifier[L] { type Out = Out0 }
+    type Aux[L <: HList, Lub, OutT0[UB] <: HList] = Unifier[L, Lub] { type OutT[UB] = OutT0[UB] }
 
-    implicit val hnilUnifier: Aux[HNil, HNil] = new Unifier[HNil] {
-      type Out = HNil
-      def apply(l : HNil): Out = l
-    }
-    
-    implicit def hsingleUnifier[T]: Aux[T :: HNil, T :: HNil] =
-      new Unifier[T :: HNil] {
-        type Out = T :: HNil
-        def apply(l : T :: HNil): Out = l
+    implicit def hnilUnifier[L <: HNil, T]: Aux[L, T, Const[HNil.type]#λ] =
+      new Unifier[L, T] {
+        type OutT[UB] = HNil.type
+        def unify[UB](l: L, f: T => UB) = HNil
       }
     
-    implicit def hlistUnifier[H1, H2, L, T <: HList]
-      (implicit u : Lub[H1, H2, L], lt : Unifier[L :: T]): Aux[H1 :: H2 :: T, L :: lt.Out] =
-        new Unifier[H1 :: H2 :: T] {
-          type Out = L :: lt.Out
-          def apply(l : H1 :: H2 :: T): Out = u.left(l.head) :: lt(u.right(l.tail.head) :: l.tail.tail)
+    implicit def hsingleUnifier[T]: Aux[T :: HNil, T, ({ type OutT[UB] = UB :: HNil })#OutT] =
+      new Unifier[T :: HNil, T] {
+        type OutT[UB] = UB :: HNil
+        def unify[UB](l: T :: HNil, f: T => UB) = f(l.head) :: HNil
+      }
+    
+    implicit def hlistUnifier[H1, H2, T <: HList, LT, L]
+      (implicit lt: Unifier[H2 :: T, LT], u: Lub[H1, LT, L])
+      : Aux[H1 :: H2 :: T, L, ({ type OutT[UB] = UB :: lt.OutT[UB] })#OutT] =
+        new Unifier[H1 :: H2 :: T, L] {
+          type OutT[UB] = UB :: lt.OutT[UB]
+          def unify[UB](l: H1 :: H2 :: T, f: L => UB) = f(u.left(l.head)) :: lt.unify(l.tail, f compose u.right)
         }
   }
 

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -747,21 +747,51 @@ object tuple {
   /**
    * Type class supporting unification of this tuple. 
    * 
-   * @author Miles Sabin
+   * @author Alexandre Archambault
    */
-  trait Unifier[T] extends DepFn1[T]
+  trait Unifier[-T,+Lub] {
+    type OutT[UB]
+    def apply[UB >: Lub](t: T): OutT[UB]
+  }
 
   object Unifier {
-    def apply[T](implicit unifier: Unifier[T]): Aux[T, unifier.Out] = unifier
-
-    type Aux[T, Out0] = Unifier[T] { type Out = Out0 }
+    // These implicits should be automatically generated for all tuple lengths 
     
-    implicit def unifier[T, L1 <: HList, L2 <: HList]
-      (implicit gen: Generic.Aux[T, L1], unifier: hl.Unifier.Aux[L1, L2], tp: hl.Tupler[L2]): Aux[T, tp.Out] =
-        new Unifier[T] {
-          type Out = tp.Out
-          def apply(t: T): Out = unifier(gen.to(t)).tupled
-        }
+    implicit def unifier0: Unifier[Unit,Nothing] { type OutT[UB] = Unit } =
+      new Unifier[Unit,Nothing] {
+        type OutT[UB] = Unit
+        def apply[UB >: Nothing](t: Unit) = t
+      }
+    
+    implicit def unifier1[T]: Unifier[Tuple1[T],T] { type OutT[UB] = Tuple1[UB] } =
+      new Unifier[Tuple1[T],T] {
+        type OutT[UB] = Tuple1[UB]
+        def apply[UB >: T](t: Tuple1[T]) = t
+      }
+    
+    implicit def unifier2[T]: Unifier[(T,T),T] { type OutT[UB] = (UB,UB) } =
+      new Unifier[(T,T),T] {
+        type OutT[UB] = (UB,UB)
+        def apply[UB >: T](t: (T,T)) = t
+      }
+
+    implicit def unifier3[T]: Unifier[(T,T,T),T] { type OutT[UB] = (UB,UB,UB) } =
+      new Unifier[(T,T,T),T] {
+        type OutT[UB] = (UB,UB,UB)
+        def apply[UB >: T](t: (T,T,T)) = t
+      }
+
+    implicit def unifier4[T]: Unifier[(T,T,T,T),T] { type OutT[UB] = (UB,UB,UB,UB) } =
+      new Unifier[(T,T,T,T),T] {
+        type OutT[UB] = (UB,UB,UB,UB)
+        def apply[UB >: T](t: (T,T,T,T)) = t
+      }
+
+    implicit def unifier5[T]: Unifier[(T,T,T,T,T),T] { type OutT[UB] = (UB,UB,UB,UB,UB) } =
+      new Unifier[(T,T,T,T,T),T] {
+        type OutT[UB] = (UB,UB,UB,UB,UB)
+        def apply[UB >: T](t: (T,T,T,T,T)) = t
+      }
   }
 
   /**

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -415,7 +415,7 @@ final class HListOps[L <: HList](l : L) {
   /**
    * Returns an `HList` typed as a repetition of the least upper bound of the types of the elements of this `HList`.
    */
-  def unify(implicit unifier : Unifier[L]) : unifier.Out = unifier(l)
+  def unify[Lub](implicit unifier : Unifier[L, Lub]) : unifier.Out = unifier(l)
 
   /**
    * Returns an `HList` with all elements that are subtypes of `B` typed as `B`.

--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -378,7 +378,7 @@ final class TupleOps[T](t: T) {
   /**
    * Returns a tuple typed as a repetition of the least upper bound of the types of the elements of this tuple.
    */
-  def unify(implicit unifier : Unifier[T]) : unifier.Out = unifier(t)
+  def unify[Lub](implicit unifier : Unifier[T, Lub]) : unifier.OutT[Lub] = unifier(t)
 
   /**
    * Returns a tuple with all elements that are subtypes of `B` typed as `B`.

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -376,13 +376,15 @@ class TupleTests {
   def testUnifier {
     import ops.tuple._
 
-    implicitly[Unifier.Aux[Tuple1[Apple], Tuple1[Apple]]]
-    implicitly[Unifier.Aux[(Fruit, Pear), (Fruit, Fruit)]]
-    //implicitly[Unifier.Aux[(Apple, Pear), (Fruit, Fruit)]]
+    implicitly[Unifier[Tuple1[Apple], Apple]]
+    implicitly[Unifier[(Fruit, Pear), Fruit]]
+    implicitly[Unifier[(Apple, Pear), Fruit]]
     
-    implicitly[Unifier.Aux[(Int, String, Int, Int), YYYY]]
+    implicitly[Unifier[(Int, String, Int, Int), Any]]
     
-    val uapap = implicitly[Unifier.Aux[(Apple, Pear, Apple, Pear), (PWS, PWS, PWS, PWS)]]
+    def getUnifier[T, Lub](t : T)(implicit u: Unifier[T, Lub]): u.type = u
+
+    val uapap = getUnifier[(Apple, Pear, Apple, Pear), PWS](apap)
     val unified1 = uapap(apap)
     typed[FFFF](unified1)
     val unified2 = apap.unify
@@ -395,31 +397,57 @@ class TupleTests {
     assertFalse(ununified2.isDefined)
     typed[Option[APBP]](ununified2)
 
-    def getUnifier[T, Out](t : T)(implicit u: Unifier.Aux[T, Out]) = u
-    
     val u2 = getUnifier(Tuple1(a))
-    typed[Unifier.Aux[Tuple1[Apple], Tuple1[Apple]]](u2)
+    typed[Unifier[Tuple1[Apple], Apple]](u2)
     val u3 = getUnifier((a, a))
-    typed[Unifier.Aux[(Apple, Apple), (Apple, Apple)]](u3)
+    typed[Unifier[(Apple, Apple), Apple]](u3)
     val u4 = getUnifier((a, a, a))
-    typed[Unifier.Aux[(Apple, Apple, Apple), (Apple, Apple, Apple)]](u4)
+    typed[Unifier[(Apple, Apple, Apple), Apple]](u4)
     val u5 = getUnifier((a, a, a, a))
-    typed[Unifier.Aux[(Apple, Apple, Apple, Apple), (Apple, Apple, Apple, Apple)]](u5)
-    //val u6 = getUnifier((a, p))
-    //typed[Unifier.Aux[(Apple, Pear), (Fruit, Fruit)]](u6)
+    typed[Unifier[(Apple, Apple, Apple, Apple), Apple]](u5)
+    val u6 = getUnifier((a, p))
+    typed[Unifier[(Apple, Pear), Fruit]](u6)
     val u7 = getUnifier((a, f))
-    typed[Unifier.Aux[(Apple, Fruit), (Fruit, Fruit)]](u7)
+    typed[Unifier[(Apple, Fruit), Fruit]](u7)
     val u8 = getUnifier((f, a))
-    typed[Unifier.Aux[(Fruit, Apple), (Fruit, Fruit)]](u8)
+    typed[Unifier[(Fruit, Apple), Fruit]](u8)
     val u9a = getUnifier((a, f))
-    typed[Unifier.Aux[(Apple, Fruit), FF]](u9a)
+    typed[Unifier[(Apple, Fruit), Fruit]](u9a)
     val u9b = getUnifier((a, p))
-    typed[Unifier.Aux[(Apple, Pear), (PWS, PWS)]](u9b)
+    typed[Unifier[(Apple, Pear), PWS]](u9b)
     val u10 = getUnifier(apap)
-    typed[Unifier.Aux[APAP, (PWS, PWS, PWS, PWS)]](u10)
+    typed[Unifier[APAP, PWS]](u10)
     val u11 = getUnifier(apbp)
-    typed[Unifier.Aux[APBP, (PWS, PWS, PWS, PWS)]](u11)
+    typed[Unifier[APBP, PWS]](u11)
     
+    def equalInferredTypes[A,B](a: A, b: B)(implicit eq: A =:= B) {}
+
+    {
+      val hl = (a, "a", 2, 3, 0.0)
+      val l = List(a, "a", 2, 3, 0.0)
+      val u = hl.unify
+      equalInferredTypes(hl.length, u.length)
+      equalInferredTypes(l.head, u._1)
+      equalInferredTypes(l.head, u._2)
+      equalInferredTypes(l.head, u._3)
+      equalInferredTypes(l.head, u._4)
+      equalInferredTypes(l.head, u._5)
+      assertEquals(hl, u)
+    }
+
+    {
+      // Explicitly provided upper bound
+      val apbpList = List[Fruit](a, p, b, p)
+      val apbpUnified = apbp.unify[Fruit]
+      equalInferredTypes(apbp.length, apbpUnified.length)
+      equalInferredTypes(apbpList.head, apbpUnified._1)
+      equalInferredTypes(apbpList.head, apbpUnified._2)
+      equalInferredTypes(apbpList.head, apbpUnified._3)
+      equalInferredTypes(apbpList.head, apbpUnified._4)
+      assertEquals(apbp, apbpUnified)
+    }
+
+
     val invar1 = (Set(23), Set("foo"))
     val uinvar1 = invar1.unify
     typed[(Set[_ >: Int with String], Set[_ >: Int with String])](uinvar1)
@@ -428,6 +456,25 @@ class TupleTests {
     // arguments fails, presumably due to a failure to compute a sensble LUB.
     //val invar2 = (Set(23), Set("foo"), Set(true))
     //val uinvar2 = invar2.unify
+
+    {
+      val cicscicicdUnified = cicscicicd.unify
+      equalInferredTypes(cicscicicd.length, cicscicicdUnified.length)
+      equalInferredTypes(cicscicicdList.head, cicscicicdUnified._1)
+      equalInferredTypes(cicscicicdList.head, cicscicicdUnified._2)
+      equalInferredTypes(cicscicicdList.head, cicscicicdUnified._3)
+      equalInferredTypes(cicscicicdList.head, cicscicicdUnified._4)
+      equalInferredTypes(cicscicicdList.head, cicscicicdUnified._5)
+      assertEquals(cicscicicd, cicscicicdUnified)
+      typed[Ctv[Int with String with Double]](cicscicicdUnified._1)
+      typed[Ctv[Int with String with Double]](cicscicicdUnified._2)
+      typed[Ctv[Int with String with Double]](cicscicicdUnified._3)
+      typed[Ctv[Int with String with Double]](cicscicicdUnified._4)
+      typed[Ctv[Int with String with Double]](cicscicicdUnified._5)
+    }
+
+    // mimsmimimd, mimsmimemd, m2im2sm2im2im2d, and m2eim2esm2eim2eem2ed unification works
+    // but cannot be properly tested as their output types involve existentials
   }
 
   @Test


### PR DESCRIPTION
This PR adds tests to the unify method of HLists - some of them failing, and changes the current Unifier implicits so that all these tests pass.

As already discussed in https://github.com/milessabin/shapeless/pull/105 which this PR supersedes, it converts the HList to a Sized of the same length (which finds the Lub), and converts back the Sized to an HList. So internally, the HList is converted to a List, before being converted again to an HList.

This implementation may be enhanced so that it doesn't use this intermediate representation anymore. In the mean time, it could make unify more robust.

The tests added for HLists should also be added to tuples. I may do that in the coming days.
