### PR TITLE
Added HList.permutations & Tuple.permutations

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1688,4 +1688,133 @@ object hlist {
           if (compareH != 0) compareH else tOrdering.compare(x.tail, y.tail)
         }
       }
+
+  /*
+   * Type class supporting consing an element onto each row of this HMatrix (HList of HLists)
+   *
+   * @author Stacy Curl
+   */
+  trait MapCons[A, M <: HList] {
+    type Out <: HList
+
+    def apply(a: A, m: M): Out
+  }
+
+  object MapCons {
+    def apply[A, M <: HList](implicit mapCons: MapCons[A, M]): MapCons[A, M] = mapCons
+
+    type Aux[A, M <: HList, Out0 <: HList] = MapCons[A, M] { type Out = Out0 }
+
+    implicit def hnilMapCons[A]: Aux[A, HNil, HNil] =
+      new MapCons[A, HNil] {
+        type Out = HNil
+
+        def apply(a: A, m: HNil): Out = HNil
+      }
+
+    implicit def hlistMapCons[A, H <: HList, TM <: HList]
+      (implicit mapCons: MapCons[A, TM]): Aux[A, H :: TM, (A :: H) :: mapCons.Out] =
+        new MapCons[A, H :: TM] {
+          type Out = (A :: H) :: mapCons.Out
+
+          def apply(a: A, l: H :: TM): Out = (a :: l.head) :: mapCons(a, l.tail)
+        }
+  }
+
+  /**
+   * Type class supporting adding an element to each possible position in this HList
+   *
+   * @author Stacy Curl
+   */
+  trait Interleave[A, L <: HList] {
+    type Out <: HList
+
+    def apply(a: A, l: L): Out
+  }
+
+  object Interleave {
+    def apply[A , L <: HList](implicit interleave: Interleave[A, L]): Interleave[A, L] = interleave
+
+    type Aux[A, L <: HList, Out0 <: HList] = Interleave[A, L] { type Out = Out0 }
+
+    implicit def hnilInterleave[A, L <: HNil]: Aux[A, L, (A :: HNil) :: HNil] =
+      new Interleave[A, L] {
+        type Out = (A :: HNil) :: HNil
+
+        def apply(a: A, l: L): Out = (a :: HNil) :: HNil
+      }
+
+    implicit def hlistInterleave[A, H, T <: HList, LI <: HList]
+      (implicit interleave: Interleave.Aux[A, T, LI], mapCons: MapCons[H, LI])
+        : Aux[A, H :: T, (A :: H :: T) :: mapCons.Out] = new Interleave[A, H :: T] {
+          type Out = (A :: H :: T) :: mapCons.Out
+
+          def apply(a: A, l: H :: T): Out = (a :: l) :: mapCons(l.head, interleave(a, l.tail))
+        }
+  }
+
+  /**
+   * Type class supporting interleaving an element into each row of this HMatrix (HList of HLists)
+   *
+   * @author Stacy Curl
+   */
+  trait FlatMapInterleave[A, M <: HList] {
+    type Out <: HList
+
+    def apply(a: A, m: M): Out
+  }
+
+  object FlatMapInterleave {
+    def apply[A, M <: HList](implicit flatMapInterleave: FlatMapInterleave[A, M]): FlatMapInterleave[A, M] =
+      flatMapInterleave
+
+    type Aux[A, M <: HList, Out0 <: HList] = FlatMapInterleave[A, M] { type Out = Out0 }
+
+    implicit def hnilFlatMapInterleave[A, M <: HNil]: Aux[A, M, HNil]
+      = new FlatMapInterleave[A, M] {
+        type Out = HNil
+
+        def apply(a: A, m: M): Out = HNil
+      }
+
+    implicit def hlistFlatMapInterleave[A, H <: HList, TM <: HList, HO <: HList, TMO <: HList]
+      (implicit interleave: Interleave.Aux[A, H, HO],
+         flatMapInterleave: FlatMapInterleave.Aux[A, TM, TMO],
+         prepend: Prepend[HO, TMO]
+       ): Aux[A, H :: TM, prepend.Out] =
+          new FlatMapInterleave[A, H :: TM] {
+            type Out = prepend.Out
+
+            def apply(a: A, m: H :: TM): Out =
+              prepend(interleave(a, m.head), flatMapInterleave(a, m.tail))
+          }
+  }
+
+  /**
+   * Type class supporting the calculation of every permutation of this 'HList'
+   *
+   * @author Stacy Curl
+   */
+  trait Permutations[L <: HList] extends DepFn1[L] { type Out <: HList }
+
+  object Permutations {
+    def apply[L <: HList](implicit permutations: Permutations[L]): Permutations[L] = permutations
+
+    type Aux[L <: HList, Out0] = Permutations[L] { type Out = Out0 }
+
+    implicit def hnilPermutations[L <: HNil]: Aux[L, HNil :: HNil] = new Permutations[L] {
+      type Out = HNil :: HNil
+
+      def apply(l: L): Out = HNil :: HNil
+    }
+
+    implicit def hlistPermutations[H, T <: HList, TP <: HList]
+      (implicit permutations: Permutations.Aux[T, TP], flatMapInterleave: FlatMapInterleave[H, TP])
+        : Aux[H :: T, flatMapInterleave.Out] =
+          new Permutations[H :: T] {
+            type Out = flatMapInterleave.Out
+
+            def apply(l: H :: T): Out = flatMapInterleave(l.head, permutations(l.tail))
+          }
+  }
 }

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -888,4 +888,26 @@ object tuple {
           def apply(t: T): tp.Out = tp(collect(gen.to(t)))
         }
   }
+
+  /**
+   * Typer class supporting the calculation of every permutation of this tuple
+   *
+   * @author Stacy Curl
+   */
+  trait Permutations[T] extends DepFn1[T]
+
+  object Permutations {
+    def apply[T](implicit permutations: Permutations[T]): Permutations[T] = permutations
+
+    type Aux[T, Out0] = Permutations[T] { type Out = Out0 }
+
+    implicit def permutations[T, L <: HList, L2 <: HList, L3 <: HList]
+      (implicit gen: Generic.Aux[T, L], collect: hl.Permutations.Aux[L, L2],
+        mapper: hl.Mapper.Aux[tupled.type, L2, L3], tp: hl.Tupler[L3]
+      ): Aux[T, tp.Out] = new Permutations[T] {
+        type Out = tp.Out
+
+        def apply(t: T): Out = tp(collect(gen.to(t)).map(tupled))
+      }
+  }
 }

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -302,6 +302,11 @@ final class HListOps[L <: HList](l : L) {
   def flatMap(f : Poly)(implicit mapper : FlatMapper[f.type, L]) : mapper.Out = mapper(l)
 
   /**
+   * Conses an element onto each row of this HMatrix (HList of HLists).
+   */
+  def mapCons[A](a: A)(implicit mapCons: MapCons[A, L]): mapCons.Out = mapCons(a, l)
+
+  /**
    * Replaces each element of this `HList` with a constant value.
    */
   def mapConst[C](c : C)(implicit mapper : ConstMapper[C, L]) : mapper.Out = mapper(c, l)
@@ -465,4 +470,9 @@ final class HListOps[L <: HList](l : L) {
    * Converts this `HList` of values into a record with the provided keys.
    */
   def zipWithKeys[K <: HList](keys: K)(implicit withKeys: ZipWithKeys[K, L]): withKeys.Out = withKeys(keys, l)
+
+  /**
+   * Returns all permutations of this 'HList'
+   */
+  def permutations(implicit permutations: Permutations[L]): permutations.Out = permutations(l)
 }

--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -411,4 +411,9 @@ final class TupleOps[T](t: T) {
    * of this tuple.
    */
   def toSized[M[_]](implicit toSized : ToSized[T, M]) : toSized.Out = toSized(t)
+
+  /**
+   * Returns all permutations of this tuple.
+   */
+  def permutations(implicit permutations: Permutations[T]): permutations.Out = permutations(t)
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1724,4 +1724,79 @@ class HListTests {
       List(2 :: "abc" :: HNil, 1 :: "def" :: HNil, 2 :: "def" :: HNil, 1 :: "abc" :: HNil).sorted
     )
   }
+
+  @Test
+  def testMapCons {
+    assertEquals(HNil, (HNil: HNil).mapCons('a'))
+
+    assertEquals((('a' :: HNil) :: HNil), (HNil :: HNil).mapCons('a'))
+
+    assertEquals(
+      ('a' :: 1 :: HNil) :: ('a' :: "foo" :: HNil) :: ('a' :: 2.0 :: HNil) :: HNil,
+      ((1 :: HNil) :: ("foo" :: HNil) :: (2.0 :: HNil) :: HNil).mapCons('a')
+    )
+  }
+
+  @Test
+  def testInterleave {
+    assertEquals(('i' :: HNil) :: HNil, Interleave[Char, HNil].apply('i', HNil))
+
+    assertEquals(('i' :: 1 :: HNil) :: (1 :: 'i' :: HNil) :: HNil,
+      Interleave[Char, Int :: HNil].apply('i', 1 :: HNil)
+    )
+
+    assertEquals(
+      ('i' :: 1 :: "foo" :: HNil) ::
+      (1 :: 'i' :: "foo" :: HNil) ::
+      (1 :: "foo" :: 'i' :: HNil) :: HNil,
+      Interleave[Char, Int :: String :: HNil].apply('i', 1 :: "foo" :: HNil)
+    )
+
+    assertEquals(
+      ('i' :: 1 :: "foo" :: 2.0 :: HNil) ::
+      (1 :: 'i' :: "foo" :: 2.0 :: HNil) ::
+      (1 :: "foo" :: 'i' :: 2.0 :: HNil) ::
+      (1 :: "foo" :: 2.0 :: 'i' :: HNil) :: HNil,
+      Interleave[Char, Int :: String :: Double :: HNil].apply('i', 1 :: "foo" :: 2.0 :: HNil)
+    )
+  }
+
+  @Test
+  def testFlatMapInterleave {
+    assertEquals(HNil, FlatMapInterleave[Char, HNil].apply('i', HNil))
+
+    assertEquals(('i' :: HNil) :: HNil, FlatMapInterleave[Char, HNil :: HNil].apply('i', HNil :: HNil))
+
+    assertEquals(
+      ('i' :: 1 :: HNil) ::
+      (1 :: 'i' :: HNil) ::
+      ('i' :: 2 :: HNil) ::
+      (2 :: 'i' :: HNil) :: HNil,
+      FlatMapInterleave[Char, (Int :: HNil) :: (Int :: HNil) :: HNil]
+        .apply('i', (1 :: HNil) :: (2 :: HNil) :: HNil)
+    )
+  }
+
+  @Test
+  def testPermutations {
+    assertEquals(HNil :: HNil, HNil.permutations)
+
+    assertEquals((1 :: HNil) :: HNil, (1 :: HNil).permutations)
+
+    assertEquals(
+      (1 :: "foo" :: HNil) ::
+      ("foo" :: 1 :: HNil) :: HNil,
+      (1 :: "foo" :: HNil).permutations
+    )
+
+    assertEquals(
+      (1 :: "foo" :: 2.0 :: HNil) ::
+      ("foo" :: 1 :: 2.0 :: HNil) ::
+      ("foo" :: 2.0 :: 1 :: HNil) ::
+      (1 :: 2.0 :: "foo" :: HNil) ::
+      (2.0 :: 1 :: "foo" :: HNil) ::
+      (2.0 :: "foo" :: 1 :: HNil) :: HNil,
+      (1 :: "foo" :: 2.0 :: HNil).permutations
+    )
+  }
 }

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1222,4 +1222,14 @@ class TupleTests {
       assertEquals((1.0, 1), result)
     }
   }
+
+  @Test
+  def testPermutations {
+    assertEquals(((1, "foo"), ("foo", 1)), (1, "foo").permutations)
+
+    assertEquals((
+      (1, "foo", 2.0), ("foo", 1, 2.0), ("foo", 2.0, 1),
+      (1, 2.0, "foo"), (2.0, 1, "foo"), (2.0, "foo", 1)
+    ), (1, "foo", 2.0).permutations)
+  }
 }


### PR DESCRIPTION
- HList.{mapCons, interleave, flatMapInterleave, mapTupler} that I used for the implementation. I can drop the syntax methods if they aren't useful otherwise & move all of the type classes into ops.Permutations

I haven't implemented Coproduct.permutations yet
