### PR TITLE
simplify the expression of the negation of a type

### DIFF
--- a/core/src/main/scala/shapeless/package.scala
+++ b/core/src/main/scala/shapeless/package.scala
@@ -26,7 +26,7 @@ package object shapeless {
   trait ¬[-T]
   type ¬¬[T] = ¬[¬[T]]
   type ∧[T, U] = T with U
-  type ∨[T, U] = ¬[¬[T] ∧ ¬[U]]
+  type ∨[T, U] = ¬[¬[T] with ¬[U]]
   
   // Type-lambda for context bound
   type |∨|[T, U] = {


### PR DESCRIPTION
I just read the blog about union type [here](http://www.chuusai.com/2011/06/09/scala-union-types-curry-howard). To achieve it, we need to express the negation of a type in scala. However, instead of `type ¬[T] = T => Nothing`, can we just use `trait ¬[-T]`? 

I tested it myself and it works.

```
trait ¬[-T]
type ¬¬[T] = ¬[¬[T]]
type ∨[T, U] = ¬[¬[T] with ¬[U]]

def size[T](t : T)(implicit ev : (¬¬[T] <:< (Int ∨ String))) = t match {
  case i : Int => i
  case s : String => s.length
}

size(12)
size("aa")
size(1.2)
```

A strange thing is that I can't use the `type ∧[T, U]`, or `size(1.2)` will compile. I'm using scala 2.11.1

Anyway, I think `trait ¬[-T]` looks simpler, did I miss something here?
