### PR TITLE
added Merge of 2 polymorphic functions

### DIFF
--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -81,6 +81,27 @@ object PolyDefns extends Cases {
   }
 
   /**
+   * Represents the merge of two polymorphic function values.
+   *
+   * @author Pascal Voitot (@mandubian)
+   */
+  class Merge[F, G](f: F, g: G) extends Poly
+
+  object Merge {
+    implicit def mergeCaseF[C, F <: Poly, G <: Poly, L <: HList, R](
+      implicit unpack: Unpack2[C, Merge, F, G], cF : Case.Aux[F, L, R]) = new Case[C, L] {
+      type Result = R
+      val value = (t : L) => cF(t)
+    }
+
+    implicit def mergeCaseG[C, F <: Poly, G <: Poly, L <: HList, R](
+      implicit unpack: Unpack2[C, Merge, F, G], cG : Case.Aux[G, L, R]) = new Case[C, L] {
+      type Result = R
+      val value = (t : L) => cG(t)
+    }
+  }
+
+  /**
    * Represents rotating a polymorphic function by N places to the left
    *
    * @author Stacy Curl
@@ -195,6 +216,9 @@ trait Poly extends PolyApply {
   def rotateLeft[N <: Nat] = new RotateLeft[this.type, N](this)
 
   def rotateRight[N <: Nat] = new RotateRight[this.type, N](this)
+
+  def merge(f: Poly) = new Merge[this.type, f.type](this, f)
+  def |+|(f: Poly) = merge(f)
 
   /** The type of the case representing this polymorphic function at argument types `L`. */
   type ProductCase[L <: HList] = Case[this.type, L]

--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -85,19 +85,47 @@ object PolyDefns extends Cases {
    *
    * @author Pascal Voitot (@mandubian)
    */
-  class Merge[F, G](f: F, g: G) extends Poly
+  class Merge[+F, G](f: F, g: G) extends Poly
 
-  object Merge {
-    implicit def mergeCaseF[C, F <: Poly, G <: Poly, L <: HList, R](
-      implicit unpack: Unpack2[C, Merge, F, G], cF : Case.Aux[F, L, R]) = new Case[C, L] {
-      type Result = R
-      val value = (t : L) => cF(t)
+  object Merge extends Merge2
+
+  trait Merge1 {
+    implicit def mergeCase1A[MG, A <: Poly, B <: Poly, ML <: HList, MR](
+      implicit unpack: Unpack2[MG, Merge, A, B],
+               c : Case.Aux[A, ML, MR]) = new Case[MG, ML] {
+      type Result = MR
+      val value = (t : ML) => c(t)
     }
 
-    implicit def mergeCaseG[C, F <: Poly, G <: Poly, L <: HList, R](
-      implicit unpack: Unpack2[C, Merge, F, G], cG : Case.Aux[G, L, R]) = new Case[C, L] {
-      type Result = R
-      val value = (t : L) => cG(t)
+    implicit def mergeCase1B[MG, A <: Poly, B <: Poly, ML <: HList, MR](
+      implicit unpack: Unpack2[MG, Merge, A, B],
+               c : Case.Aux[B, ML, MR]) = new Case[MG, ML] {
+      type Result = MR
+      val value = (t : ML) => c(t)
+    }
+  }
+
+
+  trait Merge2 extends Merge1 {
+    implicit def mergeCase2A[MG, MG2, A <: Poly, B <: Poly, C <: Poly, ML <: HList, MR](
+      implicit unpack1: Unpack2[MG, Merge, MG2, C], unpack2: Unpack2[MG2, Merge, A, B],
+               c : Case.Aux[A, ML, MR]) = new Case[MG, ML] {
+      type Result = MR
+      val value = (t : ML) => c(t)
+    }
+
+    implicit def mergeCase2B[MG, MG2, A <: Poly, B <: Poly, C <: Poly, ML <: HList, MR](
+      implicit unpack1: Unpack2[MG, Merge, MG2, C], unpack2: Unpack2[MG2, Merge, A, B],
+               c : Case.Aux[B, ML, MR]) = new Case[MG, ML] {
+      type Result = MR
+      val value = (t : ML) => c(t)
+    }
+
+    implicit def mergeCase2C[MG, MG2, A <: Poly, B <: Poly, C <: Poly, ML <: HList, MR](
+      implicit unpack1: Unpack2[MG, Merge, MG2, C], unpack2: Unpack2[MG2, Merge, A, B],
+               c : Case.Aux[C, ML, MR]) = new Case[MG, ML] {
+      type Result = MR
+      val value = (t : ML) => c(t)
     }
   }
 

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -258,8 +258,8 @@ class PolyTests {
         at[T, U]{ (t, u) => sz(t) + sz(u) }
     }
 
-    val m1 = sz |+| sz2
-    val m = m1 |+| sz3
+    val m = sz |+| sz2 |+| sz3
+
     assertEquals(m(5), 1)
     assertEquals(m("toto"), 4)
     assertEquals(m(5 -> "toto"), 5)

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -239,6 +239,35 @@ class PolyTests {
   }
 
   @Test
+  def testMerge {
+    object sz extends Poly1 {
+      implicit def caseInt = at[Int] { i => 1 }
+      implicit def caseString = at[String] { s => s.size }
+    }
+
+    // sz2 depends on sz and is poly1
+    object sz2 extends Poly1 {
+      implicit def caseTuple[T, U]
+        (implicit st : sz.Case.Aux[T, Int], su : sz.Case.Aux[U, Int]) =
+          at[(T, U)](t => sz(t._1) + sz(t._2))
+    }
+
+    // sz3 depends on sz and is poly2
+    object sz3 extends Poly2 {
+      implicit def default[T, U](implicit st: sz.Case.Aux[T, Int], su: sz.Case.Aux[U, Int]) =
+        at[T, U]{ (t, u) => sz(t) + sz(u) }
+    }
+
+    val m1 = sz |+| sz2
+    val m = m1 |+| sz3
+    assertEquals(m(5), 1)
+    assertEquals(m("toto"), 4)
+    assertEquals(m(5 -> "toto"), 5)
+    assertEquals(m(5, "toto"), 5)
+
+  }
+
+  @Test
   def testPolyVal {
     val i1 = zero[Int]
     typed[Int](i1)


### PR DESCRIPTION
- added operator `|+|` as an alias to `merge`
- Due to limitations of compiler, now you cannot write:
```scala
// DOESN'T WORK : compiles but forgets implicit cases from poly1 |+| poly2
val m = poly1 |+| poly2 |+| poly3

// WORKS
val m1 = poly1 |+| poly2
val m = m1 |+| poly3
```