### PR TITLE
Added head & tail to Coproduct

### DIFF
--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -289,6 +289,40 @@ object coproduct {
     }
   }
 
+  /**
+   * Type class providing access to head and tail of this Coproduct
+   *
+   * @author Stacy Curl
+   */
+  trait IsCCons[C <: Coproduct] {
+    type H
+    type T <: Coproduct
+
+    def head(c: C): Option[H]
+    def tail(c: C): Option[T]
+  }
+
+  object IsCCons {
+    def apply[C <: Coproduct](implicit isCCons: IsCCons[C]): Aux[C, isCCons.H, isCCons.T] = isCCons
+
+    type Aux[C <: Coproduct, H0, T0 <: Coproduct] = IsCCons[C] { type H = H0; type T = T0 }
+
+    implicit def coproductCCons[H0, T0 <: Coproduct]: Aux[H0 :+: T0, H0, T0] = new IsCCons[H0 :+: T0] {
+      type H = H0
+      type T = T0
+
+      def head(c: H0 :+: T0): Option[H0] = c match {
+        case Inl(h) => Some(h)
+        case _      => None
+      }
+
+      def tail(c: H0 :+: T0): Option[T0] = c match {
+        case Inr(t) => Some(t)
+        case _      => None
+      }
+    }
+  }
+
   implicit object cnilOrdering extends Ordering[CNil] {
     def compare(x: CNil, y: CNil) = 0
   }

--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -36,6 +36,16 @@ final class CoproductOps[C <: Coproduct](c: C) {
 
   def zipWithKeys[K <: HList](keys: K)(implicit zipWithKeys: ZipWithKeys[K, C]): zipWithKeys.Out = zipWithKeys(keys, c)
 
+  /**
+   * Returns the head of this `Coproduct`
+   */
+  def head(implicit cc: IsCCons[C]): Option[cc.H] = cc.head(c)
+
+  /**
+   * Returns the tail of this `Coproduct`
+   */
+  def tail(implicit cc: IsCCons[C]): Option[cc.T] = cc.tail(c)
+
   def length(implicit length: Length[C]): length.Out = length()
 
   def append[T](implicit append: Append[C, T]): append.Out = append(c)

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -336,4 +336,20 @@ class CoproductTests {
     assertTypedEquals[C :+: I :+: S :+: D :+: CNil](Coproduct[C :+: I :+: S :+: D :+: CNil](1), in4.rotateRight[_5])
     assertTypedEquals[D :+: C :+: I :+: S :+: CNil](Coproduct[D :+: C :+: I :+: S :+: CNil](1), in4.rotateRight[_6])
   }
+
+  @Test
+  def testHead {
+    assertTypedEquals[Option[Int]](Some(1), Coproduct[Int :+: CNil](1).head)
+    assertTypedEquals[Option[Int]](Some(1), Coproduct[Int :+: String :+: CNil](1).head)
+    assertTypedEquals[Option[Int]](None,    Coproduct[Int :+: String :+: CNil]("foo").head)
+  }
+
+  @Test
+  def testTail {
+    assertTypedEquals[Option[CNil]](None, Coproduct[Int :+: CNil](1).tail)
+    assertTypedEquals[Option[String :+: CNil]](None, Coproduct[Int :+: String :+: CNil](1).tail)
+
+    assertTypedEquals[Option[String :+: CNil]](
+      Some(Coproduct[String :+: CNil]("foo")), Coproduct[Int :+: String :+: CNil]("foo").tail)
+  }
 }


### PR DESCRIPTION
head & tail could be called headOption & tailOption; stating that it returns an Option seems redundant, but perhaps clearer.

Some coproducts could have more precise results, personally I like that it always returns Option[_], but:
(A :+: CNil).tail == None, could be undefined
(A :+: CNil).head == Some[A] could be A, or (to match tail) be undefined.
