### PR TITLE
Adding Patch to HLists and Tuples

### DIFF
--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -1053,4 +1053,26 @@ object tuple {
         }
 
   }
+
+  /**
+   * Type class supporting the patching of a tuple.
+   *
+   * @author Owein Reese
+   */
+  trait Patcher[N <: Nat, M <: Nat, T, InT] extends DepFn2[T, InT]
+
+  object Patcher{
+    def apply[N <: Nat, M <: Nat, T, InT](implicit patch: Patcher[N, M, T, InT]) = patch
+
+    implicit def tuplePatch[N <: Nat, M <: Nat, T, L <: HList, InT, InL <: HList, OutL <: HList]
+      (implicit gen: Generic.Aux[T, L], 
+        genIn: Generic.Aux[InT, InL], 
+        patch: hl.Patcher.Aux[N, M, L, InL, OutL], 
+        tp: hl.Tupler[OutL]) =
+        new Patcher[N, M, T, InT]{
+          type Out = tp.Out
+
+          def apply(t: T, in: InT) = tp(patch(gen.to(t), genIn.to(in)))
+        }
+  }
 }

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -526,4 +526,21 @@ final class HListOps[L <: HList](l : L) {
    * there is evidence `op` can consume/produce all the results of the appropriate types.
    */
   def scanRight[A, P <: Poly](z: A)(op: Poly)(implicit scanR: RightScanner[L, A, op.type]): scanR.Out = scanR(l, z)
+
+  /**
+   * 
+   * Produces a new `HList` where a slice of this `HList` is replaced by another. Available only if there are at least 
+   * ``n`` plus ``m`` elements.
+   */
+  def patch[In <: HList](n: Nat, in: In, m: Nat)(implicit patcher: Patcher[n.N, m.N, L, In]): patcher.Out = patcher(l, in)
+
+  /**
+   * Produces a new `HList` where a slice of this `HList` is replaced by another. Two explicit type arguments must be 
+   * provided. Available only if there are at least `N` plus `M` elements.
+   */
+  def patch[N <: Nat, M <: Nat] = new PatchAux[N, M]
+
+  class PatchAux[N <: Nat, M <: Nat]{
+    def apply[In <: HList](in: In)(implicit patcher: Patcher[N, M, L, In]): patcher.Out = patcher(l, in)
+  }
 }

--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -461,4 +461,21 @@ final class TupleOps[T](t: T) {
    * there is evidence `op` can consume/produce all the results of the appropriate types.
    */
    def scanRight[Z, P <: Poly](z: Z)(op: Poly)(implicit scanR: RightScanner[T, Z, op.type]): scanR.Out = scanR(t, z)
+
+  /**
+   *
+   * Produces a new tuple where a slice of this tuple is replaced by another. Available only if there are at least 
+   * ``n`` plus ``m`` elements.
+   */
+  def patch[In](n: Nat, in: In, m: Nat)(implicit patcher: Patcher[n.N, m.N, T, In]): patcher.Out = patcher(t, in)
+
+  /**
+   * Produces a new tuple where a slice of this tuple is replaced by another. Two explicit type arguments must be provided.
+   * Available only if there are at least `N` plus `M` elements.
+   */
+  def patch[N <: Nat, M <: Nat] = new PatchAux[N, M]
+
+  class PatchAux[N <: Nat, M <: Nat]{
+    def apply[In](in: In)(implicit patcher: Patcher[N, M, T, In]): patcher.Out = patcher(t, in)
+  }
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -2243,4 +2243,57 @@ class HListTests {
       assertEquals(None, twoByThree.at[_1].at[_2])
     }
   } 
+
+  @Test
+  def testPatch{
+    val basehl = 1 :: 2 :: "three" :: HNil
+
+    { //patch an empty hlist
+      val out = HNil.patch(0, basehl, 0)
+      val out2 = HNil.patch[_0,_0](basehl)
+
+      typed[Int :: Int :: String :: HNil](out)
+      assertEquals(out, basehl)
+      assertTypedEquals[Int :: Int :: String :: HNil](out, out2)
+    }
+
+    { //single patch w/ nothing removed
+      val out = basehl.patch(1, 4 :: HNil, 0)
+      val out2 = basehl.patch[_1,_0](4 :: HNil)
+
+      typed[Int :: Int :: Int :: String :: HNil](out)
+      assertEquals(1 :: 4 :: 2 :: "three" :: HNil, out)
+      assertTypedEquals[Int :: Int :: Int :: String :: HNil](out, out2)
+    }
+
+    { //single patch w/ 2 elements removed
+      val out = basehl.patch(1, 3 :: HNil, 2)
+      val out2 = basehl.patch[_1,_2](3 :: HNil)
+
+      typed[Int :: Int :: HNil](out)
+      assertEquals(1 :: 3 :: HNil, out)
+      assertTypedEquals[Int :: Int :: HNil](out, out2)
+    }
+
+    { //essentially append
+      val p = 4 :: 5 :: "six" :: HNil
+      val out = basehl.patch(3, p, 0)
+      val out2 = basehl.patch[_3,_0](p)
+
+      typed[Int :: Int :: String :: Int :: Int :: String :: HNil](out)
+      assertEquals(1 :: 2 :: "three" :: 4 :: 5 :: "six" :: HNil, out)
+      assertTypedEquals[Int :: Int :: String :: Int :: Int :: String :: HNil](out, out2)
+    }
+
+    { //several patched w/ everything from original removed
+      val sub = 4 :: "five" :: "six" :: HNil
+      val out = basehl.patch(0, sub, 3)
+      val out2 = basehl.patch[_0,_3](sub)
+
+      typed[Int :: String :: String :: HNil](out)
+      assertEquals(sub, out)
+      assertTypedEquals[Int :: String :: String :: HNil](out, out2)
+    }
+  }
+
 }

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1588,4 +1588,46 @@ class TupleTests {
       assertEquals(((None, None, None), (None, None, None)), twoByThree)
     }
   }  
+
+  @Test
+  def testPatch{
+    val in = (1, "two", 3)
+
+    { //single patch w/ nothing removed
+      val out = in.patch(1, (4,5), 0)
+      val out2 = in.patch[_1, _0]((4,5))
+
+      typed[(Int, Int, Int, String, Int)](out)
+      assertEquals((1, 4, 5, "two", 3), out)
+      assertTypedEquals[(Int, Int, Int, String, Int)](out, out2)
+    }
+
+    { //single patch w/ 2 elements removed
+      val out = in.patch(1, (3, 4), 2)
+      val out2 = in.patch[_1,_2]((3,4))
+
+      typed[(Int, Int, Int)](out)
+      assertEquals((1, 3, 4), out)
+      assertTypedEquals[(Int, Int, Int)](out, out2)
+    }
+
+    { //essentially append
+      val out = in.patch(3, (4, 5, "six"), 0)
+      val out2 = in.patch[_3,_0]((4, 5, "six"))
+
+      typed[(Int, String, Int, Int, Int, String)](out)
+      assertEquals((1, "two", 3, 4, 5, "six"), out)
+      assertTypedEquals[(Int, String, Int, Int, Int, String)](out, out2)
+    }
+
+    { //several patched w/ everything from original removed
+      val sub = (4, "five", "six")
+      val out = in.patch(0, sub, 3)
+      val out2 = in.patch[_0,_3]((4, "five", "six"))
+
+      typed[(Int, String, String)](out)
+      assertEquals(sub, out)
+      assertTypedEquals[(Int, String, String)](out, out2)
+    }
+  }
 }


### PR DESCRIPTION
This adds the much needed utility method patch to tuples and hlists. Not as powerful as say, a Lens that does several fields at once, but fairly general in purpose and application.
