### PR TITLE
Common assertTypedEquals and assertTypedSame

### DIFF
--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import test._
+import testutil._
 
 import ops.coproduct._
 
@@ -335,7 +336,4 @@ class CoproductTests {
     assertTypedEquals[C :+: I :+: S :+: D :+: CNil](Coproduct[C :+: I :+: S :+: D :+: CNil](1), in4.rotateRight[_5])
     assertTypedEquals[D :+: C :+: I :+: S :+: CNil](Coproduct[D :+: C :+: I :+: S :+: CNil](1), in4.rotateRight[_6])
   }
-
-  private def assertTypedEquals[A](expected: A, actual: A) = assertEquals(expected, actual)
-  private def assertTypedSame[A](expected: A, actual: A) = assertSame(expected, actual)
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import test._
+import testutil._
 
 class HListTests {
   import nat._
@@ -2053,7 +2054,4 @@ class HListTests {
     assertTypedEquals[C :: I :: S :: D :: HNil]('a' :: 1 :: "foo" :: 2.0 :: HNil, in4.rotateRight[_5])
     assertTypedEquals[D :: C :: I :: S :: HNil](2.0 :: 'a' :: 1 :: "foo" :: HNil, in4.rotateRight[_6])
   }
-
-  private def assertTypedEquals[A](expected: A, actual: A) = assertEquals(expected, actual)
-  private def assertTypedSame[A](expected: A, actual: A) = assertSame(expected, actual)
 }

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -22,6 +22,7 @@ import org.junit.Assert._
 import poly._
 import ops.hlist.Mapper
 import test._
+import testutil._
 
 /** Polymorphic singleton function. */
 object singleton extends (Id ~> Set) {
@@ -526,8 +527,6 @@ class PolyTests {
 
     assertTypedEquals[String]("i: 1, s: foo, d: 2.0, c: a", dcis(2.0, 'a', 1, "foo"))
   }
-
-  private def assertTypedEquals[A](expected: A, actual: A) = assertEquals(expected, actual)
 }
 
 object LiftMethods {

--- a/core/src/test/scala/shapeless/testutil.scala
+++ b/core/src/test/scala/shapeless/testutil.scala
@@ -1,0 +1,9 @@
+package shapeless
+
+import org.junit.Assert._
+
+object testutil {
+  def assertTypedEquals[A](expected: A, actual: A): Unit = assertEquals(expected, actual)
+
+  def assertTypedSame[A](expected: A, actual: A): Unit = assertSame(expected, actual)
+}

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import shapeless.test._
+import testutil._
 
 class TupleTests {
   import nat._
@@ -1472,6 +1473,4 @@ class TupleTests {
     assertTypedEquals[(C, I, S, D)](('a', 1, "foo", 2.0), in4.rotateRight[_5])
     assertTypedEquals[(D, C, I, S)]((2.0, 'a', 1, "foo"), in4.rotateRight[_6])
   }
-
-  private def assertTypedEquals[A](expected: A, actual: A) = assertEquals(expected, actual)
 }


### PR DESCRIPTION
They are now in a common `testutil` object instead of being implemented
in multiple files.

First suggested in
https://github.com/milessabin/shapeless/pull/165#issuecomment-48813493
