### PR TITLE
Simplifying HList.fill and Tuple.fill definitions

### DIFF
--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -61,19 +61,15 @@ object HList {
   
   def apply[P <: Product, L <: HList](p : P)(implicit gen: Generic.Aux[P, L]) : L = gen.to(p)
 
-  case class FillBuilder[N]() {
-    def apply[A](elem: A)(implicit fill: Fill[N, A]) : fill.Out = fill(elem)
-  }
-
   /**
    * Produces a HList of length `N` filled with `elem`.
    */
-  def fill(n: Nat) = FillBuilder[n.N]()
+  def fill[A](n: Nat)(elem: A)(implicit fill: Fill[n.N, A]) : fill.Out = fill(elem)
 
   /**
    * Produces a `N1`-length HList made of `N2`-length HLists filled with `elem`.
    */
-  def fill(n1: Nat, n2: Nat) = FillBuilder[(n1.N, n2.N)]()
+  def fill[A](n1: Nat, n2: Nat)(elem: A)(implicit fill: Fill[(n1.N, n2.N), A]) : fill.Out = fill(elem)
   
   implicit def hlistOps[L <: HList](l : L) : HListOps[L] = new HListOps(l)
 

--- a/core/src/main/scala/shapeless/tuples.scala
+++ b/core/src/main/scala/shapeless/tuples.scala
@@ -3,18 +3,14 @@ package shapeless
 object Tuple {
   import ops.tuple._
 
-  case class FillBuilder[N]() {
-    def apply[A](elem: A)(implicit fill: Fill[N, A]) : fill.Out = fill(elem)
-  }
-
   /**
    * Produces a tuple of length `N` filled with `elem`.
    */
-  def fill(n: Nat) = FillBuilder[n.N]()
+  def fill[A](n: Nat)(elem: A)(implicit fill: Fill[n.N, A]) : fill.Out = fill(elem)
   
   /**
    * Produces a `N1`-length tuple made of `N2`-length tuples filled with `elem`.
    */
-  def fill(n1: Nat, n2: Nat) = FillBuilder[(n1.N, n2.N)]()
+  def fill[A](n1: Nat, n2: Nat)(elem: A)(implicit fill: Fill[(n1.N, n2.N), A]) : fill.Out = fill(elem)
   
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1917,7 +1917,7 @@ class HListTests {
     }
 
     {
-      val empty = HList.fill(0)[Boolean](true)
+      val empty = HList.fill[Boolean](0)(true)
       typed[_0](empty.length)
     }
 
@@ -1929,7 +1929,7 @@ class HListTests {
     }
 
     {
-      val single = HList.fill(1)[None.type](None)
+      val single = HList.fill[None.type](1)(None)
       typed[_1](single.length)
       typed[None.type](single.head)
       assertEquals(None, single.head)
@@ -1947,7 +1947,7 @@ class HListTests {
     }
 
     {
-      val three = HList.fill(3)[M2[Int, Unit]](m2i)
+      val three = HList.fill[M2[Int, Unit]](3)(m2i)
       typed[_3](three.length)
       typed[M2[Int, Unit]](three(_0))
       typed[M2[Int, Unit]](three(_1))
@@ -1963,7 +1963,7 @@ class HListTests {
     }
 
     {
-      val empty = HList.fill(0, 0)[Boolean](true)
+      val empty = HList.fill[Boolean](0, 0)(true)
       typed[_0](empty.length)
     }
 
@@ -1975,7 +1975,7 @@ class HListTests {
     }
 
     {
-      val empty = HList.fill(2, 0)[Boolean](true)
+      val empty = HList.fill[Boolean](2, 0)(true)
       typed[_2](empty.length)
       typed[_0](empty(_0).length)
       typed[_0](empty(_1).length)
@@ -1987,7 +1987,7 @@ class HListTests {
     }
 
     {
-      val empty = HList.fill(0, 2)[Boolean](true)
+      val empty = HList.fill[Boolean](0, 2)(true)
       typed[_0](empty.length)
     }
 
@@ -2002,7 +2002,7 @@ class HListTests {
     }
 
     {
-      val oneByTwo = HList.fill(1, 2)[None.type](None)
+      val oneByTwo = HList.fill[None.type](1, 2)(None)
       typed[_1](oneByTwo.length)
       typed[_2](oneByTwo.head.length)
       typed[None.type](oneByTwo.head(_0))
@@ -2031,7 +2031,7 @@ class HListTests {
     }
 
     {
-      val twoByThree = HList.fill(2, 3)[None.type](None)
+      val twoByThree = HList.fill[None.type](2, 3)(None)
       typed[_2](twoByThree.length)
       typed[_3](twoByThree(_0).length)
       typed[_3](twoByThree(_1).length)

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1506,7 +1506,7 @@ class TupleTests {
     }
 
     {
-      val empty = Tuple.fill(0)[Boolean](true)
+      val empty = Tuple.fill[Boolean](0)(true)
       typed[Unit](empty)
     }
 
@@ -1517,7 +1517,7 @@ class TupleTests {
     }
 
     {
-      val single = Tuple.fill(1)[None.type](None)
+      val single = Tuple.fill[None.type](1)(None)
       typed[Tuple1[None.type]](single)
       assertEquals(Tuple1(None), single)
     }
@@ -1529,7 +1529,7 @@ class TupleTests {
     }
 
     {
-      val three = Tuple.fill(3)[M2[Int, Unit]](m2i)
+      val three = Tuple.fill[M2[Int, Unit]](3)(m2i)
       typed[(M2[Int, Unit], M2[Int, Unit], M2[Int, Unit])](three)
       assertEquals((m2i, m2i, m2i), three)
     }
@@ -1540,7 +1540,7 @@ class TupleTests {
     }
 
     {
-      val empty = Tuple.fill(0, 0)[Boolean](true)
+      val empty = Tuple.fill[Boolean](0, 0)(true)
       typed[Unit](empty)
     }
 
@@ -1550,7 +1550,7 @@ class TupleTests {
     }
 
     {
-      val empty = Tuple.fill(2, 0)[Boolean](true)
+      val empty = Tuple.fill[Boolean](2, 0)(true)
       typed[(Unit, Unit)](empty)
     }
 
@@ -1560,7 +1560,7 @@ class TupleTests {
     }
 
     {
-      val empty = Tuple.fill(0, 2)[Boolean](true)
+      val empty = Tuple.fill[Boolean](0, 2)(true)
       typed[Unit](empty)
     }
 
@@ -1571,7 +1571,7 @@ class TupleTests {
     }
 
     {
-      val oneByTwo = Tuple.fill(1, 2)[None.type](None)
+      val oneByTwo = Tuple.fill[None.type](1, 2)(None)
       typed[Tuple1[(None.type, None.type)]](oneByTwo)
       assertEquals(Tuple1((None, None)), oneByTwo)
     }
@@ -1583,7 +1583,7 @@ class TupleTests {
     }
 
     {
-      val twoByThree = Tuple.fill(2, 3)[None.type](None)
+      val twoByThree = Tuple.fill[None.type](2, 3)(None)
       typed[((None.type, None.type, None.type), (None.type, None.type, None.type))](twoByThree)
       assertEquals(((None, None, None), (None, None, None)), twoByThree)
     }


### PR DESCRIPTION
Following the discussion in https://github.com/milessabin/shapeless/pull/172, the signatures of HList.fill and Tuple.fill evolved and the FillBuilder classes which were used in the first proposed implementations are no longer required. This PR drops them. This moves the type argument of the filling element to a more conventional place (see the modified test lines).
