### PR TITLE
Added Exact extractor for Sized that requires the right number of patterns

### DIFF
--- a/core/src/main/scala/shapeless/sized.scala
+++ b/core/src/main/scala/shapeless/sized.scala
@@ -184,4 +184,16 @@ object Sized extends LowPrioritySized {
   def wrap[Repr, L <: Nat](r : Repr) = new Sized[Repr, L](r)
 
   def unapplySeq[Repr, L <: Nat](x : Sized[Repr, L]) = Some(x.unsized)
+
+  /**
+   * An extractor that guarantees that exactly the right number of patterns are provided.
+   */
+  object Exact {
+    import ops.hlist.Tupler
+    import ops.sized.ToHList
+
+    def unapply[Repr, L <: Nat, Out <: HList, T <: Product](x: Sized[Repr, L])
+      (implicit itl: IsTraversableLike[Repr], fs: ToHList.Aux[Repr, L, Out], t: Tupler.Aux[Out, T]): Option[T] =
+        Some(fs(x).tupled)
+  }
 }

--- a/core/src/test/scala/shapeless/sized.scala
+++ b/core/src/test/scala/shapeless/sized.scala
@@ -388,4 +388,18 @@ class SizedTests {
       ss(3)
     """)
   }
+
+  @Test
+  def testExact {
+    val ss = Sized[List](0, 1, 2)
+    val Sized.Exact(x, y, z) = ss
+
+    typed[Int](x)
+    typed[Int](y)
+    typed[Int](z)
+
+    assertEquals(x, 0)
+    assertEquals(y, 1)
+    assertEquals(z, 2)
+  }
 }


### PR DESCRIPTION
This is a reworked version of #93 that uses the new `ToHList` type class from #114.

While this extractor behaves correctly (`val Sized.Exact(a, b) = Sized('foo)` doesn't compile), we can't confirm that with `illTyped` in 2.11 at the moment because of [this bug](https://issues.scala-lang.org/browse/SI-8719) (see [this Stack Overflow question](http://stackoverflow.com/q/24231855/334519) and Eugene Burmako's answer for discussion). I'll create an issue to remind us to add these tests when [Eugene's fix](https://github.com/scala/scala/pull/3876) lands.