### PR TITLE
Added removeElem to Coproduct

### DIFF
--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -78,6 +78,25 @@ final class CoproductOps[C <: Coproduct](c: C) {
   def filterNot[U](implicit filterNot: FilterNot[C, U]): Option[filterNot.A] = filterNot(c)
 
   /**
+   * Returns the first element of type `U` of this `Coproduct` plus the remainder of the `Coproduct`.
+   * An explicit type argument must be provided. Available only if there is evidence that this
+   * `Coproduct` has an element of type `U`.
+   *
+   * The `Elem` suffix is here to avoid creating an ambiguity with RecordOps#remove and should be removed if
+   * SI-5414 is resolved in a way which eliminates the ambiguity.
+   */
+  def removeElem[U](implicit removeElem: RemoveElem[C, U]): Either[U, removeElem.Rest] =
+    removeElem.either(c)
+
+  /**
+   * Returns the first element of type `U` of this `Coproduct` plus the remainder of the `Coproduct`.
+   * An explicit type argument must be provided. Available only if there is evidence that this
+   * `Coproduct` has an element of type `U`.
+   */
+  def removeElemC[U](implicit removeElem: RemoveElem[C, U]): U :+: removeElem.Rest = removeElem(c)
+
+
+  /**
    * Splits this `Coproduct` at the ''nth'' element, returning the prefix and suffix as a pair. An explicit type
    * argument must be provided. Available only if there is evidence that this `Coproduct` has at least ''n'' elements.
    */

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -605,4 +605,20 @@ class CoproductTests {
     assertTypedEquals[(I :+: S :+: CNil) :+: (D :+: C :+: CNil) :+: CNil](
       Coproduct[(I :+: S :+: CNil) :+: (D :+: C :+: CNil) :+: CNil](dc), isdc.split[_2])
   }
+
+  @Test
+  def testRemoveElem {
+    type S = String; type I = Int; type D = Double; type C = Char
+    val i = Coproduct[I :+: CNil](1)
+    val is = Coproduct[I :+: S :+: CNil](1)
+
+    assertTypedEquals[I :+: CNil](i, i.removeElemC[I])
+    assertTypedEquals[Either[I, CNil]](Left(1), i.removeElem[I])
+
+    assertTypedEquals[I :+: S :+: CNil](is, is.removeElemC[I])
+    assertTypedEquals[Either[I, S :+: CNil]](Left(1), is.removeElem[I])
+
+    assertTypedEquals[S :+: I :+: CNil](Coproduct[S :+: I :+: CNil](1), is.removeElemC[S])
+    assertTypedEquals[Either[S, I :+: CNil]](Right(i), is.removeElem[S])
+  }
 }


### PR DESCRIPTION
val c: Int :+: String :+: CNil = ...
c.removeElem[Int] must return either an Int and an uninhabited remainder, or an uninhabited Int and a remainder, i.e
c.removeElem[Int] == identity & more generally removeElem == moveToHead.

I haven't quite finished on this one, want to add a few more tests & I'd like some feedback, do you think it's ok to call this removeElem, it seems to be the natural dual to the operation on hlist but maybe it should be named differently, if removeElem on hlists is changed to return a hlist too then that will also == moveToHead and probably should get a new name too (no need to wait for SI-5414 then)
