### PR TITLE
Enforced Sized to nest only white-listed collections

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -609,7 +609,7 @@ object hlist {
     type Aux[L <: HList, M[_], Lub0, N0 <: Nat] = ToSized[L, M] { type Lub = Lub0; type N = N0 }
 
     implicit def hnilToSized[L <: HNil, M[_]]
-      (implicit cbf : CanBuildFrom[M[Nothing], Nothing, M[Nothing]]) : Aux[L, M, Nothing, Nat._0] =
+      (implicit cbf : CanBuildFrom[M[Nothing], Nothing, M[Nothing]], ev : AdditiveCollection[M[Nothing]]) : Aux[L, M, Nothing, Nat._0] =
         new ToSized[L, M] {
           type Lub = Nothing
           type N = Nat._0
@@ -617,7 +617,7 @@ object hlist {
         }
 
     implicit def hsingleToSized[T, M[_]]
-    (implicit cbf : CanBuildFrom[Nothing, T, M[T]]) : Aux[T :: HNil, M, T, Nat._1] =
+    (implicit cbf : CanBuildFrom[Nothing, T, M[T]], ev : AdditiveCollection[M[T]]) : Aux[T :: HNil, M, T, Nat._1] =
       new ToSized[T :: HNil, M] {
         type Lub = T
         type N = Nat._1
@@ -628,10 +628,12 @@ object hlist {
       (implicit
        tts  : Aux[H2 :: T, M, LT, N0],
        u    : Lub[H1, LT, L],
-       tvs2 : M[LT] => GenTraversableLike[LT, M[LT]], // tvs2 and tcbf are required for the call to map below 
+       tvs2 : M[LT] => GenTraversableLike[LT, M[LT]], // tvs2, tev, and tcbf are required for the call to map below
+       tev  : AdditiveCollection[M[LT]],
        tcbf : CanBuildFrom[M[LT], L, M[L]],
-       tvs  : M[L] => GenTraversableLike[L, M[L]], // tvs and cbf are required for the call to +: below
-       cbf  : CanBuildFrom[M[L], L, M[L]]) : Aux[H1 :: H2 :: T, M, L, Succ[N0]] =
+       tvs  : M[L] => GenTraversableLike[L, M[L]], // tvs, cbf, and ev are required for the call to +: below
+       cbf  : CanBuildFrom[M[L], L, M[L]],
+       ev   : AdditiveCollection[M[L]]) : Aux[H1 :: H2 :: T, M, L, Succ[N0]] =
         new ToSized[H1 :: H2 :: T, M] {
           type Lub = L
           type N = Succ[N0]

--- a/core/src/main/scala/shapeless/ops/sizeds.scala
+++ b/core/src/main/scala/shapeless/ops/sizeds.scala
@@ -24,7 +24,7 @@ object sized {
       }
 
     implicit def nonEmptySizedToHList[Repr, L <: Nat]
-      (implicit itl: IsTraversableLike[Repr], ts: ToHList[Repr, L]): Aux[Repr, Succ[L], itl.A :: ts.Out] =
+      (implicit itl: IsTraversableLike[Repr], ev: AdditiveCollection[Repr], ts: ToHList[Repr, L]): Aux[Repr, Succ[L], itl.A :: ts.Out] =
         new ToHList[Repr, Succ[L]] {
           type Out = itl.A :: ts.Out
           def apply(s: Sized[Repr, Succ[L]]) = s.head :: ts(s.tail)

--- a/core/src/main/scala/shapeless/sized.scala
+++ b/core/src/main/scala/shapeless/sized.scala
@@ -36,7 +36,7 @@ final class Sized[+Repr, L <: Nat](val unsized : Repr) extends AnyVal
  * 
  * @author Miles Sabin
  */
-class SizedOps[A0, Repr, L <: Nat](s : Sized[Repr, L], itl: IsTraversableLike[Repr] { type A = A0 }) { outer =>
+class SizedOps[A0, Repr : AdditiveCollection, L <: Nat](s : Sized[Repr, L], itl: IsTraversableLike[Repr] { type A = A0 }) { outer =>
   import nat._
   import ops.nat._
   import LT._
@@ -153,13 +153,15 @@ class SizedOps[A0, Repr, L <: Nat](s : Sized[Repr, L], itl: IsTraversableLike[Re
     (implicit
       sum : Sum[L, M],
       cbf : CanBuildFrom[Repr, B, That],
-      convThat : That => GenTraversableLike[B, That]) = wrap[That, sum.Out](s.unsized ++ that.unsized)
+      convThat : That => GenTraversableLike[B, That],
+      ev : AdditiveCollection[That]) = wrap[That, sum.Out](s.unsized ++ that.unsized)
     
   /**
    * Map across this collection. The resulting collection will be statically known to have the same number of elements
    * as this collection.
    */
-  def map[B, That](f : A0 => B)(implicit cbf : CanBuildFrom[Repr, B, That]) = wrap[That, L](s.unsized map f)
+  def map[B, That](f : A0 => B)(implicit cbf : CanBuildFrom[Repr, B, That], ev : AdditiveCollection[That]) =
+    wrap[That, L](s.unsized map f)
 
   /**
    * Converts this `Sized` to an `HList` whose elements have the same type as in `Repr`. 
@@ -178,16 +180,58 @@ trait LowPrioritySized {
 
 object Sized extends LowPrioritySized {
   implicit def sizedOps[Repr, L <: Nat](s : Sized[Repr, L])
-    (implicit itl: IsTraversableLike[Repr]): SizedOps[itl.A, Repr, L] =
+    (implicit itl: IsTraversableLike[Repr], ev: AdditiveCollection[Repr]): SizedOps[itl.A, Repr, L] =
       new SizedOps[itl.A, Repr, L](s, itl)
   
   def apply[CC[_]] = new SizedBuilder[CC]
   
   def apply[CC[_]]()
-    (implicit cbf : CanBuildFrom[Nothing, Nothing, CC[Nothing]]) =
+    (implicit cbf : CanBuildFrom[Nothing, Nothing, CC[Nothing]], ev : AdditiveCollection[CC[Nothing]]) =
       new Sized[CC[Nothing], _0](cbf().result)
   
-  def wrap[Repr, L <: Nat](r : Repr) = new Sized[Repr, L](r)
+  def wrap[Repr, L <: Nat](r : Repr)(implicit ev : AdditiveCollection[Repr]) = new Sized[Repr, L](r)
 
   def unapplySeq[Repr, L <: Nat](x : Sized[Repr, L]) = Some(x.unsized)
+}
+
+/**
+ * Evidence that `Repr` instances can be nested in a `Sized`.
+ *
+ * Should assert that a `Builder[_, Repr]` given n elements will result in a Repr of length n.
+ *
+ * @author Alexandre Archambault
+ */
+trait AdditiveCollection[Repr]
+
+object AdditiveCollection {
+  import scala.collection.immutable.Queue
+  import scala.collection.LinearSeq
+
+  implicit def linearSeqAdditiveCollection[T]: AdditiveCollection[LinearSeq[T]] =
+    new AdditiveCollection[LinearSeq[T]] {}
+
+  implicit def vectorAdditiveCollection[T]: AdditiveCollection[Vector[T]] =
+    new AdditiveCollection[Vector[T]] {}
+
+  implicit def arrayAdditiveCollection[T]: AdditiveCollection[Array[T]] =
+    new AdditiveCollection[Array[T]] {}
+
+  implicit def stringAdditiveCollection: AdditiveCollection[String] =
+    new AdditiveCollection[String] {}
+
+  implicit def listAdditiveCollection[T]: AdditiveCollection[List[T]] =
+    new AdditiveCollection[List[T]] {}
+
+  implicit def streamAdditiveCollection[T]: AdditiveCollection[Stream[T]] =
+    new AdditiveCollection[Stream[T]] {}
+
+  implicit def queueAdditiveCollection[T]: AdditiveCollection[Queue[T]] =
+    new AdditiveCollection[Queue[T]] {}
+
+  implicit def indexedSeqAdditiveCollection[T]: AdditiveCollection[IndexedSeq[T]] =
+    new AdditiveCollection[IndexedSeq[T]] {}
+
+  implicit def defaultAdditiveCollection[T]: AdditiveCollection[collection.immutable.IndexedSeq[T]] =
+    new AdditiveCollection[collection.immutable.IndexedSeq[T]] {}
+
 }

--- a/core/src/main/scala/shapeless/syntax/sized.scala
+++ b/core/src/main/scala/shapeless/syntax/sized.scala
@@ -21,12 +21,13 @@ import scala.collection.{ GenTraversable, GenTraversableLike }
 
 object sized {
   implicit def genTraversableSizedConv[CC[X] <: GenTraversable[X], T](cc : CC[T])
-    (implicit conv : CC[T] => GenTraversableLike[T, CC[T]]) = new SizedConv[T, CC[T]](cc)
+    (implicit conv : CC[T] => GenTraversableLike[T, CC[T]], ev : AdditiveCollection[CC[T]]) =
+      new SizedConv[T, CC[T]](cc)
   
   implicit def stringSizedConv(s : String) = new SizedConv[Char, String](s)
 }
 
-final class SizedConv[A, Repr <% GenTraversableLike[A, Repr]](r : Repr) {
+final class SizedConv[A, Repr <% GenTraversableLike[A, Repr] : AdditiveCollection](r : Repr) {
   import ops.nat._
   import Sized._
 

--- a/core/src/test/scala/shapeless/sized.scala
+++ b/core/src/test/scala/shapeless/sized.scala
@@ -197,6 +197,10 @@ class SizedTests {
     typed[Sized[Array[String], _1]](isa1)
     val isa2 = Sized[Array]("foo", "bar")
     typed[Sized[Array[String], _2]](isa2)
+
+    val set = Set(1, 2)
+    illTyped(""" set.sized(2) """)
+    illTyped(""" Sized[Set](1, 1, 1) """)
   }
 
   trait Fruit

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -429,7 +429,7 @@ object Boilerplate {
         |  import Sized.wrap
         |
         -  def apply[T](${`a:T..n:T`})
-        -    (implicit cbf : CanBuildFrom[Nothing, T, CC[T]]) = 
+        -    (implicit cbf : CanBuildFrom[Nothing, T, CC[T]], ev : AdditiveCollection[CC[T]]) =
         -    wrap[CC[T], _${arity}]((cbf() += (${`a..n`})).result)
         -
         |}


### PR DESCRIPTION
A possible workaround for https://github.com/milessabin/shapeless/issues/206 .

I mainly added a `StrictSizeCollection` type class, used as an evidence that a `Repr` is a collection that behaves as expected for `Sized` (which should be that a `Builder[_, Repr]` given `n` elements results in a `Repr` of length `n`). I added here or there requirements of a `StrictSizeCollection` when this was required. Plus a few  `illTyped`-based tests.
