### PR TITLE
Added headTail & initLast to HList & Coproduct

### DIFF
--- a/core/src/main/scala/shapeless/lenses.scala
+++ b/core/src/main/scala/shapeless/lenses.scala
@@ -19,7 +19,7 @@ package shapeless
 import scala.language.dynamics
 
 import ops.coproduct.{ Inject, Selector => CSelector }
-import ops.hlist.{ At, Init, Last, Prepend, Selector, ReplaceAt, Replacer, Tupler }
+import ops.hlist.{ At, InitLast, Prepend, Selector, ReplaceAt, Replacer, Tupler }
 import ops.record.{ Selector => RSelector, Updater }
 import record.{ FieldType, field }
 import tag.@@
@@ -109,8 +109,7 @@ trait ProductLensBuilder[C, P <: Product] extends Lens[C, P] {
       pre: Prepend.Aux[L, T :: HNil, LT],
       tpq: Tupler.Aux[LT, Q],
       genq: Generic.Aux[Q, QL],
-      init: Init.Aux[QL, L],
-      last: Last.Aux[QL, T]) =
+      initLast: InitLast.Aux[QL, L, T]) =
       new ProductLensBuilder[C, Q] {
         def get(c: C): Q = (genp.to(outer.get(c)) :+ other.get(c)).tupled
         def set(c: C)(q: Q) = {
@@ -129,10 +128,9 @@ trait ProductPrismBuilder[C, P <: Product] extends Prism[C, P] {
       pre: Prepend.Aux[L, T :: HNil, LT],
       tpq: Tupler.Aux[LT, Q],
       genq: Generic.Aux[Q, QL],
-      init: Init.Aux[QL, L],
-      last: Last.Aux[QL, T]) =
+      initLast: InitLast.Aux[QL, L, T]) =
       new ProductPrismBuilder[C, Q] {
-        def get(c: C): Option[Q] = 
+        def get(c: C): Option[Q] =
           for {
             init <- outer.get(c)
             last <- other.get(c)

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -123,10 +123,10 @@ object tuple {
     type Aux[T, Out0] = Last[T] { type Out = Out0 }
 
     implicit def last[T, L <: HList]
-      (implicit gen: Generic.Aux[T, L], last: hl.Last[L]): Aux[T, last.Out] =
+      (implicit gen: Generic.Aux[T, L], initLast: hl.InitLast[L]): Aux[T, initLast.Suffix] =
         new Last[T] {
-          type Out = last.Out
-          def apply(t: T): Out = gen.to(t).last
+          type Out = initLast.Suffix
+          def apply(t: T): Out = initLast.last(gen.to(t))
         }
   }
 
@@ -143,11 +143,12 @@ object tuple {
 
     type Aux[T, Out0] = Init[T] { type Out = Out0 }
 
-    implicit def init[T, L1 <: HList, L2 <: HList]
-      (implicit gen: Generic.Aux[T, L1], init: hl.Init.Aux[L1, L2], tp: hl.Tupler[L2]): Aux[T, tp.Out] =
+    implicit def init[T, L <: HList, LInit <: HList, LLast](
+      implicit gen: Generic.Aux[T, L], initLast: hl.InitLast.Aux[L, LInit, LLast], tp: hl.Tupler[LInit]
+    ): Aux[T, tp.Out] =
         new Init[T] {
           type Out = tp.Out
-          def apply(t: T): Out = init(gen.to(t)).tupled
+          def apply(t: T): Out = initLast.init(gen.to(t)).tupled
         }
   }
 

--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -31,13 +31,15 @@ final class CoproductOps[C <: Coproduct](c: C) {
   /**
    * Returns the head of this `Coproduct`
    */
-  def head(implicit cc: IsCCons[C]): Option[cc.H] = cc.head(c)
+  def head(implicit cc: IsCCons[C]): Option[cc.Prefix] = cc.head(c)
 
   /**
    * Returns the tail of this `Coproduct`
    */
+  def tail(implicit cc: IsCCons[C]): Option[cc.Suffix] = cc.tail(c)
 
-  def tail(implicit cc: IsCCons[C]): Option[cc.T] = cc.tail(c)
+  def headTail(implicit cc: IsCCons[C]): Either[cc.Prefix, cc.Suffix] = cc(c)
+  def headTailC(implicit cc: IsCCons[C]): cc.Prefix :+: cc.Suffix :+: CNil = cc.coproduct(c)
 
   /**
    * Returns the ''nth'' element of this `Coproduct`. An explicit type must be provided.
@@ -54,12 +56,15 @@ final class CoproductOps[C <: Coproduct](c: C) {
   /**
    * Returns the last element of this 'Coproduct'
    */
-  def last(implicit il: InitLast[C]): Option[il.L] = il.last(c)
+  def last(implicit il: InitLast[C]): Option[il.Suffix] = il.last(c)
 
   /**
    * Returns all elements except the last
    */
-  def init(implicit il: InitLast[C]): Option[il.I] = il.init(c)
+  def init(implicit il: InitLast[C]): Option[il.Prefix] = il.init(c)
+
+  def initLast(implicit il: InitLast[C]): Either[il.Prefix, il.Suffix] = il(c)
+  def initLastC(implicit il: InitLast[C]): il.Prefix :+: il.Suffix :+: CNil = il.coproduct(c)
 
   /**
    * Returns the first element of type `U` of this `Coproduct`. An explicit type argument must be provided. Available

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -40,6 +40,9 @@ final class HListOps[L <: HList](l : L) {
    */
   def tail(implicit c : IsHCons[L]) : c.T = c.tail(l)
 
+  def headTail(implicit c: IsHCons[L]): (c.H, c.T) = c.apply(l)
+  def headTailP(implicit c: IsHCons[L]): c.H :: c.T :: HNil = c.product(l)
+
   /**
    * Prepend the argument element to this `HList`.
    */
@@ -102,13 +105,16 @@ final class HListOps[L <: HList](l : L) {
   /**
    * Returns the last element of this `HList`. Available only if there is evidence that this `HList` is composite.
    */
-  def last(implicit last : Last[L]) : last.Out = last(l)
+  def last(implicit initLast : InitLast[L]) : initLast.Suffix = initLast.last(l)
 
   /**
    * Returns an `HList` consisting of all the elements of this `HList` except the last. Available only if there is
    * evidence that this `HList` is composite.
    */
-  def init(implicit init : Init[L]) : init.Out = init(l)
+  def init(implicit initLast : InitLast[L]) : initLast.Prefix = initLast.init(l)
+
+  def initLast(implicit initLast: InitLast[L]): (initLast.Prefix, initLast.Suffix) = initLast(l)
+  def initLastP(implicit initLast: InitLast[L]): initLast.Prefix :: initLast.Suffix :: HNil = initLast.product(l)
 
   /**
    * Returns the first element of type `U` of this `HList`. An explicit type argument must be provided. Available only

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -565,6 +565,27 @@ class CoproductTests {
   }
 
   @Test
+  def testHeadTail {
+    val r1 = Coproduct[Int :+: CNil](1).headTail
+    assertTypedEquals[Either[Int, CNil]](Left(1), r1)
+
+    val r2 = Coproduct[Int :+: String :+: CNil](1).headTail
+    assertTypedEquals[Either[Int, String :+: CNil]](Left(1), r2)
+
+    val r3 = Coproduct[Int :+: String :+: CNil]("foo").headTail
+    assertTypedEquals[Either[Int, String :+: CNil]](Right(Coproduct[String :+: CNil]("foo")), r3)
+
+    val r4 = Coproduct[Int :+: CNil](1).headTailC
+    assertTypedEquals[Int :+: CNil :+: CNil](Inl(1), r4)
+
+    val r5 = Coproduct[Int :+: String :+: CNil](1).headTailC
+    assertTypedEquals[Int :+: (String :+: CNil) :+: CNil](Inl(1), r5)
+
+    val r6 = Coproduct[Int :+: String :+: CNil]("foo").headTailC
+    assertTypedEquals[Int :+: (String :+: CNil) :+: CNil](Inr(Inl(Inl("foo"))), r6)
+  }
+
+  @Test
   def testReverse {
     type S = String; type I = Int; type D = Double; type C = Char
     type SI = S :+: I :+: CNil; type IS = I :+: S :+: CNil
@@ -601,6 +622,27 @@ class CoproductTests {
 
     val r3 = Coproduct[Int :+: String :+: CNil](1).last
     assertTypedEquals[Option[String]](None, r3)
+  }
+
+  @Test
+  def testInitLast {
+    val r1 = Coproduct[Int :+: CNil](1).initLast
+    assertTypedEquals[Either[CNil, Int]](Right(1), r1)
+
+    val r2 = Coproduct[Int :+: String :+: CNil]("foo").initLast
+    assertTypedEquals[Either[Int :+: CNil, String]](Right("foo"), r2)
+
+    val r3 = Coproduct[Int :+: String :+: CNil](1).initLast
+    assertTypedEquals[Either[Int :+: CNil, String]](Left(Coproduct[Int :+: CNil](1)), r3)
+
+    val r4 = Coproduct[Int :+: CNil](1).initLastC
+    assertTypedEquals[CNil :+: Int :+: CNil](Inr(Inl((1))), r4)
+
+    val r5 = Coproduct[Int :+: String :+: CNil]("foo").initLastC
+    assertTypedEquals[(Int :+: CNil) :+: String :+: CNil](Inr(Inl("foo")), r5)
+
+    val r6 = Coproduct[Int :+: String :+: CNil](1).initLastC
+    assertTypedEquals[(Int :+: CNil) :+: String :+: CNil](Inl(Inl(1)), r6)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -137,6 +137,12 @@ class HListTests {
     val r2 = l.tail.head
     assertTypedEquals[String]("foo", r2)
 
+    val r3 = l.headTail
+    assertTypedEquals[(Int, String :: Double :: HNil)]((1, "foo" :: 2.0 :: HNil), r3)
+
+    val r4 = l.headTailP
+    assertTypedEquals[Int :: (String :: Double :: HNil) :: HNil](1 :: ("foo" :: 2.0 :: HNil) :: HNil, r4)
+
     assertEquals(2.0, l.tail.tail.head, Double.MinPositiveValue)
 
     illTyped("""
@@ -145,6 +151,14 @@ class HListTests {
 
     illTyped("""
       HNil.tail
+    """)
+
+    illTyped("""
+      HNil.headTail
+    """)
+
+    illTyped("""
+      HNil.headTailP
     """)
 
     illTyped("""
@@ -278,12 +292,17 @@ class HListTests {
 
   @Test
   def testInitLast {
+    val r1 = apbp.last
+    assertTypedEquals[Pear](p, r1)
 
-    val lp = apbp.last
-    assertTypedEquals[Pear](p, lp)
+    val r2 = apbp.init
+    assertTypedEquals[APB](a :: p :: b :: HNil, r2)
 
-    val iapb = apbp.init
-    assertTypedEquals[APB](a :: p :: b :: HNil, iapb)
+    val r3 = apbp.initLast
+    assertTypedEquals[(APB, Pear)]((a :: p :: b :: HNil, p), r3)
+
+    val r4 = apbp.initLastP
+    assertTypedEquals[APB :: Pear :: HNil]((a :: p :: b :: HNil) :: p :: HNil, r4)
   }
 
   @Test


### PR DESCRIPTION
- Aliases: HList.{headTailP, initLastP}, Coproduct.{headTailC, initLastC}
- Added ProductDepFn1 & CoproductDepFn1 for dependant functions that return products / coproducts.
- Replaced HList.{Init, Last} type classes with InitLast
