### PR TITLE
Fixed hygiene bug in witness generation.

### DIFF
--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -80,7 +80,7 @@ class SingletonTypeMacros(val c: whitebox.Context) {
 
     q"""
       {
-        final class $name extends Witness {
+        final class $name extends _root_.shapeless.Witness {
           type T = $sTpe
           val value: $sTpe = $s
         }


### PR DESCRIPTION
Here's a quick example:

``` scala
case class Foo(i: Int)

object Bar {
  import shapeless._
  def firstKeyName[K <: Symbol, V, T <: HList](l: record.FieldType[K, V] :: T)(implicit
    witness: Witness.Aux[K]
  ): String = witness.value.name
}
```

And then:

``` scala
scala> Bar.firstKeyName(shapeless.LabelledGeneric[Foo].to(Foo(1)))
<console>:11: shapeless.this.Witness.apply is not a valid implicit value for shapeless.Witness.Aux[Symbol with shapeless.tag.Tagged[String("i")]] because:
hasMatchingSymbol reported error: not found: type Witness
              Bar.firstKeyName(shapeless.LabelledGeneric[Foo].to(Foo(1)))
                              ^
<console>:11: error: could not find implicit value for parameter witness: shapeless.Witness.Aux[Symbol with shapeless.tag.Tagged[String("i")]]
              Bar.firstKeyName(shapeless.LabelledGeneric[Foo].to(Foo(1)))
                              ^
```

But:

``` scala
scala> import shapeless._
import shapeless._

scala> Bar.firstKeyName(shapeless.LabelledGeneric[Foo].to(Foo(1)))
res1: String = i
```

Adding the full path from `_root_` in `mkWitness` fixes the issue.
