### PR TITLE
Coproduct.embed/Basis (converts Sub-Coproduct to Super-Coproduct)

### DIFF
--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -180,4 +180,10 @@ final class CoproductOps[C <: Coproduct](c: C) {
    */
   def extendRightBy[K <: Coproduct](implicit extendRightBy: ExtendRightBy[C, K]): extendRightBy.Out =
     extendRightBy(c)
+
+  /**
+   * Embeds this `Coproduct` into a "bigger" `Coproduct` if possible.
+   */
+  def embed[Super <: Coproduct](implicit basis: Basis[C, Super]): basis.Out =
+    basis(c)
 }

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -934,4 +934,38 @@ class CoproductTests {
     type PISBb = the.`ToHList[CISB]`.Out
     implicitly[PISBa =:= PISBb]
   }
+
+  @Test
+  def testEmbed {
+    type S1 = Int :+: CNil
+    type S2 = Int :+: String :+: CNil
+    type S3 = Int :+: String :+: Boolean :+: CNil
+    type S4 = String :+: Boolean :+: CNil
+
+    type S1a = the.`Basis[S1, S1]`.Out
+    implicitly[S1 =:= S1a]
+
+    type S2a = the.`Basis[S1, S2]`.Out
+    implicitly[S2 =:= S2a]
+    
+    type S3a = the.`Basis[S1, S3]`.Out
+    implicitly[S3 =:= S3a]
+
+    type S3b = the.`Basis[S2, S3]`.Out
+    implicitly[S3 =:= S3b]
+
+    type S3c = the.`Basis[S3, S3]`.Out
+    implicitly[S3 =:= S3c]
+    
+    val c1 = Coproduct[S1](5).embed[S2]
+    assertTypedEquals[S2](c1, Coproduct[S2](5))
+
+    val c2 = Coproduct[S1](5).embed[S3]
+    assertTypedEquals[S3](c2, Coproduct[S3](5))
+
+    val c3 = Coproduct[S2]("toto").embed[S3]
+    assertTypedEquals[S3](c3, Coproduct[S3]("toto"))
+
+    illTyped("Coproduct[S1](5).embed[S4]")
+  }
 }


### PR DESCRIPTION
- checks that a Coproduct is a sub-union of a _bigger_ Coproduct
- enlarges a _sub_-Coproduct into a _super_-Coproduct
