### PR TITLE
Fix in coproduct at signature

### DIFF
--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -49,7 +49,7 @@ final class CoproductOps[C <: Coproduct](c: C) {
    * Returns the ''nth'' element of this `Coproduct`.
    * Available only if there is evidence that this `Coproduct` has at least ''n'' elements.
    */
-  def at[N <: Nat](n: N)(implicit at: At[C, n.N]): Option[at.A] = at(c)
+  def at(n: Nat)(implicit at: At[C, n.N]): Option[at.A] = at(c)
 
   /**
    * Returns the last element of this 'Coproduct'

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -778,24 +778,47 @@ class CoproductTests {
     val in2 = Coproduct[I :+: S :+: CNil](1)
     val in3 = Coproduct[I :+: S :+: D :+: CNil](1)
 
-    val r1 = in1.at[_0]
-    assertTypedEquals[Option[I]](Some(1), r1)
+    {
+      val r1 = in1.at(0)
+      assertTypedEquals[Option[I]](Some(1), r1)
 
-    val r2 = in2.at[_0]
-    assertTypedEquals[Option[I]](Some(1), r2)
+      val r2 = in2.at(0)
+      assertTypedEquals[Option[I]](Some(1), r2)
 
-    val r3 = in3.at[_0]
-    assertTypedEquals[Option[I]](Some(1), r3)
+      val r3 = in3.at(0)
+      assertTypedEquals[Option[I]](Some(1), r3)
 
 
-    val r4 = in2.at[_1]
-    assertTypedEquals[Option[S]](None, r4)
+      val r4 = in2.at(1)
+      assertTypedEquals[Option[S]](None, r4)
 
-    val r5 = in3.at[_1]
-    assertTypedEquals[Option[S]](None, r5)
+      val r5 = in3.at(1)
+      assertTypedEquals[Option[S]](None, r5)
 
-    val r6 = in3.at[_2]
-    assertTypedEquals[Option[D]](None, r6)
+      val r6 = in3.at(2)
+      assertTypedEquals[Option[D]](None, r6)
+    }
+
+    {
+      val r1 = in1.at[nat._0]
+      assertTypedEquals[Option[I]](Some(1), r1)
+
+      val r2 = in2.at[nat._0]
+      assertTypedEquals[Option[I]](Some(1), r2)
+
+      val r3 = in3.at[nat._0]
+      assertTypedEquals[Option[I]](Some(1), r3)
+
+
+      val r4 = in2.at[nat._1]
+      assertTypedEquals[Option[S]](None, r4)
+
+      val r5 = in3.at[nat._1]
+      assertTypedEquals[Option[S]](None, r5)
+
+      val r6 = in3.at[nat._2]
+      assertTypedEquals[Option[D]](None, r6)
+    }
   }
 
   @Test


### PR DESCRIPTION
``` scala
scala> val c = Coproduct[Int :+: Double :+: Boolean :+: CNil](0.0)
c: shapeless.:+:[Int,shapeless.:+:[Double,shapeless.:+:[Boolean,shapeless.CNil]]] = 0.0

scala> c.at(0)
<console>:12: error: overloaded method value at with alternatives:
  [N <: shapeless.Nat](n: N)(implicit at: shapeless.ops.coproduct.At[shapeless.:+:[Int,shapeless.:+:[Double,shapeless.:+:[Boolean,shapeless.CNil]]],n.N])Option[at.A] <and>
  [N <: shapeless.Nat](implicit at: shapeless.ops.coproduct.At[shapeless.:+:[Int,shapeless.:+:[Double,shapeless.:+:[Boolean,shapeless.CNil]]],N])Option[at.A]
 cannot be applied to (Int)
              c.at(0)
                ^
```

Looks a bit like https://github.com/milessabin/shapeless/pull/246, https://github.com/milessabin/shapeless/pull/209. But both overloads can be kept, the non-type argument one just needs some adjustments.
