### PR TITLE
Ignore common incidental workspace files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,27 @@
 scratch/
 target/
+
+# Ignore project files for Eclipse
+/.classpath
+/*/.classpath
+/.settings
+/*/.settings
+/.project
+/*/.project
+/.worksheet
+/*/.worksheet
+
+# Ignore project files for IntelliJ
+/.idea
+/*/.idea
+*.iml
+*.iws
+
+# Ignore OS X metadata
+.DS_Store
+
+# Ignore vim swap files
+.swp
+.*.swp
+.swo
+.*.swo


### PR DESCRIPTION
This adds Git ignore patterns for Eclipse, IDEA, OS X and Vim.

These files are pretty common in various editing and development environments. If not ignored, they clutter up your git status and it's easy to commit them by accident. (It's true that individual developers can put these in their global ignore files, but I think it's good hygiene for Scala projects to explicitly ignore these common files.)
