### PR TITLE
Added Literals selectDynamic macro

### DIFF
--- a/core/src/main/scala/shapeless/labelled.scala
+++ b/core/src/main/scala/shapeless/labelled.scala
@@ -152,4 +152,40 @@ class LabelledMacros(val c: whitebox.Context) {
     // to result in a runtime exception if the value is used in term position.
     Literal(Constant(())).setType(carrier)
   }
+
+  def literalsTypeImpl(tpeSelector: c.Tree): c.Tree = {
+    import c.universe.{ Try => _, _ }
+    import internal._, decorators._
+
+    val q"${tpeString: String}" = tpeSelector
+    val types = tpeString.split(",").map(_.trim).map { value =>
+      (for {
+        parsed <- Try(c.parse(value)).toOption
+        checked = c.typecheck(parsed, silent = true)
+        if checked.nonEmpty
+      } yield
+        checked match {
+          case q""" ${SingletonKeyType(keyType)} """ => keyType
+          case _ =>
+            c.abort(c.enclosingPosition, s"$checked does not look like a literal")
+        }
+      ).getOrElse(c.abort(c.enclosingPosition, s"Malformed type $tpeString"))
+    }
+
+    val productTpe =
+      types.foldRight(hnilTpe) { case (tpe, acc) =>
+        appliedType(hconsTpe, List(tpe, acc))
+      }
+
+    val sumTpe =
+      types.foldRight(cnilTpe) { case (tpe, acc) =>
+        appliedType(cconsTpe, List(tpe, acc))
+      }
+
+    val carrier = c.typecheck(tq"{ type T = $productTpe; type S = $sumTpe }", mode = c.TYPEmode).tpe
+
+    // We can't yield a useful value here, so return Unit instead which is at least guaranteed
+    // to result in a runtime exception if the value is used in term position.
+    Literal(Constant(())).setType(carrier)
+  }
 }

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -16,6 +16,7 @@
 
 package shapeless
 
+import scala.language.dynamics
 import scala.language.existentials
 import scala.language.experimental.macros
 
@@ -47,6 +48,10 @@ object Witness {
       type T = Succ[P]
       val value = new Succ[P]()
     }
+}
+
+object Literals extends Dynamic {
+  def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.literalsTypeImpl
 }
 
 trait WitnessWith[TC[_]] extends Witness {

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -136,6 +136,40 @@ class SingletonTypesTests {
     assertEquals("'bar", sBar)
   }
 
+  trait LiteralsShow[-T] {
+    def show: String
+  }
+
+  object LiteralsShow {
+    implicit val showTrueFalse        = new LiteralsShow[Literals.`true, false`.T] { def show = "true, false" }
+    implicit val showOneOrTwoOrThree  = new LiteralsShow[Literals.`1, 2, 3`.S] { def show = "One | Two | Three" }
+    implicit val showFooBar           = new LiteralsShow[Literals.`'foo, 'bar`.T] { def show = "'foo, 'bar" }
+  }
+
+  def literalsShow[T](t: T)(implicit s: LiteralsShow[T]) = s.show
+
+  @Test
+  def testRefinedLiteralsTypeClass {
+    val sTrueFalse = literalsShow(true.narrow :: false.narrow :: HNil)
+    assertEquals("true, false", sTrueFalse)
+
+    val sOne = literalsShow(Inl(1.narrow))
+    assertEquals("One | Two | Three", sOne)
+
+    val sTwo = literalsShow(Inr(Inl(2.narrow)))
+    assertEquals("One | Two | Three", sTwo)
+
+    val sThree = literalsShow(Inr(Inr(Inl(3.narrow))))
+    assertEquals("One | Two | Three", sThree)
+
+    illTyped("""
+      literalsShow(true :: false :: HNil)
+    """)
+
+    val sFooBar = literalsShow('foo.narrow :: 'bar.narrow :: HNil)
+    assertEquals("'foo, 'bar", sFooBar)
+  }
+
   @Test
   def testWitness {
     val wTrue = Witness(true)


### PR DESCRIPTION
Same as https://github.com/milessabin/shapeless/pull/270 for `HList`s/`Coproduct`s

Allows one to write

``` scala
val l: Literals.`2, true, "a"`.T = 2.narrow :: true.narrow :: "a".narrow :: HNil
val c1 = Coproduct[Literals.`2, true, "a"`.S](2.narrow)
val c2 = Coproduct[Literals.`2, true, "a"`.S](true.narrow)
val c3 = Coproduct[Literals.`2, true, "a"`.S]("a".narrow)
```

Will also be useful with overloads of `zipWithKeys` methods, in my next PR.
