### PR TITLE
Added HList.{partition, partitionP} & Coproduct.{partition, partitionC}

### DIFF
--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -70,12 +70,17 @@ final class CoproductOps[C <: Coproduct](c: C) {
   /**
    * Returns all elements of type `U` of this `Coproduct`. An explicit type argument must be provided.
    */
-  def filter[U](implicit filter: Filter[C, U]): Option[filter.A]  = filter(c)
+  def filter[U](implicit partition: Partition[C, U]): Option[partition.Prefix]  = partition.filter(c)
 
   /**
    * Returns all elements of type different than `U` of this `Coproduct`. An explicit type argument must be provided.
    */
-  def filterNot[U](implicit filterNot: FilterNot[C, U]): Option[filterNot.A] = filterNot(c)
+  def filterNot[U](implicit partition: Partition[C, U]): Option[partition.Suffix] = partition.filterNot(c)
+
+  def partition[U](implicit partition: Partition[C, U]): Either[partition.Prefix, partition.Suffix] = partition(c)
+
+  def partitionC[U]
+    (implicit partition: Partition[C, U]): partition.Prefix :+: partition.Suffix :+: CNil = partition.coproduct(c)
 
   /**
    * Returns the first element of type `U` of this `Coproduct` plus the remainder of the `Coproduct`.

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -119,12 +119,17 @@ final class HListOps[L <: HList](l : L) {
   /**
    * Returns all elements of type `U` of this `HList`. An explicit type argument must be provided.
    */
-  def filter[U](implicit filter : Filter[L, U]) : filter.Out  = filter(l)
+  def filter[U](implicit partition : Partition[L, U]) : partition.Prefix  = partition.filter(l)
 
   /**
    * Returns all elements of type different than `U` of this `HList`. An explicit type argument must be provided.
    */
-  def filterNot[U](implicit filter : FilterNot[L, U]) : filter.Out  = filter(l)
+  def filterNot[U](implicit partition : Partition[L, U]) : partition.Suffix  = partition.filterNot(l)
+
+  def partition[U](implicit partition: Partition[L, U]): (partition.Prefix, partition.Suffix) = partition(l)
+
+  def partitionP[U]
+    (implicit partition: Partition[L, U]): partition.Prefix :: partition.Suffix :: HNil = partition.product(l)
 
   /**
    * Returns the first element of type `U` of this `HList` plus the remainder of the `HList`. An explicit type argument

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -928,50 +928,88 @@ class CoproductTests {
   }
 
   @Test
-  def testFilter {
+  def testPartition {
     type S = String; type I = Int; type D = Double; type C = Char
-    val in1   = Coproduct[I :+: CNil](1)
-    val in2   = Coproduct[I :+: S :+: CNil](1)
-    val in3   = Coproduct[I :+: S :+: D :+: CNil](1)
-    val isdi1 = Coproduct[I :+: S :+: D :+: I :+: CNil](1)
+    val i   = Coproduct[I :+: CNil](1)
+    val is   = Coproduct[I :+: S :+: CNil](1)
 
-    val isdi2: I :+: S :+: D :+: I :+: CNil =
+    val isdi: I :+: S :+: D :+: I :+: CNil =
       Inr[I, S :+: D :+: I :+: CNil](Coproduct[S :+: D :+: I :+: CNil](2))
 
-    val r1 = in1.filter[I]
-    assertTypedEquals[Option[I :+: CNil]](Some(in1), r1)
+    val r1 = i.partition[I]
+    assertTypedEquals[Either[I :+: CNil, CNil]](Left(i), r1)
+    val r2 = is.partition[I]
+    assertTypedEquals[Either[I :+: CNil, S :+: CNil]](Left(i), r2)
 
-    val r2 = in2.filter[I]
-    assertTypedEquals[Option[I :+: CNil]](Some(in1), r2)
+    val r3 = i.partition[S]
+    assertTypedEquals[Either[CNil, I :+: CNil]](Right(i), r3)
+    val r4 = is.partition[S]
+    assertTypedEquals[Either[S :+: CNil, I :+: CNil]](Right(i), r4)
 
-    val r3 = in3.filter[I]
-    assertTypedEquals[Option[I :+: CNil]](Some(in1), r3)
+    val r5 = i.partition[C]
+    assertTypedEquals[Either[CNil, I :+: CNil]](Right(i), r5)
+    val r6 = is.partition[C]
+    assertTypedEquals[Either[CNil, I :+: S :+: CNil]](Right(is), r6)
 
+    val r7 = isdi.partition[I]
+    assertTypedEquals[Either[I :+: I :+: CNil, S :+: D :+: CNil]](Left(Inr[I, I :+: CNil](Inl[I, CNil](2))), r7)
+  }
 
-    val r4 = in2.filter[S]
+  @Test
+  def testPartitionC {
+    type S = String; type I = Int; type D = Double; type C = Char
+    val i   = Coproduct[I :+: CNil](1)
+    val is   = Coproduct[I :+: S :+: CNil](1)
+
+    val isdi: I :+: S :+: D :+: I :+: CNil =
+      Inr[I, S :+: D :+: I :+: CNil](Coproduct[S :+: D :+: I :+: CNil](2))
+
+    val r1 = i.partitionC[I]
+    assertTypedEquals[(I :+: CNil) :+: CNil :+: CNil](Inl(i), r1)
+    val r2 = is.partitionC[I]
+    assertTypedEquals[(I :+: CNil) :+: (S :+: CNil) :+: CNil](Inl(i), r2)
+
+    val r3 = i.partitionC[S]
+    assertTypedEquals[CNil :+: (I :+: CNil) :+: CNil](Inr(Inl(i)), r3)
+    val r4 = is.partitionC[S]
+    assertTypedEquals[(S :+: CNil) :+: (I :+: CNil) :+: CNil](Inr(Inl(i)), r4)
+
+    val r5 = i.partitionC[C]
+    assertTypedEquals[CNil :+: (I :+: CNil) :+: CNil](Inr(Inl(i)), r5)
+    val r6 = is.partitionC[C]
+    assertTypedEquals[CNil :+: (I :+: S :+: CNil) :+: CNil](Inr(Inl(is)), r6)
+
+    val r7 = isdi.partitionC[I]
+    assertTypedEquals[(I :+: I :+: CNil) :+: (S :+: D :+: CNil) :+: CNil](
+      Inl(Inr[I, I :+: CNil](Inl[I, CNil](2))), r7)
+  }
+
+  @Test
+  def testFilter {
+    type S = String; type I = Int; type D = Double; type C = Char
+    val i   = Coproduct[I :+: CNil](1)
+    val is   = Coproduct[I :+: S :+: CNil](1)
+
+    val isdi: I :+: S :+: D :+: I :+: CNil =
+      Inr[I, S :+: D :+: I :+: CNil](Coproduct[S :+: D :+: I :+: CNil](2))
+
+    val r1 = i.filter[I]
+    assertTypedEquals[Option[I :+: CNil]](Some(i), r1)
+    val r2 = is.filter[I]
+    assertTypedEquals[Option[I :+: CNil]](Some(i), r2)
+
+    val r3 = i.filter[S]
+    assertTypedEquals[Option[CNil]](None, r3)
+    val r4 = is.filter[S]
     assertTypedEquals[Option[S :+: CNil]](None, r4)
 
-    val r5 = in3.filter[S]
-    assertTypedEquals[Option[S :+: CNil]](None, r5)
+    val r5 = i.filter[C]
+    assertTypedEquals[Option[CNil]](None, r5)
+    val r6 = is.filter[C]
+    assertTypedEquals[Option[CNil]](None, r6)
 
-    val r6 = in3.filter[D]
-    assertTypedEquals[Option[D :+: CNil]](None, r6)
-
-
-    val r7 = in1.filter[C]
-    assertTypedEquals[Option[CNil]](None, r7)
-
-    val r8 = in2.filter[C]
-    assertTypedEquals[Option[CNil]](None, r8)
-
-    val r9 = in3.filter[C]
-    assertTypedEquals[Option[CNil]](None, r9)
-
-    val r10 = isdi1.filter[I]
-    assertTypedEquals[Option[I :+: I :+: CNil]](Some(Inl[I, I :+: CNil](1)), r10)
-
-    val r11 = isdi2.filter[I]
-    assertTypedEquals[Option[I :+: I :+: CNil]](Some(Inr[I, I :+: CNil](Inl[I, CNil](2))), r11)
+    val r7 = isdi.filter[I]
+    assertTypedEquals[Option[I :+: I :+: CNil]](Some(Inr[I, I :+: CNil](Inl[I, CNil](2))), r7)
   }
 
   @Test
@@ -979,47 +1017,28 @@ class CoproductTests {
     type S = String; type I = Int; type D = Double; type C = Char
     val i     = Coproduct[I :+: CNil](1)
     val is    = Coproduct[I :+: S :+: CNil](1)
-    val isd   = Coproduct[I :+: S :+: D :+: CNil](1)
-    val isdi1 = Coproduct[I :+: S :+: D :+: I :+: CNil](1)
 
-    val isdi2: I :+: S :+: D :+: I :+: CNil =
+    val isdi: I :+: S :+: D :+: I :+: CNil =
       Inr[I, S :+: D :+: I :+: CNil](Coproduct[S :+: D :+: I :+: CNil](2))
 
     val r1 = i.filterNot[I]
     assertTypedEquals[Option[CNil]](None, r1)
     val r2 = is.filterNot[I]
     assertTypedEquals[Option[S :+: CNil]](None, r2)
-    val r3 = isd.filterNot[I]
-    assertTypedEquals[Option[S :+: D :+: CNil]](None, r3)
 
 
     val r4 = i.filterNot[S]
     assertTypedEquals[Option[I :+: CNil]](Some(i), r4)
     val r5 = is.filterNot[S]
     assertTypedEquals[Option[I :+: CNil]](Some(i), r5)
-    val r6 = isd.filterNot[S]
-    assertTypedEquals[Option[I :+: D :+: CNil]](Some(Coproduct[I :+: D :+: CNil](1)), r6)
 
 
     val r7 = i.filterNot[D]
     assertTypedEquals[Option[I :+: CNil]](Some(i), r7)
     val r8 = is.filterNot[D]
     assertTypedEquals[Option[I :+: S :+: CNil]](Some(is), r8)
-    val r9 = isd.filterNot[D]
-    assertTypedEquals[Option[I :+: S :+: CNil]](Some(is), r9)
 
-
-    val r10 = i.filterNot[C]
-    assertTypedEquals[Option[I :+: CNil]](Some(i), r10)
-    val r11 = is.filterNot[C]
-    assertTypedEquals[Option[I :+: S :+: CNil]](Some(is), r11)
-    val r12 = isd.filterNot[C]
-    assertTypedEquals[Option[I :+: S :+: D :+: CNil]](Some(isd), r12)
-
-
-    val r13 = isdi1.filterNot[I]
-    assertTypedEquals[Option[S :+: D :+: CNil]](None, r13)
-    val r14 = isdi2.filterNot[I]
+    val r14 = isdi.filterNot[I]
     assertTypedEquals[Option[S :+: D :+: CNil]](None, r14)
   }
 

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1236,6 +1236,26 @@ class HListTests {
   }
 
   @Test
+  def testPartition {
+    val l1 = 1 :: 2 :: HNil
+    val l2 = 1 :: true :: "foo" :: 2 :: HNil
+
+    val r1 = l1.partition[Int]
+    assertTypedEquals[(Int :: Int :: HNil, HNil)]((1 :: 2 :: HNil, HNil), r1)
+
+    val r2 = l1.partitionP[Int]
+    assertTypedEquals[(Int :: Int :: HNil) :: HNil :: HNil]((1 :: 2 :: HNil) :: HNil :: HNil, r2)
+
+    val r3 = l2.partition[Int]
+    assertTypedEquals[(Int :: Int :: HNil, Boolean :: String :: HNil)]((1 :: 2 :: HNil, true :: "foo" :: HNil), r3)
+
+    val r4 = l2.partitionP[Int]
+    assertTypedEquals[(Int :: Int :: HNil) :: (Boolean :: String :: HNil) :: HNil](
+      (1 :: 2 :: HNil) :: (true :: "foo" :: HNil) :: HNil, r4
+    )
+  }
+
+  @Test
   def testReplace {
     val sl = 1 :: true :: "foo" :: 2.0 :: HNil
 


### PR DESCRIPTION
Reimplemented Filter & FilterNot type classes in terms of Partition
  (for both HList & Coproduct)

Not sure why I let this one languish for so long. Maybe because it doesn't compile. Doh !
