### PR TITLE
explicit label annotation

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -47,6 +47,8 @@ object LabelledGeneric {
 
 class nonGeneric extends StaticAnnotation
 
+final class LabelName(name: String) extends StaticAnnotation
+
 class GenericMacros(val c: whitebox.Context) {
   import c.universe._
 
@@ -122,10 +124,25 @@ class GenericMacros(val c: whitebox.Context) {
 
     def nameOf(tpe: Type) = tpe.typeSymbol.name
 
-    def fieldsOf(tpe: Type): List[(TermName, Type)] =
+    def fieldsOf(tpe: Type): List[(TermName, Type)] = {
+      val explicitLabels = tpe.decls.flatMap { sym =>
+        for {
+          a <- sym.annotations.find(_.tree.tpe =:= typeOf[Label])
+        } yield {
+          val label = a.tree.children.collectFirst {
+            case Literal(Constant(value: String)) => value
+          }.getOrElse {
+            abort(s"$tpe.${sym.name} has a @Label annotation, but the argument is not a String constant value")
+          }
+          (sym.fullName, TermName(label))
+        }
+      }.toMap
+
       tpe.decls.toList collect {
-        case sym: TermSymbol if isCaseAccessorLike(sym) => (sym.name, sym.typeSignatureIn(tpe).finalResultType)
+        case sym: TermSymbol if isCaseAccessorLike(sym) =>
+          (explicitLabels.getOrElse(sym.fullName, sym.name), sym.typeSignatureIn(tpe).finalResultType)
       }
+    }
 
     def reprOf(tpe: Type): Type = {
       val fields = fieldsOf(tpe)

--- a/core/src/main/scala/shapeless/package.scala
+++ b/core/src/main/scala/shapeless/package.scala
@@ -102,4 +102,6 @@ package object shapeless {
   type Everywhere[F <: Poly, T] = Case1[EverywhereAux[F], T]
 
   def everywhere(f: Poly): EverywhereAux[f.type] {} = new EverywhereAux[f.type]
+
+  type Label = LabelName @scala.annotation.meta.field
 }

--- a/core/src/test/scala/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala/shapeless/labelledgeneric.scala
@@ -63,6 +63,11 @@ object LabelledGenericTestsAux {
     lazy val prev = prev0
     lazy val next = next0
   }
+
+  case class ExplicitLabelledClass(@Label("explicit_name") field1: Int, field2: String)
+
+  private val labelName = "labelName"
+  case class InvalidLabelledClass(@Label(labelName) a: Int, b: String)
 }
 
 class LabelledGenericTests {
@@ -283,5 +288,21 @@ class LabelledGenericTests {
     typed[NonCCLazy](fD)
     assertEquals(a, fD.prev)
     assertEquals(c, fD.next)
+  }
+
+  @Test
+  def testExplicitLabelAnnotation {
+    val gen = LabelledGeneric[ExplicitLabelledClass]
+    val a = ExplicitLabelledClass(42, "42")
+    val t = gen.to(a)
+    val record = 'explicit_name ->> 42 :: 'field2 ->> "42" :: HNil
+    val f = gen.from(record)
+    typed[ExplicitLabelledClass](f)
+    assertEquals(t.keys, 'explicit_name.narrow :: 'field2.narrow :: HNil)
+    assertEquals(a, f)
+    assertEquals(t, record)
+
+    illTyped("""LabelledGeneric.materialize[InvalidLabelledClass, Int :: String :: HNil]""")
+    illTyped("""LabelledGeneric[InvalidLabelledClass]""")
   }
 }


### PR DESCRIPTION
LabelledGeneric is so useful.
but sometimes I want to specify the label names explicitly.
for example, when using LabelledGeneric for serialize to Json,
can not change the field names if json keys depends on field names directly.
