### PR TITLE
Allowed Record to be called with no arguments

### DIFF
--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -56,6 +56,7 @@ object record {
    * }}}
    */
   object Record extends Dynamic {
+    def applyDynamic(method: String)(rec: Any*): HList = macro RecordMacros.mkRecordEmptyImpl
     def applyDynamicNamed(method: String)(rec: Any*): HList = macro RecordMacros.mkRecordNamedImpl
 
     def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.recordTypeImpl
@@ -97,6 +98,13 @@ class RecordMacros(val c: whitebox.Context) {
   val fieldTypeTpe = typeOf[FieldType[_, _]].typeConstructor
   val SymTpe = typeOf[scala.Symbol]
   val atatTpe = typeOf[tag.@@[_,_]].typeConstructor
+
+  def mkRecordEmptyImpl(method: Tree)(rec: Tree*): Tree = {
+    if(rec.nonEmpty)
+      c.abort(c.enclosingPosition, "this method must be called with named arguments")
+    
+    q"_root_.shapeless.HNil"
+  }
 
   def mkRecordNamedImpl(method: Tree)(rec: Tree*): Tree = {
     val q"${methodString: String}" = method

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -622,9 +622,25 @@ class RecordTests {
   }
 
   @Test
+  def testNamedArgs {
+    {
+      val r = Record()
+      typed[HNil](r)
+    }
+    
+    {
+      val r = Record(i = 23, s = "foo", b = true)
+      typed[Record.`'i -> Int, 's -> String, 'b -> Boolean`.T](r)
+    }
+
+    {
+      illTyped(""" Record(2, "a") """)
+    }
+  }
+
+  @Test
   def testNamedArgsInject {
     val r = Record(i = 23, s = "foo", b = true)
-    typed[Record.`'i -> Int, 's -> String, 'b -> Boolean`.T](r)
 
     val v1 = r.get('i)
     typed[Int](v1)


### PR DESCRIPTION
Allows the following to compile:
```scala
val r = Record()
```