### PR TITLE
Generic ops, Generic withLabels method

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -34,6 +34,10 @@ object Generic {
   def apply[T](implicit gen: Generic[T]): Aux[T, gen.Repr] = gen
 
   implicit def materialize[T, R]: Aux[T, R] = macro GenericMacros.materialize[T, R]
+
+  import syntax.GenericOps
+
+  implicit def genOps[T, R](gen: Generic.Aux[T, R]): GenericOps[T, R] = new GenericOps(gen)
 }
 
 trait LabelledGeneric[T] extends Generic[T]

--- a/core/src/main/scala/shapeless/ops/generic.scala
+++ b/core/src/main/scala/shapeless/ops/generic.scala
@@ -1,0 +1,56 @@
+package shapeless
+package ops
+
+import labelled._
+
+object generic {  
+  trait WithLabels[Repr, L <: HList] {
+    type Out
+    def to(r: Repr): Out
+    def from(out: Out): Repr
+  }
+
+  object WithLabels {
+    type Aux[Repr, L <: HList, Out0] = WithLabels[Repr, L] { type Out = Out0 }
+
+    def apply[Repr, L <: HList](implicit withLabels: WithLabels[Repr, L]): Aux[Repr, L, withLabels.Out] = withLabels
+
+    implicit val hnilWithLabels: Aux[HNil, HNil, HNil] =
+      new WithLabels[HNil, HNil] {
+        type Out = HNil
+        def to(r: HNil) = HNil
+        def from(out: HNil) = HNil
+      }
+
+    implicit def hconsWithLabels[H, T <: HList, LH <: Symbol, LT <: HList, TL <: HList](implicit
+      tailWithLabels: WithLabels.Aux[T, LT, TL]
+    ): Aux[H :: T, LH :: LT, FieldType[LH, H] :: TL] =
+      new WithLabels[H :: T, LH :: LT] {
+        type Out = FieldType[LH, H] :: TL
+        def to(r: H :: T) = field[LH](r.head) :: tailWithLabels.to(r.tail)
+        def from(out: FieldType[LH, H] :: TL) = out.head :: tailWithLabels.from(out.tail)
+      }
+
+    implicit val cnilWithLabels: Aux[CNil, HNil, CNil] =
+      new WithLabels[CNil, HNil] {
+        type Out = CNil
+        def to(r: CNil) = r
+        def from(out: CNil) = out
+      }
+
+    implicit def cconsWithLabels[H, T <: Coproduct, LH <: Symbol, LT <: HList, TL <: Coproduct](implicit
+      tailWithLabels: WithLabels.Aux[T, LT, TL]
+    ): Aux[H :+: T, LH :: LT, FieldType[LH, H] :+: TL] =
+      new WithLabels[H :+: T, LH :: LT] {
+        type Out = FieldType[LH, H] :+: TL
+        def to(r: H :+: T) = r match {
+          case Inl(h) => Inl(field[LH](h))
+          case Inr(t) => Inr(tailWithLabels.to(t))
+        } 
+        def from(out: FieldType[LH, H] :+: TL) = out match {
+          case Inl(h) => Inl(h)
+          case Inr(t) => Inr(tailWithLabels.from(t))
+        }  
+      }
+  }
+}

--- a/core/src/main/scala/shapeless/syntax/generic.scala
+++ b/core/src/main/scala/shapeless/syntax/generic.scala
@@ -1,0 +1,15 @@
+package shapeless
+package syntax
+
+final class GenericOps[T, R](gen: Generic.Aux[T, R]) {
+  import ops.generic._
+
+  def withLabels[L <: HList](implicit
+    withLabels0: WithLabels[R, L]
+  ): LabelledGeneric.Aux[T, withLabels0.Out] =
+    new LabelledGeneric[T] {
+      type Repr = withLabels0.Out
+      def to(t: T) = withLabels0.to(gen.to(t))
+      def from(r: withLabels0.Out) = gen.from(withLabels0.from(r))
+    }
+}


### PR DESCRIPTION
This PR adds a method to `Generic` (via a `GenericOps` intermediate class).

This method allows to somehow override the labels set by default by `LabelledGeneric`, liked wished in https://github.com/milessabin/shapeless/pull/289, with
```scala
// case class Person(lastName: String, addressLine: String, yearsOld: Int)

implicit val personLabelsOverride = 
  Generic[Person].withLabels[HList.`'last_name, 'address_line, 'years_old`.T]
```