### PR TITLE
prettyString method for records, unions, products

### DIFF
--- a/core/src/main/scala/shapeless/ops/prettystring.scala
+++ b/core/src/main/scala/shapeless/ops/prettystring.scala
@@ -1,0 +1,150 @@
+package shapeless
+package ops
+
+import shapeless.labelled.FieldType
+
+object prettystring {  
+  trait PrettyString[T] {
+    def suggestedName: String
+
+    /**
+     * Prints the elements of `t` in `b`
+     * 
+     * @param sepBefore: if Left, a separator between elements, if Right, a string to prepend before each element  
+     */
+    def addElements(t: T, b: StringBuilder, sepBefore: Either[String, String]): Unit
+
+    def mkString(t: T, prefix: String, sep: String, suffix: String): String = {
+      val b = new StringBuilder      
+      b ++= prefix; addElements(t, b, Left(sep)); b ++= suffix      
+      b.result()
+    }
+    
+    def apply(t: T): String =
+      mkString(t, s"$suggestedName(", ", ", ")")
+  }
+  
+  trait LowPriorityPrettyString {
+    implicit def hconsNonHeadRecursivePrettyString[K <: Symbol, H, T <: HList](implicit
+      key: Witness.Aux[K],
+      tailPrettyPrint: Lazy[PrettyString[T]]
+    ): PrettyString[FieldType[K, H] :: T] =
+      new PrettyString[FieldType[K, H] :: T] {
+        def suggestedName = tailPrettyPrint.value.suggestedName
+        def addElements(r: FieldType[K, H] :: T, b: StringBuilder, sepBefore: Either[String, String]) = {
+          sepBefore match {
+            case Right(before) =>
+              b ++= before
+            case _ =>
+          }
+          
+          b ++= key.value.name
+          b += '='
+          b ++= r.head.toString
+
+          tailPrettyPrint.value.addElements(r.tail, b, Right(sepBefore.merge))
+        }
+      }
+
+    implicit def cconsNonHeadRecursivePrettyString[K <: Symbol, H, T <: Coproduct](implicit
+      key: Witness.Aux[K],
+      tailPrettyPrint: Lazy[PrettyString[T]]
+    ): PrettyString[FieldType[K, H] :+: T] =
+      new PrettyString[FieldType[K, H] :+: T] {
+        def suggestedName = tailPrettyPrint.value.suggestedName
+        def addElements(u: FieldType[K, H] :+: T, b: StringBuilder, sepBefore: Either[String, String]) =
+          u match {
+            case Inl(h) =>
+              sepBefore match {
+                case Right(before) =>
+                  b ++= before
+                case _ =>
+              }
+
+              b ++= key.value.name
+              b += '='
+              b ++= h.toString
+              
+            case Inr(t) =>
+              tailPrettyPrint.value.addElements(t, b, sepBefore)
+          }
+      }
+  }
+  
+  object PrettyString extends LowPriorityPrettyString {
+    def apply[T](implicit prettyString: PrettyString[T]): PrettyString[T] = prettyString
+    
+    implicit def hnilPrettyString[R <: HNil]: PrettyString[R] =
+      new PrettyString[R] {
+        val suggestedName = "Record"
+        def addElements(r: R, b: StringBuilder, sepBefore: Either[String, String]) = {}
+      }
+    
+    implicit def hconsHeadRecursivePrettyString[K <: Symbol, H, T <: HList](implicit
+      key: Witness.Aux[K],
+      headPrettyPrint: Lazy[PrettyString[H]],
+      tailPrettyPrint: Lazy[PrettyString[T]]                                                        
+    ): PrettyString[FieldType[K, H] :: T] =
+      new PrettyString[FieldType[K, H] :: T] {
+        def suggestedName = tailPrettyPrint.value.suggestedName
+        def addElements(r: FieldType[K, H] :: T, b: StringBuilder, sepBefore: Either[String, String]) = {
+          sepBefore match {
+            case Right(before) =>
+              b ++= before
+            case _ =>
+          }
+
+          b ++= key.value.name
+          b += '='
+          b ++= headPrettyPrint.value(r.head)
+          
+          tailPrettyPrint.value.addElements(r.tail, b, Right(sepBefore.merge))
+        }
+      }
+
+    implicit val cnilPrettyString: PrettyString[CNil] =
+      new PrettyString[CNil] {
+        val suggestedName = "Union"
+        def addElements(u: CNil, b: StringBuilder, sepBefore: Either[String, String]) = {}
+      }
+
+    implicit def cconsHeadRecursivePrettyString[K <: Symbol, H, T <: Coproduct](implicit
+      key: Witness.Aux[K],
+      headPrettyPrint: Lazy[PrettyString[H]],
+      tailPrettyPrint: Lazy[PrettyString[T]]
+    ): PrettyString[FieldType[K, H] :+: T] =
+      new PrettyString[FieldType[K, H] :+: T] {
+        def suggestedName = tailPrettyPrint.value.suggestedName
+        def addElements(u: FieldType[K, H] :+: T, b: StringBuilder, sepBefore: Either[String, String]) = 
+          u match {
+            case Inl(h) =>
+              sepBefore match {
+                case Right(before) =>
+                  b ++= before
+                case _ =>
+              }
+
+              b ++= key.value.name
+              b += '='
+              b ++= headPrettyPrint.value(h)
+              
+            case Inr(t) =>
+              tailPrettyPrint.value.addElements(t, b, sepBefore)
+          }
+      }
+    
+    implicit def instancePrettyString[F, G](implicit
+      manifest: Manifest[F],
+      lgen: LabelledGeneric.Aux[F, G],
+      instance: PrettyString[G]                                     
+    ): PrettyString[F] =
+      new PrettyString[F] {
+        val suggestedName = {
+          val s = manifest.toString().takeWhile(_ != '[')
+          s.substring((s.lastIndexOf('.') max s.lastIndexOf('$')) + 1)
+        }
+        def addElements(f: F, b: StringBuilder, sepBefore: Either[String, String]) =
+          instance.addElements(lgen.to(f), b, sepBefore)
+      }
+  }  
+}

--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -28,6 +28,7 @@ import tag.@@
 final class RecordOps[L <: HList](l : L) {
   import shapeless.labelled._
   import ops.record._
+  import ops.prettystring.PrettyString
 
   /**
    * Returns the value associated with the singleton typed key k. Only available if this record has a field with
@@ -114,6 +115,11 @@ final class RecordOps[L <: HList](l : L) {
    * Returns a wrapped version of this record that provides `selectDynamic` access to fields.
    */
   def record: DynamicRecordOps[L] = DynamicRecordOps(l)
+
+  /**
+   * Returns a pretty string representation of this record
+   */
+  def prettyString(implicit prettyString: PrettyString[L]): String = prettyString(l)
 }
 
 /**

--- a/core/src/main/scala/shapeless/syntax/std/products.scala
+++ b/core/src/main/scala/shapeless/syntax/std/products.scala
@@ -24,6 +24,7 @@ object product {
 
 final class ProductOps[P](p: P) {
   import ops.product._
+  import ops.prettystring.PrettyString
 
   /**
    * Returns an `HList` containing the elements of this tuple.
@@ -64,4 +65,9 @@ final class ProductOps[P](p: P) {
    * Returns a sized collection `M` whose elements are typed as the Lub of the elements of this product.
    */
   def toSized[M[_]](implicit toSized: ToSized[P, M]): toSized.Out = toSized(p)
+
+  /**
+   * Returns a pretty string representation of this product
+   */
+  def prettyString(implicit prettyString: PrettyString[P]): String = prettyString(p)
 }

--- a/core/src/main/scala/shapeless/syntax/unions.scala
+++ b/core/src/main/scala/shapeless/syntax/unions.scala
@@ -28,6 +28,7 @@ import tag.@@
 final class UnionOps[C <: Coproduct](c : C) {
   import shapeless.union._
   import ops.union._
+  import ops.prettystring.PrettyString
 
   /**
    * Returns the value associated with the singleton typed key k. Only available if this union has a field with
@@ -70,6 +71,11 @@ final class UnionOps[C <: Coproduct](c : C) {
    * Returns a wrapped version of this union that provides `selectDynamic` access to fields.
    */
   def union: DynamicUnionOps[C] = DynamicUnionOps(c)
+
+  /**
+   * Returns a pretty string representation of this union
+   */
+  def prettyString(implicit prettyString: PrettyString[C]): String = prettyString(c)
 }
 
 /**

--- a/core/src/test/scala/shapeless/product.scala
+++ b/core/src/test/scala/shapeless/product.scala
@@ -1,7 +1,7 @@
 package shapeless
 
 import org.junit.Test
-import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.{ assertEquals, assertArrayEquals }
 import testutil._
 
 import syntax.std.product._
@@ -328,6 +328,24 @@ class ProductTests {
       val expected = Map[Symbol, Any]('i -> 1, 's -> "b")
       equalInferredTypes(expected, m)
       assertTypedEquals(expected, m)
+    }
+  }
+
+  @Test
+  def testPrettyString {
+    {
+      val e = EmptyCC()
+      assertEquals("EmptyCC()", e.prettyString)
+    }
+
+    {
+      val foo = Foo(i=2, s="a")
+      assertEquals("Foo(i=2, s=a)", foo.prettyString)
+    }
+
+    {
+      val bar = Bar(b=true, f=Foo(i=3, s="b"))
+      assertEquals("Bar(b=true, f=Foo(i=3, s=b))", bar.prettyString)
     }
   }
 }

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -753,4 +753,22 @@ class RecordTests {
       assertEquals(2.0, v3, Double.MinPositiveValue)
     }
   }
+
+  @Test
+  def testPrettyString {
+    {
+      val r = HNil // FIXME should be Record()
+      assertEquals("Record()", r.prettyString)
+    }
+
+    {
+      val r = Record(i=2, s="a", b=true)
+      assertEquals("Record(i=2, s=a, b=true)", r.prettyString)
+    }
+
+    {
+      val r = Record(i=2, s="a", r=Record(b=true, s="b"))
+      assertEquals("Record(i=2, s=a, r=Record(b=true, s=b))", r.prettyString)
+    }
+  }
 }

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -307,4 +307,33 @@ class UnionTests {
       assertTypedEquals[U](Coproduct[U]("baz" ->> 2.0), r3)
     }
   }
+
+  @Test
+  def testPrettyString {    
+    {
+      type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
+      val ui = Union[U](i=2)
+      val us = Union[U](s="a")
+      val ub = Union[U](b=true)
+      
+      assertEquals("Union(i=2)", ui.prettyString)
+      assertEquals("Union(s=a)", us.prettyString)
+      assertEquals("Union(b=true)", ub.prettyString)
+    }
+
+    {
+      type U = Union.`'s -> String, 'b -> Boolean`.T
+      type U2 = Union.`'i -> Int, 's -> String, 'u -> U`.T
+
+      val ui = Union[U2](i=2)
+      val us = Union[U2](s="a")
+      val uus = Union[U2](u=Union[U](s="b"))
+      val uub = Union[U2](u=Union[U](b=true))
+
+      assertEquals("Union(i=2)", ui.prettyString)
+      assertEquals("Union(s=a)", us.prettyString)
+      assertEquals("Union(u=Union(s=b))", uus.prettyString)
+      assertEquals("Union(u=Union(b=true))", uub.prettyString)
+    }
+  }
 }


### PR DESCRIPTION
This PR proposes to add a `prettyString` method to records, unions, and products too, so that we can write
```scala
scala> Record(i=2, s="a").prettyString
res0: String = Record(i=2, s=a)
```

```scala
scala> type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
defined type alias U

scala> Union[U](s="a").prettyString
res0: String = Union(s=a)
```
or
```scala
scala> case class Foo(i: Int, s: String)
defined class Foo

scala> Foo(i=2, s="b").prettyString
res0: String = Foo(i=2, s=b)
```