### PR TITLE
More quasiquote hygiene

### DIFF
--- a/core/src/main/scala/shapeless/labelled.scala
+++ b/core/src/main/scala/shapeless/labelled.scala
@@ -103,7 +103,7 @@ class LabelledMacros(val c: whitebox.Context) extends SingletonTypeUtils with Ca
       }
 
     q"""
-      new DefaultSymbolicLabelling[$tTpe] {
+      new _root_.shapeless.DefaultSymbolicLabelling[$tTpe] {
         type Out = $labelsTpe
         def apply(): $labelsTpe = $labelsValue
       }


### PR DESCRIPTION
Should fix https://groups.google.com/forum/#!topic/typelevel/LmgntI3LU8c, I was running into the same problem with `Lazy` uses involving labelling, like in argonaut-shapeless.