### PR TITLE
Add nifty handling of the Option type to csv example

### DIFF
--- a/examples/src/main/scala/shapeless/examples/csv.scala
+++ b/examples/src/main/scala/shapeless/examples/csv.scala
@@ -34,7 +34,7 @@ object CSVExample extends App {
 
   import CSVConverter._
 
-  val input = """John,Carmack,23
+  val input = """John,Carmack,23,0
 Brian,Fargo,35
 Markus,Persson,32"""
 

--- a/examples/src/main/scala/shapeless/examples/csv.scala
+++ b/examples/src/main/scala/shapeless/examples/csv.scala
@@ -28,7 +28,7 @@ import scala.util.{Try,Success,Failure}
  * */
 
 // The class to serialize or deserialize
-case class Person(name: String, surname: String, age: Int)
+case class Person(name: String, surname: String, age: Int, id: Option[Int])
 
 object CSVExample extends App {
 
@@ -118,6 +118,28 @@ object CSVConverter {
           scv.value.to(ft.head) ++ "," ++ sct.value.to(ft.tail)
         }
       }
+
+  implicit def deriveHConsOption[V, T <: HList]
+  (implicit scv: Lazy[CSVConverter[V]], sct: Lazy[CSVConverter[T]])
+  : CSVConverter[Option[V] :: T] =
+    new CSVConverter[Option[V] :: T] {
+
+      def from(s: String): Try[Option[V] :: T] = s.span(_ != ',') match {
+        case (before,after) =>
+          (for {
+            front <- scv.value.from(before)
+            back <- sct.value.from(if (after.isEmpty) after else after.tail)
+          } yield Some(front) :: back).orElse {
+            sct.value.from(s).map(None :: _)
+          }
+
+        case _ => fail("Cannot convert '" ++ s ++ "' to HList")
+      }
+
+      def to(ft: Option[V] :: T): String = {
+        ft.head.map(scv.value.to(_) ++ ",").getOrElse("") ++ sct.value.to(ft.tail)
+      }
+    }
 
 
   // Anything with a Generic


### PR DESCRIPTION
I find this pretty cool that it's possible to do this! And it's a good example of a case where it is necessary to avoid using `LabelledProductTypeClassCompanion`. Should we add it to the example?