### PR TITLE
Include modules in top-level REPL classpath.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -34,11 +34,10 @@ import sbtrelease.Utilities._
 
 object ShapelessBuild extends Build {
 
-  lazy val shapeless = Project(
-    id = "shapeless",
-    base = file("."),
-    aggregate = Seq(shapelessCore, shapelessExamples),
-    settings = commonSettings ++ Seq(
+  lazy val shapeless = (project in file(".")
+    aggregate (core, examples)
+    settings (commonSettings: _*)
+    settings (
       moduleName := "shapeless-root",
 
       (unmanagedSourceDirectories in Compile) := Nil,
@@ -49,11 +48,9 @@ object ShapelessBuild extends Build {
     )
   )
 
-  lazy val shapelessCore =
-    Project(
-      id = "shapeless-core",
-      base = file("core"),
-      settings = commonSettings ++ Publishing.settings ++ osgiSettings ++ buildInfoSettings ++ releaseSettings ++ Seq(
+  lazy val core = (project
+      settings(commonSettings ++ Publishing.settings ++ osgiSettings ++ buildInfoSettings ++ releaseSettings: _*)
+      settings(
         moduleName := "shapeless",
 
         managedSourceDirectories in Test := Nil,
@@ -73,7 +70,7 @@ object ShapelessBuild extends Build {
           },
 
         mappings in (Compile, packageSrc) <++=
-          (mappings in (Compile, packageSrc) in LocalProject("shapeless-examples")),
+          (mappings in (Compile, packageSrc) in LocalProject("examples")),
 
         OsgiKeys.exportPackage := Seq("shapeless.*;version=${Bundle-Version}"),
         OsgiKeys.importPackage := Seq("""scala.*;version="$<range;[==,=+);$<@>>""""),
@@ -105,12 +102,12 @@ object ShapelessBuild extends Build {
       )
     )
 
-  lazy val shapelessScratch = Project(
-    id = "shapeless-scratch",
-    base = file("scratch"),
-    dependencies = Seq(shapelessCore),
+  lazy val scratch = (project
+    dependsOn core
+    settings (commonSettings: _*)
+    settings (
+      moduleName := "shapeless-scratch",
 
-    settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
         // needs compiler for `scala.tools.reflect.Eval`
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
@@ -122,12 +119,12 @@ object ShapelessBuild extends Build {
     )
   )
 
-  lazy val shapelessExamples = Project(
-    id = "shapeless-examples",
-    base = file("examples"),
-    dependencies = Seq(shapelessCore),
+  lazy val examples = (project
+    dependsOn core
+    settings (commonSettings: _*)
+    settings (
+      moduleName := "shapeless-examples",
 
-    settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
         // needs compiler for `scala.tools.reflect.Eval`
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,6 +36,7 @@ object ShapelessBuild extends Build {
 
   lazy val shapeless = (project in file(".")
     aggregate (core, examples)
+    dependsOn (core, examples, scratch)
     settings (commonSettings: _*)
     settings (
       moduleName := "shapeless-root",


### PR DESCRIPTION
Also drops "shapeless-" from the modules, locally (jars retain the prefix).

Fixes #203. Surprisingly easy (solves all 4 points).