### PR TITLE
Limiting file name length to 240 chars.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -176,6 +176,7 @@ object ShapelessBuild extends Build {
         "-language:higherKinds",
         "-language:implicitConversions",
         "-Xfatal-warnings",
+        "-Xmax-classfile-name","240",
         "-deprecation",
         "-unchecked"),
 


### PR DESCRIPTION
Setting file name length limit on generated classes.

Encrypted disks or containers via Docker often has file name length limits that Shapeless often exceeds. 
Docker for instance has a limit of 242 charachters.

This is easily worked around by moving the build to non encrypted partition e.g. /tmp if that is available. 
For full disk encrypted machines and always with Docker that is not an option.

The other option is adding "-Xmax-classfile-name 240" to your project's scalacOption.
But that only solves it for your own generated classes not your dependencies.

If your build uses for instance sbt-assembly, which my Docker build does, then it will extract 
all classes out of your dependencies jars and some may violate the file name length. 
So some individual transitive dependency may also need to be buildt with Xmax-classfile-name, in my case Shapeless :(

This PR sets the "-Xmax-classfile-name" to 240 characters in the scalacOption.

If this is approved, I will create PRs for the same change on the 1.2.4 branches.

Please note I do not know if there are other side effects of setting the physical file name length limit.
