### PR TITLE
Don't rely on macro for the.apply

### DIFF
--- a/core/src/main/scala/shapeless/typeoperators.scala
+++ b/core/src/main/scala/shapeless/typeoperators.scala
@@ -106,14 +106,12 @@ object newtype {
  * }}}
  */
 object the extends Dynamic {
-  def apply[T](implicit t: T): T = macro TheMacros.applyImpl
+  def apply[T <: AnyRef](implicit t: T): t.type = t
 
   def selectDynamic(tpeSelector: String): Any = macro TheMacros.implicitlyImpl
 }
 
 object TheMacros {
-  def applyImpl(c: whitebox.Context)(t: c.Tree): c.Tree = t
-
   def implicitlyImpl(c: whitebox.Context)(tpeSelector: c.Tree): c.Tree = {
     import c.universe.{ Try => _, _ }
     import internal._, decorators._


### PR DESCRIPTION
This seems to work for all of the uses in the tests. Is there a reason a
macro is needed for this?