### PR TITLE
Add unit test for `the` with value classes

### DIFF
--- a/core/src/test/scala/shapeless/typeoperators.scala
+++ b/core/src/test/scala/shapeless/typeoperators.scala
@@ -24,6 +24,7 @@ import org.junit.Assert._
 import newtype._, tag._, test._, testutil._
 
 class TypeOperatorTests {
+  import TypeOperatorTests._
 
   trait ATag
 
@@ -163,4 +164,16 @@ class TypeOperatorTests {
     val blah = the.`package wibble`
     """)
   }
+
+  @Test
+  def testValueClass {
+    implicit val one: AValueClass = AValueClass(1L)
+
+    val x = the[AValueClass]
+    typed[AValueClass](x)
+  }
+}
+
+object TypeOperatorTests {
+  final case class AValueClass(l: Long) extends AnyVal
 }


### PR DESCRIPTION
This unit test wouldn't have compiled with my proposed changes in #341,
which would have alerted me that my changes were a bad idea.