### PR TITLE
fix #280

### DIFF
--- a/core/src/main/scala/shapeless/syntax/coproduct.scala
+++ b/core/src/main/scala/shapeless/syntax/coproduct.scala
@@ -25,7 +25,7 @@ package syntax
  *
  * @author Miles Sabin
  */
-final class CoproductOps[C <: Coproduct](c: C) {
+final class CoproductOps[C <: Coproduct](val c: C) extends AnyVal {
   import ops.coproduct._
 
   /**

--- a/core/src/main/scala/shapeless/syntax/nat.scala
+++ b/core/src/main/scala/shapeless/syntax/nat.scala
@@ -22,7 +22,7 @@ package syntax
  *
  * @author Dale Wijnand
  */
-final class NatOps[N <: Nat](n : Nat) {
+final class NatOps[N <: Nat](val n : Nat) extends AnyVal {
   import ops.nat._
 
   /**

--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -25,7 +25,7 @@ import tag.@@
  * 
  * @author Miles Sabin
  */
-final class RecordOps[L <: HList](l : L) {
+final class RecordOps[L <: HList](val l : L) extends AnyVal {
   import shapeless.labelled._
   import ops.record._
 

--- a/core/src/main/scala/shapeless/syntax/std/products.scala
+++ b/core/src/main/scala/shapeless/syntax/std/products.scala
@@ -22,7 +22,7 @@ object product {
   implicit def productOps[P <: Product](p: P): ProductOps[P] = new ProductOps[P](p)
 }
 
-final class ProductOps[P](p: P) {
+final class ProductOps[P](val p: P) extends AnyVal {
   import ops.product._
 
   /**

--- a/core/src/main/scala/shapeless/syntax/typeable.scala
+++ b/core/src/main/scala/shapeless/syntax/typeable.scala
@@ -21,7 +21,7 @@ object typeable {
   implicit def typeableOps[T](t : T): TypeableOps[T] = new TypeableOps(t)
 }
 
-final class TypeableOps[T](t : T) {
+final class TypeableOps[T](val t : T) extends AnyVal {
   /**
    * Cast the receiver to a value of type `U` if possible. This operation will be as precise wrt erasure as possible
    * given the in-scope `Typeable` instances available.

--- a/core/src/main/scala/shapeless/syntax/unions.scala
+++ b/core/src/main/scala/shapeless/syntax/unions.scala
@@ -25,7 +25,7 @@ import tag.@@
  * 
  * @author Miles Sabin
  */
-final class UnionOps[C <: Coproduct](c : C) {
+final class UnionOps[C <: Coproduct](val c : C) extends AnyVal {
   import shapeless.union._
   import ops.union._
 

--- a/core/src/main/scala/shapeless/syntax/zipper.scala
+++ b/core/src/main/scala/shapeless/syntax/zipper.scala
@@ -27,6 +27,6 @@ class GenericZipperOps[C, CL <: HList](c : C)(implicit gen : Generic.Aux[C, CL])
   def toZipper = Zipper(c)
 }
 
-class HListZipperOps[L <: HList](l : L) {
+class HListZipperOps[L <: HList](val l : L) extends AnyVal {
   def toZipper = Zipper(l)
 }


### PR DESCRIPTION
Since @milessabin said PR's welcome I changed the *Ops* classes to extend `AnyVal`. Furthermore since there are many examples of @non's spire classes extending `AnyVal` such as [Ops](https://github.com/non/spire/blob/master/core/src/main/scala/spire/syntax/std/Ops.scala) and [Literals] (https://github.com/non/spire/blob/master/core/src/main/scala/spire/syntax/Literals.scala), I don't think Erik is totally against value classes. As a final example also Scala's [StringOps](https://github.com/scala/scala/blob/v2.11.6/src/library/scala/collection/immutable/StringOps.scala) extends `AnyVal` so I guess it should not be a problem following this *convention* to avoid boxing.