### PR TITLE
Backport of Generic for overlapping types

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -163,8 +163,16 @@ trait CaseClassMacros extends ReprTypes {
   def productCtorsOf(tpe: Type): List[Symbol] =
     tpe.declarations.toList.filter { x => x.isMethod && x.asMethod.isConstructor }
 
-  def ctorsOf(tpe: Type): List[Type] = ctorsOfAux(tpe, false)
-  def ctorsOf1(tpe: Type): List[Type] = ctorsOfAux(tpe, true)
+  def ctorsOf(tpe: Type): List[Type] = distinctCtorsOfAux(tpe, false)
+  def ctorsOf1(tpe: Type): List[Type] = distinctCtorsOfAux(tpe, true)
+
+  def distinctCtorsOfAux(tpe: Type, hk: Boolean): List[Type] = {
+    def distinct[A](list: List[A])(eq: (A, A) => Boolean): List[A] = list.foldLeft(List.empty[A]) { (acc, x) =>
+      if (!acc.exists(eq(x, _))) x :: acc
+      else acc
+    }.reverse
+    distinct(ctorsOfAux(tpe, hk))(_ =:= _)
+  }
 
   def ctorsOfAux(tpe: Type, hk: Boolean): List[Type] = {
     def collectCtors(classSym: ClassSymbol): List[ClassSymbol] = {

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -114,6 +114,13 @@ package GenericTestsAux {
 
   sealed trait Base[BA, BB]
   case class Swap[SA, SB](a: SA, b: SB) extends Base[SB, SA]
+
+  sealed trait Overlapping
+  sealed trait OA extends Overlapping
+  case class OAC(s: String) extends OA
+  sealed trait OB extends Overlapping
+  case class OBC(s: String) extends OB
+  case class OAB(i: Int) extends OA with OB
 }
 
 class GenericTests {
@@ -263,6 +270,17 @@ class GenericTests {
 
     val s1 = gen.from(s0)
     typed[AbstractSingle](s1)
+  }
+
+  @Test
+  def testOverlappingCoproducts {
+    val gen = Generic[Overlapping]
+    val o: Overlapping = OAB(1)
+    val o0 = gen.to(o)
+    typed[OAB :+: OAC :+: OBC :+: CNil](o0)
+
+    val o1 = gen.from(o0)
+    typed[Overlapping](o1)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/generic1.scala
+++ b/core/src/test/scala/shapeless/generic1.scala
@@ -54,6 +54,16 @@ package Generic1TestsAux {
   case class Leaf[T](t: T) extends Tree[T]
   case class Node[T](l: Tree[T], r: Tree[T]) extends Tree[T]
 
+  sealed trait Overlapping1[+T]
+
+  sealed trait OA1[+T] extends Overlapping1[T]
+  case class OAC1[+T](t: T) extends OA1[T]
+
+  sealed trait OB1[+T] extends Overlapping1[T]
+  case class OBC1[+T](t: T) extends OB1[T]
+
+  case class OAB1[+T](t: T) extends OA1[T] with OB1[T]
+
   trait Functor[F[_]] {
     def map[A, B](fa: F[A])(f: A => B): F[B]
   }
@@ -130,6 +140,17 @@ class Generic1Tests {
     val fr = gen0.fr
     typed[TC2[gen0.R]](fr)
     typed[TC2[({ type λ[t] = t :: List[t] :: HNil })#λ]](fr)
+  }
+
+  @Test
+  def testOverlappingCoproducts1 {
+    val gen = Generic1[Overlapping1, TC1]
+    val o: Overlapping1[Int] = OAB1(1)
+    val o0 = gen.to(o)
+    typed[OAB1[Int] :+: OAC1[Int] :+: OBC1[Int] :+: CNil](o0)
+
+    val s1 = gen.from(o0)
+    typed[Overlapping1[Int]](s1)
   }
 
   @Test


### PR DESCRIPTION
This is backport of #372 for Scala 2.10.x.