### PR TITLE
Made ToTraversable for List serializable

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -529,9 +529,14 @@ object hlist {
    * Type class supporting conversion of this `HList` to a `M` with elements typed
    * as the least upper bound Lub of the types of the elements of this `HList`.
    *
+   * Serializable if the `CanBuildFrom`s it implicitly finds are too.
+   * Note that the `CanBuildFrom`s from the standard library are *not*
+   * serializable. See the tests for how to make your own serializable
+   * `CanBuildFrom` available to `ToTraversable`.
+   *
    * @author Alexandre Archambault
    */
-  trait ToTraversable[L <: HList, M[_]] extends DepFn1[L] {
+  trait ToTraversable[L <: HList, M[_]] extends DepFn1[L] with Serializable {
     type Lub
     def builder(): mutable.Builder[Lub, M[Lub]]
     def append[LLub](l: L, b: mutable.Builder[LLub, M[LLub]], f: Lub => LLub): Unit
@@ -599,9 +604,11 @@ object hlist {
    * Type class supporting conversion of this `HList` to a `Sized[M[Lub], N]` with elements typed
    * as the least upper bound Lub of the types of the elements of this `HList`.
    *
+   * About serializability, see the comment in `ToTraversable`.
+   *
    * @author Alexandre Archambault
    */
-  trait ToSized[L <: HList, M[_]] extends DepFn1[L] {
+  trait ToSized[L <: HList, M[_]] extends DepFn1[L] with Serializable {
     type Lub
     type N <: Nat
     type Out = Sized[M[Lub], N]

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -590,10 +590,10 @@ object hlist {
    * Type aliases and constructors provided for backward compatibility
    **/
   type ToArray[L <: HList, Lub] = ToTraversable.Aux[L, Array, Lub]
-  def ToArray[L <: HList, Lub](l: L)(implicit toArray: ToArray[L, Lub]) = toArray
+  def ToArray[L <: HList, Lub](implicit toArray: ToArray[L, Lub]) = toArray
 
   type ToList[L <: HList, Lub] = ToTraversable.Aux[L, List, Lub]
-  def ToList[L <: HList, Lub](l: L)(implicit toList: ToList[L, Lub]) = toList
+  def ToList[L <: HList, Lub](implicit toList: ToList[L, Lub]) = toList
 
   /**
    * Type class supporting conversion of this `HList` to a `Sized[M[Lub], N]` with elements typed

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -900,12 +900,18 @@ object tuple {
   object ToList {
     type Aux[T, Lub, Out0] = ToList[T, Lub] { type Out = Out0 }
 
-    implicit def toList[T, L <: HList, Lub]
+    def apply[T, Lub](implicit toList: ToList[T, Lub]): Aux[T, Lub, toList.Out] = toList
+
+    implicit def toList[T, Lub]
       (implicit toTraversable: ToTraversable.Aux[T, List, Lub]): Aux[T, Lub, List[Lub]] =
         new ToList[T, Lub] {
           type Out = List[Lub]
           def apply(t: T) = toTraversable(t)
         }
+
+    implicit def toListNothing[T]
+      (implicit toTraversable: ToTraversable.Aux[T, List, Nothing]): Aux[T, Nothing, List[Nothing]] =
+        toList[T, Nothing]
   }
 
   /**
@@ -921,12 +927,18 @@ object tuple {
   object ToArray {
     type Aux[T, Lub, Out0] = ToArray[T, Lub] { type Out = Out0 }
 
-    implicit def toArray[T, L <: HList, Lub]
+    def apply[T, Lub](implicit toArray: ToArray[T, Lub]): Aux[T, Lub, toArray.Out] = toArray
+
+    implicit def toArray[T, Lub]
       (implicit toTraversable: ToTraversable.Aux[T, Array, Lub]): Aux[T, Lub, Array[Lub]] =
         new ToArray[T, Lub] {
           type Out = Array[Lub]
           def apply(t: T) = toTraversable(t)
         }
+
+    implicit def toArrayNothing[T]
+      (implicit toTraversable: ToTraversable.Aux[T, Array, Nothing]): Aux[T, Nothing, Array[Nothing]] =
+        toArray[T, Nothing]
   }
 
   /**

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -862,7 +862,7 @@ object tuple {
    *
    * @author Alexandre Archambault
    */
-  trait ToTraversable[T, M[_]] extends DepFn1[T] {
+  trait ToTraversable[T, M[_]] extends DepFn1[T] with Serializable {
     type Lub
     type Out = M[Lub]
   }
@@ -895,7 +895,7 @@ object tuple {
    *
    * @author Miles Sabin
    */
-  trait ToList[T, Lub] extends DepFn1[T]
+  trait ToList[T, Lub] extends DepFn1[T] with Serializable
 
   object ToList {
     type Aux[T, Lub, Out0] = ToList[T, Lub] { type Out = Out0 }
@@ -947,7 +947,7 @@ object tuple {
    *
    * @author Alexandre Archambault
    */
-  trait ToSized[T, M[_]] extends DepFn1[T]
+  trait ToSized[T, M[_]] extends DepFn1[T] with Serializable
 
   object ToSized {
     def apply[T, M[_]](implicit toSized: ToSized[T, M]): Aux[T, M, toSized.Out] = toSized

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -632,8 +632,8 @@ class HListTests {
     val r1 = HNil.to[List]
     assertTypedEquals[List[Nothing]](Nil, r1)
 
-    implicitly[ToList[HNil, Nothing]]
-    implicitly[ToList[HNil, Int]]
+    ToList[HNil, Nothing]
+    ToList[HNil, Int]
 
     {
       implicitly[ToTraversable.Aux[M[Int] :: HNil, List, M[Int]]]
@@ -856,8 +856,8 @@ class HListTests {
     typed[Array[Nothing]](empty)
     assertArrayEquals2(Array[Nothing](), empty)
 
-    implicitly[ToArray[HNil, Nothing]]
-    implicitly[ToArray[HNil, Int]]
+    ToArray[HNil, Nothing]
+    ToArray[HNil, Int]
 
     {
       val a1 = (mi :: HNil).toArray[M[Int]]

--- a/core/src/test/scala/shapeless/serialization.scala
+++ b/core/src/test/scala/shapeless/serialization.scala
@@ -21,6 +21,8 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
+import scala.collection.generic.CanBuildFrom
+
 import labelled._
 import nat._
 import ops.function._
@@ -214,6 +216,16 @@ object SerializationTestDefns {
       }
     }
   }
+
+  /**
+   * A `CanBuildFrom` for `List` implementing `Serializable`, unlike the one provided by the standard library.
+   */
+  implicit def listSerializableCanBuildFrom[T]: CanBuildFrom[List[T], T, List[T]] =
+    new CanBuildFrom[List[T], T, List[T]] with Serializable {
+      def apply(from: List[T]) = from.genericBuilder[T]
+      def apply() = List.newBuilder[T]
+    }
+
 }
 
 class SerializationTests {
@@ -337,13 +349,15 @@ class SerializationTests {
     assertSerializable(SubtypeUnifier[HNil, Quux])
     assertSerializable(SubtypeUnifier[Q, Quux])
 
-    // Depends on CanBuildFrom
-    //assertSerializable(ToTraversable[HNil, List])
-    //assertSerializable(ToTraversable[L, List])
+    assertSerializable(ToTraversable[HNil, List])
+    assertSerializable(ToTraversable[L, List])
 
-    // Depends on CanBuildFrom
-    //assertSerializable(ToSized[HNil, List])
-    //assertSerializable(ToSized[L, List])
+    assertSerializable(ToList[HNil, Nothing])
+    assertSerializable(ToList[HNil, Int])
+    assertSerializable(ToList[L, Any])
+
+    assertSerializable(ToSized[HNil, List])
+    assertSerializable(ToSized[L, List])
 
     assertSerializable(Tupler[HNil])
     assertSerializable(Tupler[L])
@@ -780,6 +794,16 @@ class SerializationTests {
 
     assertSerializable(Length[Unit])
     assertSerializable(Length[L])
+
+    assertSerializable(ToTraversable[Unit, List])
+    assertSerializable(ToTraversable[L, List])
+
+    assertSerializable(ToList[Unit, Nothing])
+    assertSerializable(ToList[Unit, Int])
+    assertSerializable(ToList[L, Any])
+
+    assertSerializable(ToSized[Unit, List])
+    assertSerializable(ToSized[L, List])
 
     assertSerializable(Collect[Unit, selInt.type])
     assertSerializable(Collect[L, selInt.type])

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -517,6 +517,12 @@ class TupleTests {
 
   @Test
   def testToList {
+    import ops.tuple.ToList
+
+    ToList[Unit, Nothing]
+    ToList[Unit, Int]
+    ToList[APAP, Fruit]
+
     val empty = ().toList
     assertTypedEquals[List[Nothing]](Nil, empty)
 
@@ -642,6 +648,12 @@ class TupleTests {
 
   @Test
   def testToArray {
+    import ops.tuple.ToArray
+
+    ToArray[Unit, Nothing]
+    ToArray[Unit, Int]
+    ToArray[APAP, Fruit]
+
     def assertArrayEquals2[T](arr1 : Array[T], arr2 : Array[T]) =
       assertArrayEquals(arr1.asInstanceOf[Array[Object]], arr2.asInstanceOf[Array[Object]])
 


### PR DESCRIPTION
This PR makes `ToTraversable` / `ToSized` for `List` serializable.

For this, it puts a custom `CanBuildFrom` instance for `List` into scope (under `shapeless.syntax`), which implements `Serializable`, and which is found instead of the one provided by the standard library. The caveat is that this replaces some `CanBuildFrom` from the standard library by some from shapeless, as soon as one imports `shapeless.syntax._`.

Other serializable `CanBuildFrom` like these could be implemented, like in https://github.com/datastax/spark-cassandra-connector/blob/master/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CanBuildFrom.scala