### PR TITLE
Better prepending to HNil

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1497,9 +1497,18 @@ object hlist {
    */
   trait Prepend[P <: HList, S <: HList] extends DepFn2[P, S] with Serializable { type Out <: HList }
 
-  trait LowPriorityPrepend {
+  trait LowestPriorityPrepend {
     type Aux[P <: HList, S <: HList, Out0 <: HList] = Prepend[P, S] { type Out = Out0 }
 
+    implicit def hlistPrepend[PH, PT <: HList, S <: HList]
+     (implicit pt : Prepend[PT, S]): Aux[PH :: PT, S, PH :: pt.Out] =
+      new Prepend[PH :: PT, S] {
+        type Out = PH :: pt.Out
+        def apply(prefix : PH :: PT, suffix : S): Out = prefix.head :: pt(prefix.tail, suffix)
+      }
+  }
+
+  trait LowPriorityPrepend extends LowestPriorityPrepend {
     implicit def hnilPrepend0[P <: HList, S <: HNil]: Aux[P, S, P] =
       new Prepend[P, S] {
         type Out = P
@@ -1515,13 +1524,6 @@ object hlist {
         type Out = S
         def apply(prefix : P, suffix : S): S = suffix
       }
-
-    implicit def hlistPrepend[PH, PT <: HList, S <: HList]
-      (implicit pt : Prepend[PT, S]): Aux[PH :: PT, S, PH :: pt.Out] =
-        new Prepend[PH :: PT, S] {
-          type Out = PH :: pt.Out
-          def apply(prefix : PH :: PT, suffix : S): Out = prefix.head :: pt(prefix.tail, suffix)
-        }
   }
 
   /**

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -387,25 +387,48 @@ class HListTests {
     val pabp = ap reverse_::: bp
     assertTypedEquals[PABP](p :: a :: b :: p :: HNil, pabp)
 
-    // must compile without requiring an implicit Prepend
-    def prependWithHNil[L <: HList](list: L) = HNil ::: list
-    def prependToHNil[L <: HList](list: L) = list ::: HNil
-    val r1 = prependWithHNil(ap)
-    assertTypedEquals[AP](ap, r1)
-    val r2 = prependToHNil(ap)
-    assertTypedEquals[AP](ap, r2)
-    val r3 = HNil ::: HNil
-    assertTypedEquals[HNil](HNil, r3)
+    {
+      // must compile without requiring an implicit Prepend
+      def prependWithHNil[L <: HList](list: L) = HNil ::: list
+      def prependToHNil[L <: HList](list: L) = list ::: HNil
 
-    // must compile without requiring an implicit ReversePrepend
-    def reversePrependWithHNil[L <: HList](list: L) = HNil reverse_::: list
-    def reversePrependToHNil[L <: HList: Reverse](list: L) = list reverse_::: HNil
-    val r4 = reversePrependWithHNil(ap)
-    assertTypedEquals[AP](ap, r4)
-    val r5 = reversePrependToHNil(ap)
-    assertTypedEquals[Pear :: Apple :: HNil](ap.reverse, r5)
-    val r6 = HNil reverse_::: HNil
-    assertTypedEquals[HNil](HNil, r6)
+      val r1 = prependWithHNil(ap)
+      assertTypedSame[AP](ap, r1)
+      val r2 = prependToHNil(ap)
+      assertTypedSame[AP](ap, r2)
+      val r3 = HNil ::: HNil
+      assertTypedSame[HNil](HNil, r3)
+
+      val r4 = prependWithHNil(pabp)
+      assertTypedSame[PABP](pabp, r4)
+      val r5 = prependToHNil(pabp)
+      assertTypedSame[PABP](pabp, r5)
+    }
+
+    {
+      // must also pass with the default implicit
+      val r1 = HNil ::: ap
+      assertTypedSame[AP](ap, r1)
+      val r2 = ap ::: HNil
+      assertTypedSame[AP](ap, r2)
+
+      val r4 = HNil ::: pabp
+      assertTypedSame[PABP](pabp, r4)
+      val r5 = pabp ::: HNil
+      assertTypedSame[PABP](pabp, r5)
+    }
+
+    {
+      // must compile without requiring an implicit ReversePrepend
+      def reversePrependWithHNil[L <: HList](list: L) = HNil reverse_::: list
+      def reversePrependToHNil[L <: HList : Reverse](list: L) = list reverse_::: HNil
+      val r4 = reversePrependWithHNil(ap)
+      assertTypedSame[AP](ap, r4)
+      val r5 = reversePrependToHNil(ap)
+      assertTypedEquals[Pear :: Apple :: HNil](ap.reverse, r5)
+      val r6 = HNil reverse_::: HNil
+      assertTypedSame[HNil](HNil, r6)
+    }
   }
 
   @Test


### PR DESCRIPTION
It now returns directly the prepended HList, instead of rebuilding it recursively.