### PR TITLE
Topic/rotates

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1497,9 +1497,18 @@ object hlist {
    */
   trait Prepend[P <: HList, S <: HList] extends DepFn2[P, S] with Serializable { type Out <: HList }
 
-  trait LowPriorityPrepend {
+  trait LowestPriorityPrepend {
     type Aux[P <: HList, S <: HList, Out0 <: HList] = Prepend[P, S] { type Out = Out0 }
 
+    implicit def hlistPrepend[PH, PT <: HList, S <: HList]
+     (implicit pt : Prepend[PT, S]): Aux[PH :: PT, S, PH :: pt.Out] =
+      new Prepend[PH :: PT, S] {
+        type Out = PH :: pt.Out
+        def apply(prefix : PH :: PT, suffix : S): Out = prefix.head :: pt(prefix.tail, suffix)
+      }
+  }
+
+  trait LowPriorityPrepend extends LowestPriorityPrepend {
     implicit def hnilPrepend0[P <: HList, S <: HNil]: Aux[P, S, P] =
       new Prepend[P, S] {
         type Out = P
@@ -1515,13 +1524,6 @@ object hlist {
         type Out = S
         def apply(prefix : P, suffix : S): S = suffix
       }
-
-    implicit def hlistPrepend[PH, PT <: HList, S <: HList]
-      (implicit pt : Prepend[PT, S]): Aux[PH :: PT, S, PH :: pt.Out] =
-        new Prepend[PH :: PT, S] {
-          type Out = PH :: pt.Out
-          def apply(prefix : PH :: PT, suffix : S): Out = prefix.head :: pt(prefix.tail, suffix)
-        }
   }
 
   /**

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1970,17 +1970,26 @@ object hlist {
   trait RotateLeft[L <: HList, N <: Nat] extends DepFn1[L] with Serializable { type Out <: HList }
 
   object RotateLeft extends LowPriorityRotateLeft {
+    type Aux[L <: HList, N <: Nat, Out0] = RotateLeft[L, N] { type Out = Out0 }
+
     def apply[L <: HList, N <: Nat]
       (implicit rotateLeft: RotateLeft[L, N]): Aux[L, N, rotateLeft.Out] = rotateLeft
 
+    implicit def hnilRotateLeft[L <: HNil, N <: Nat]: RotateLeft.Aux[L, N, L] = new RotateLeft[L, N] {
+      type Out = L
+      def apply(l: L) = l
+    }
+  }
+
+  trait LowPriorityRotateLeft {
     implicit def hlistRotateLeft[
-      L <: HList, N <: Nat, Size <: Nat, NModSize <: Succ[_], Before <: HList, After <: HList
+    L <: HList, N <: Nat, Size <: Nat, NModSize <: Nat, Before <: HList, After <: HList
     ](implicit
       length: Length.Aux[L, Size],
       mod: nat.Mod.Aux[N, Size, NModSize],
       split: Split.Aux[L, NModSize, Before, After],
       prepend: Prepend[After, Before]
-    ): Aux[L, N, prepend.Out] = new RotateLeft[L, N] {
+       ): RotateLeft.Aux[L, N, prepend.Out] = new RotateLeft[L, N] {
       type Out = prepend.Out
 
       def apply(l: L): Out = {
@@ -1988,16 +1997,6 @@ object hlist {
 
         prepend(after, before)
       }
-    }
-  }
-
-  trait LowPriorityRotateLeft {
-    type Aux[L <: HList, N <: Nat, Out0] = RotateLeft[L, N] { type Out = Out0 }
-
-    implicit def noopRotateLeft[L <: HList, N <: Nat]: Aux[L, N, L] = new RotateLeft[L, N] {
-      type Out = L
-
-      def apply(l: L): Out = l
     }
   }
 
@@ -2009,30 +2008,29 @@ object hlist {
   trait RotateRight[L <: HList, N <: Nat] extends DepFn1[L] with Serializable { type Out <: HList }
 
   object RotateRight extends LowPriorityRotateRight {
+    type Aux[L <: HList, N <: Nat, Out0 <: HList] = RotateRight[L, N] { type Out = Out0 }
+
     def apply[L <: HList, N <: Nat]
       (implicit rotateRight: RotateRight[L, N]): Aux[L, N, rotateRight.Out] = rotateRight
 
+    implicit def hnilRotateRight[L <: HNil, N <: Nat]: RotateRight.Aux[L, N, L] = new RotateRight[L, N] {
+      type Out = L
+      def apply(l: L) = l
+    }
+  }
+
+  trait LowPriorityRotateRight {
     implicit def hlistRotateRight[
-      L <: HList, N <: Nat, Size <: Nat, NModSize <: Succ[_], Size_Diff_NModSize <: Nat
+    L <: HList, N <: Nat, Size <: Nat, NModSize <: Nat, Size_Diff_NModSize <: Nat
     ](implicit
       length: Length.Aux[L, Size],
       mod: nat.Mod.Aux[N, Size, NModSize],
       diff: nat.Diff.Aux[Size, NModSize, Size_Diff_NModSize],
       rotateLeft: RotateLeft[L, Size_Diff_NModSize]
-    ): Aux[L, N, rotateLeft.Out] = new RotateRight[L, N] {
+       ): RotateRight.Aux[L, N, rotateLeft.Out] = new RotateRight[L, N] {
       type Out = rotateLeft.Out
 
       def apply(l: L): Out = rotateLeft(l)
-    }
-  }
-
-  trait LowPriorityRotateRight {
-    type Aux[L <: HList, N <: Nat, Out0 <: HList] = RotateRight[L, N] { type Out = Out0 }
-
-    implicit def noopRotateRight[L <: HList, N <: Nat]: Aux[L, N, L] = new RotateRight[L, N] {
-      type Out = L
-
-      def apply(l: L): Out = l
     }
   }
 

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -728,6 +728,55 @@ class CoproductTests {
   }
 
   @Test
+  def testPrepend: Unit = {
+    type S = String; type I = Int; type D = Double; type C = Char
+    val in1 = Coproduct[I :+: CNil](1)
+    val in2 = Coproduct[I :+: S :+: CNil](1)
+    val in3 = Coproduct[I :+: S :+: D :+: CNil](1)
+    val in4 = Coproduct[I :+: S :+: D :+: C :+: CNil](1)
+
+    {
+      // Prepending CNil - checking for same-ness, not only equality
+      val r1 = Prepend[CNil, I :+: CNil].apply(Right(in1))
+      assertTypedSame(in1, r1)
+      val r2 = Prepend[CNil, I :+: S :+: CNil].apply(Right(in2))
+      assertTypedSame(in2, r2)
+      val r3 = Prepend[CNil, I :+: S :+: D :+: CNil].apply(Right(in3))
+      assertTypedSame(in3, r3)
+      val r4 = Prepend[CNil, I :+: S :+: D :+: C :+: CNil].apply(Right(in4))
+      assertTypedSame(in4, r4)
+    }
+
+    {
+      // Appending CNil - checking for same-ness, not only equality
+      val r1 = Prepend[I :+: CNil, CNil].apply(Left(in1))
+      assertTypedSame(in1, r1)
+      val r2 = Prepend[I :+: S :+: CNil, CNil].apply(Left(in2))
+      assertTypedSame(in2, r2)
+      val r3 = Prepend[I :+: S :+: D :+: CNil, CNil].apply(Left(in3))
+      assertTypedSame(in3, r3)
+      val r4 = Prepend[I :+: S :+: D :+: C :+: CNil, CNil].apply(Left(in4))
+      assertTypedSame(in4, r4)
+    }
+
+    {
+      val r11_1 = Prepend[I :+: CNil, I :+: CNil].apply(Left(in1))
+      assertTypedEquals(Inl(1), r11_1)
+      val r11_2 = Prepend[I :+: CNil, I :+: CNil].apply(Right(in1))
+      assertTypedEquals(Inr(Inl(1)), r11_2)
+      val r12_1 = Prepend[I :+: CNil, I :+: S :+: CNil].apply(Left(in1))
+      assertTypedEquals(Inl(1), r12_1)
+      val r12_2 = Prepend[I :+: CNil, I :+: S :+: CNil].apply(Right(in2))
+      assertTypedEquals(Inr(Inl(1)), r12_2)
+
+      val r34_3 = Prepend[I :+: S :+: D :+: CNil, I :+: S :+: D :+: C :+: CNil].apply(Left(in3))
+      assertTypedEquals(Inl(1), r34_3)
+      val r34_4 = Prepend[I :+: S :+: D :+: CNil, I :+: S :+: D :+: C :+: CNil].apply(Right(in4))
+      assertTypedEquals(Inr(Inr(Inr(Inl(1)))), r34_4)
+    }
+  }
+
+  @Test
   def testAlign {
     type K0 = Int :+: String :+: Boolean :+: CNil
     type K1 = Int :+: Boolean :+: String :+: CNil

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -585,6 +585,38 @@ class CoproductTests {
       val r7 = in4.rotateLeft[_6]
       assertTypedEquals[D :+: C :+: I :+: S :+: CNil](Coproduct[D :+: C :+: I :+: S :+: CNil](1), r7)
     }
+
+    {
+      type C1 = Int :+: Boolean :+: String :+: Int :+: CNil
+      type C2 = Boolean :+: String :+: Int :+: Int :+: CNil
+      type C3 = String :+: Int :+: Int :+: Boolean :+: CNil
+      type C4 = Int :+: Int :+: Boolean :+: String :+: CNil
+
+      val i1: C1 = Inl(1)
+      val i2: C2 = Inr(Inr(Inr(Inl(1))))
+      val i3: C3 = Inr(Inr(Inl(1)))
+      val i4: C4 = Inr(Inl(1))
+
+      assertTypedEquals(i1, i1.rotateLeft(0))
+      assertTypedEquals(i2, i1.rotateLeft(1))
+      assertTypedEquals(i3, i1.rotateLeft(2))
+      assertTypedEquals(i4, i1.rotateLeft(3))
+
+      assertTypedEquals(i2, i2.rotateLeft(0))
+      assertTypedEquals(i3, i2.rotateLeft(1))
+      assertTypedEquals(i4, i2.rotateLeft(2))
+      assertTypedEquals(i1, i2.rotateLeft(3))
+
+      assertTypedEquals(i3, i3.rotateLeft(0))
+      assertTypedEquals(i4, i3.rotateLeft(1))
+      assertTypedEquals(i1, i3.rotateLeft(2))
+      assertTypedEquals(i2, i3.rotateLeft(3))
+
+      assertTypedEquals(i4, i4.rotateLeft(0))
+      assertTypedEquals(i1, i4.rotateLeft(1))
+      assertTypedEquals(i2, i4.rotateLeft(2))
+      assertTypedEquals(i3, i4.rotateLeft(3))
+    }
   }
 
   @Test
@@ -700,6 +732,38 @@ class CoproductTests {
 
       val r7 = in4.rotateRight[_6]
       assertTypedEquals[D :+: C :+: I :+: S :+: CNil](Coproduct[D :+: C :+: I :+: S :+: CNil](1), r7)
+    }
+
+    {
+      type C1 = Int :+: Boolean :+: String :+: Int :+: CNil
+      type C2 = Int :+: Int :+: Boolean :+: String :+: CNil
+      type C3 = String :+: Int :+: Int :+: Boolean :+: CNil
+      type C4 = Boolean :+: String :+: Int :+: Int :+: CNil
+
+      val i1: C1 = Inl(1)
+      val i2: C2 = Inr(Inl(1))
+      val i3: C3 = Inr(Inr(Inl(1)))
+      val i4: C4 = Inr(Inr(Inr(Inl(1))))
+
+      assertTypedEquals(i1, i1.rotateRight(0))
+      assertTypedEquals(i2, i1.rotateRight(1))
+      assertTypedEquals(i3, i1.rotateRight(2))
+      assertTypedEquals(i4, i1.rotateRight(3))
+
+      assertTypedEquals(i2, i2.rotateRight(0))
+      assertTypedEquals(i3, i2.rotateRight(1))
+      assertTypedEquals(i4, i2.rotateRight(2))
+      assertTypedEquals(i1, i2.rotateRight(3))
+
+      assertTypedEquals(i3, i3.rotateRight(0))
+      assertTypedEquals(i4, i3.rotateRight(1))
+      assertTypedEquals(i1, i3.rotateRight(2))
+      assertTypedEquals(i2, i3.rotateRight(3))
+
+      assertTypedEquals(i4, i4.rotateRight(0))
+      assertTypedEquals(i1, i4.rotateRight(1))
+      assertTypedEquals(i2, i4.rotateRight(2))
+      assertTypedEquals(i3, i4.rotateRight(3))
     }
   }
 

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -387,25 +387,48 @@ class HListTests {
     val pabp = ap reverse_::: bp
     assertTypedEquals[PABP](p :: a :: b :: p :: HNil, pabp)
 
-    // must compile without requiring an implicit Prepend
-    def prependWithHNil[L <: HList](list: L) = HNil ::: list
-    def prependToHNil[L <: HList](list: L) = list ::: HNil
-    val r1 = prependWithHNil(ap)
-    assertTypedEquals[AP](ap, r1)
-    val r2 = prependToHNil(ap)
-    assertTypedEquals[AP](ap, r2)
-    val r3 = HNil ::: HNil
-    assertTypedEquals[HNil](HNil, r3)
+    {
+      // must compile without requiring an implicit Prepend
+      def prependWithHNil[L <: HList](list: L) = HNil ::: list
+      def prependToHNil[L <: HList](list: L) = list ::: HNil
 
-    // must compile without requiring an implicit ReversePrepend
-    def reversePrependWithHNil[L <: HList](list: L) = HNil reverse_::: list
-    def reversePrependToHNil[L <: HList: Reverse](list: L) = list reverse_::: HNil
-    val r4 = reversePrependWithHNil(ap)
-    assertTypedEquals[AP](ap, r4)
-    val r5 = reversePrependToHNil(ap)
-    assertTypedEquals[Pear :: Apple :: HNil](ap.reverse, r5)
-    val r6 = HNil reverse_::: HNil
-    assertTypedEquals[HNil](HNil, r6)
+      val r1 = prependWithHNil(ap)
+      assertTypedSame[AP](ap, r1)
+      val r2 = prependToHNil(ap)
+      assertTypedSame[AP](ap, r2)
+      val r3 = HNil ::: HNil
+      assertTypedSame[HNil](HNil, r3)
+
+      val r4 = prependWithHNil(pabp)
+      assertTypedSame[PABP](pabp, r4)
+      val r5 = prependToHNil(pabp)
+      assertTypedSame[PABP](pabp, r5)
+    }
+
+    {
+      // must also pass with the default implicit
+      val r1 = HNil ::: ap
+      assertTypedSame[AP](ap, r1)
+      val r2 = ap ::: HNil
+      assertTypedSame[AP](ap, r2)
+
+      val r4 = HNil ::: pabp
+      assertTypedSame[PABP](pabp, r4)
+      val r5 = pabp ::: HNil
+      assertTypedSame[PABP](pabp, r5)
+    }
+
+    {
+      // must compile without requiring an implicit ReversePrepend
+      def reversePrependWithHNil[L <: HList](list: L) = HNil reverse_::: list
+      def reversePrependToHNil[L <: HList : Reverse](list: L) = list reverse_::: HNil
+      val r4 = reversePrependWithHNil(ap)
+      assertTypedSame[AP](ap, r4)
+      val r5 = reversePrependToHNil(ap)
+      assertTypedEquals[Pear :: Apple :: HNil](ap.reverse, r5)
+      val r6 = HNil reverse_::: HNil
+      assertTypedSame[HNil](HNil, r6)
+    }
   }
 
   @Test


### PR DESCRIPTION
This PR makes the implementation of `RotateLeft` / `RotateRight` for coproducts a simple transposition of the one for HLists.

It also makes the one of HLists safer, with no case that can return a plain wrong type class (the `noop`* ones could be called with any hlist and any nat).

The added tests for coproduct rotates were suggested by @alexknvl 