### PR TITLE
2.2.0 / 2.2.1 binary compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ script:
           "${TRAVIS_BRANCH}" == "scalajs-2.11.x" || "${TRAVIS_BRANCH}" == "scalajs-2.10.x") &&
          $(cat version.sbt) =~ "-SNAPSHOT"
     ]]; then
-      sbt ++${TRAVIS_SCALA_VERSION} test publish ;
+      sbt ++${TRAVIS_SCALA_VERSION} test mima-report-binary-issues publish ;
     else
-      sbt ++${TRAVIS_SCALA_VERSION} test ;
+      sbt ++${TRAVIS_SCALA_VERSION} test mima-report-binary-issues ;
     fi
 
 env:

--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -562,6 +562,44 @@ object coproduct {
       type Out = CNil
       def apply(c: CNil) = c
     }
+
+    /** Binary compatibility stub */
+    def implToRotateLeft[C <: Coproduct, N <: Nat, Size <: Nat, NModSize <: Succ[_]](implicit
+      length: Length.Aux[C, Size],
+      mod: nat.Mod.Aux[N, Size, NModSize],
+      impl: Impl[C, NModSize]
+    ): Aux[C, N, impl.Out] =
+      new RotateLeft[C, N] {
+        type Out = impl.Out
+        def apply(c: C): Out = impl(c)
+      }
+
+    /** Binary compatibility stub */
+    trait Impl[C <: Coproduct, N <: Nat] extends DepFn1[C] with Serializable { type Out <: Coproduct }
+
+    /** Binary compatibility stub */
+    object Impl {
+      type Aux[C <: Coproduct, N <: Nat, Out0 <: Coproduct] = Impl[C, N] { type Out = Out0 }
+
+      def rotateCoproductOne[H, T <: Coproduct, TH <: Coproduct]
+        (implicit extendRight: ExtendRight.Aux[T, H, TH], inject: Inject[TH, H]): Aux[H :+: T, Nat._1, TH] =
+          new Impl[H :+: T, Nat._1] {
+            type Out = TH
+
+            def apply(c: H :+: T): Out = c match {
+              case Inl(a)    => inject(a)
+              case Inr(tail) => extendRight(tail)
+            }
+          }
+
+      def rotateCoproductN[C <: Coproduct, N <: Nat, CN <: Coproduct, CSN <: Coproduct]
+        (implicit rotateN: Aux[C, N, CN], rotate1: Aux[CN, Nat._1, CSN]): Aux[C, Succ[N], CSN] =
+          new Impl[C, Succ[N]] {
+            type Out = CSN
+
+            def apply(c: C): Out = rotate1(rotateN(c))
+          }
+    }
   }
 
   trait LowPriorityRotateLeft {
@@ -581,6 +619,12 @@ object coproduct {
         prepend(e.swap)
       }
     }
+
+    /** Binary compatibility stub */
+    def noopRotateLeftImpl[C <: Coproduct, N <: Nat]: RotateLeft.Aux[C, N, C] = new RotateLeft[C, N] {
+      type Out = C
+      def apply(c: C): Out = c
+    }
   }
 
   /**
@@ -592,8 +636,6 @@ object coproduct {
   trait RotateRight[C <: Coproduct, N <: Nat] extends DepFn1[C] with Serializable { type Out <: Coproduct }
 
   object RotateRight extends LowPriorityRotateRight {
-    type Aux[C <: Coproduct, N <: Nat, Out0 <: Coproduct] = RotateRight[C, N] { type Out = Out0 }
-
     def apply[C <: Coproduct, N <: Nat]
      (implicit rotateRight: RotateRight[C, N]): Aux[C, N, rotateRight.Out] = rotateRight
 
@@ -601,9 +643,24 @@ object coproduct {
       type Out = CNil
       def apply(c: CNil) = c
     }
+
+    /** Binary compatibility stub */
+    def hlistRotateRight[
+      C <: Coproduct, N <: Nat, Size <: Nat, NModSize <: Succ[_], Size_Diff_NModSize <: Nat
+    ](implicit
+      length: Length.Aux[C, Size],
+      mod: nat.Mod.Aux[N, Size, NModSize],
+      diff: nat.Diff.Aux[Size, NModSize, Size_Diff_NModSize],
+      rotateLeft: RotateLeft.Impl[C, Size_Diff_NModSize]
+    ): Aux[C, N, rotateLeft.Out] = new RotateRight[C, N] {
+      type Out = rotateLeft.Out
+      def apply(c: C): Out = rotateLeft(c)
+    }
   }
 
   trait LowPriorityRotateRight {
+    type Aux[C <: Coproduct, N <: Nat, Out0 <: Coproduct] = RotateRight[C, N] { type Out = Out0 }
+
     implicit def coproductRotateRight[
      C <: Coproduct, N <: Nat, Size <: Nat, NModSize <: Nat, Size_Diff_NModSize <: Nat
     ](implicit
@@ -615,6 +672,12 @@ object coproduct {
       type Out = rotateLeft.Out
 
       def apply(c: C): Out = rotateLeft(c)
+    }
+
+    /** Binary compatibility stub */
+    def noopRotateRight[C <: Coproduct, N <: Nat]: Aux[C, N, C] = new RotateRight[C, N] {
+      type Out = C
+      def apply(c: C): Out = c
     }
   }
 
@@ -799,6 +862,22 @@ object coproduct {
             case Right(Inr(t)) => Right(t)
           })
         }
+    }
+
+    /** Binary compatibility stub */
+    val reverseCNil: Aux[CNil, CNil] = reverse[CNil, CNil]
+
+    /** Binary compatibility stub */
+    def reverseCoproduct[H, T <: Coproduct, ReverseT <: Coproduct, RotateL_HReverseT <: Coproduct](implicit
+      reverse: Aux[T, ReverseT],
+      rotateLeft: RotateLeft.Aux[H :+: ReverseT, Nat._1, RotateL_HReverseT],
+      inject: Inject[RotateL_HReverseT, H]
+    ): Aux[H :+: T, RotateL_HReverseT] = new Reverse[H :+: T] {
+      type Out = RotateL_HReverseT
+      def apply(c: H :+: T): Out = c match {
+        case Inl(h) => inject(h)
+        case Inr(t) => rotateLeft(Inr[H, ReverseT](reverse(t)))
+      }
     }
   }
 

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1501,7 +1501,7 @@ object hlist {
     type Aux[P <: HList, S <: HList, Out0 <: HList] = Prepend[P, S] { type Out = Out0 }
 
     implicit def hlistPrepend[PH, PT <: HList, S <: HList]
-     (implicit pt : Prepend[PT, S]): Aux[PH :: PT, S, PH :: pt.Out] =
+     (implicit pt : Prepend[PT, S]): Prepend.Aux[PH :: PT, S, PH :: pt.Out] =
       new Prepend[PH :: PT, S] {
         type Out = PH :: pt.Out
         def apply(prefix : PH :: PT, suffix : S): Out = prefix.head :: pt(prefix.tail, suffix)
@@ -1509,6 +1509,12 @@ object hlist {
   }
 
   trait LowPriorityPrepend extends LowestPriorityPrepend {
+    /**
+     * Binary compatibility stub
+     * This one is for https://github.com/milessabin/shapeless/issues/406
+     */
+    override type Aux[P <: HList, S <: HList, Out0 <: HList] = Prepend[P, S] { type Out = Out0 }
+
     implicit def hnilPrepend0[P <: HList, S <: HNil]: Aux[P, S, P] =
       new Prepend[P, S] {
         type Out = P
@@ -1970,8 +1976,6 @@ object hlist {
   trait RotateLeft[L <: HList, N <: Nat] extends DepFn1[L] with Serializable { type Out <: HList }
 
   object RotateLeft extends LowPriorityRotateLeft {
-    type Aux[L <: HList, N <: Nat, Out0] = RotateLeft[L, N] { type Out = Out0 }
-
     def apply[L <: HList, N <: Nat]
       (implicit rotateLeft: RotateLeft[L, N]): Aux[L, N, rotateLeft.Out] = rotateLeft
 
@@ -1982,6 +1986,8 @@ object hlist {
   }
 
   trait LowPriorityRotateLeft {
+    type Aux[L <: HList, N <: Nat, Out0] = RotateLeft[L, N] { type Out = Out0 }
+
     implicit def hlistRotateLeft[
     L <: HList, N <: Nat, Size <: Nat, NModSize <: Nat, Before <: HList, After <: HList
     ](implicit
@@ -1998,6 +2004,12 @@ object hlist {
         prepend(after, before)
       }
     }
+
+    /** Binary compatibility stub */
+    def noopRotateLeft[L <: HList, N <: Nat]: Aux[L, N, L] = new RotateLeft[L, N] {
+      type Out = L
+      def apply(l: L): Out = l
+    }
   }
 
   /**
@@ -2008,8 +2020,6 @@ object hlist {
   trait RotateRight[L <: HList, N <: Nat] extends DepFn1[L] with Serializable { type Out <: HList }
 
   object RotateRight extends LowPriorityRotateRight {
-    type Aux[L <: HList, N <: Nat, Out0 <: HList] = RotateRight[L, N] { type Out = Out0 }
-
     def apply[L <: HList, N <: Nat]
       (implicit rotateRight: RotateRight[L, N]): Aux[L, N, rotateRight.Out] = rotateRight
 
@@ -2020,6 +2030,8 @@ object hlist {
   }
 
   trait LowPriorityRotateRight {
+    type Aux[L <: HList, N <: Nat, Out0 <: HList] = RotateRight[L, N] { type Out = Out0 }
+
     implicit def hlistRotateRight[
     L <: HList, N <: Nat, Size <: Nat, NModSize <: Nat, Size_Diff_NModSize <: Nat
     ](implicit
@@ -2031,6 +2043,11 @@ object hlist {
       type Out = rotateLeft.Out
 
       def apply(l: L): Out = rotateLeft(l)
+    }
+
+    def noopRotateRight[L <: HList, N <: Nat]: Aux[L, N, L] = new RotateRight[L, N] {
+      type Out = L
+      def apply(l: L): Out = l
     }
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")


### PR DESCRIPTION
This PR fixes (possibly not all?) the backward compatibility issues of 2.2.1, and adds the sbt-mima plugin (https://github.com/typesafehub/migration-manager), to check that no changes that break backward compatibility are introduced.

sbt-mima does not seem to cover all the compatibility issues, in particular the one of https://github.com/milessabin/shapeless/issues/406 (type definition that was moved) would have gone undetected apparently. https://github.com/milessabin/shapeless/issues/406 is fixed anyway.