### PR TITLE
Fix Remove and add reinsert and reinsertAll methods

### DIFF
--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -169,6 +169,24 @@ final class HListOps[L <: HList](l : L) extends Serializable {
   def removeAll[SL <: HList](implicit removeAll : RemoveAll[L, SL]): removeAll.Out = removeAll(l)
 
   /**
+   * Reinserts an element `U` into this `HList` to return another `HList` `O`.
+   */
+  def reinsert[O <: HList] = new ReinsertAux[O]
+
+  class ReinsertAux[O <: HList] {
+    def apply[U](u: U)(implicit remove: Remove.Aux[O, U, (U, L)]): O = remove.reinsert((u, l))
+  }
+
+  /**
+   * Reinserts the elements of `SL` into this `HList` to return another `HList` `O`.
+   */
+  def reinsertAll[O <: HList] = new ReinsertAllAux[O]
+
+  class ReinsertAllAux[O <: HList] {
+    def apply[SL <: HList](sl: SL)(implicit removeAll: RemoveAll.Aux[O, SL, (SL, L)]): O = removeAll.reinsert((sl, l))
+  }
+
+  /**
    * Replaces the first element of type `U` of this `HList` with the supplied value, also of type `U` returning both
    * the replaced element and the updated `HList`. Available only if there is evidence that this `HList` has an element
    * of type `U`.

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1810,6 +1810,10 @@ class HListTests {
 
     val ls = l.removeElem[String]
     assertTypedEquals[(String, Int :: Boolean :: HNil)](("foo", 1 :: true :: HNil), ls)
+
+    val withDuplicates = 1 :: 'a' :: 'b' :: HNil
+    val remover = implicitly[Remove.Aux[Int :: Char :: Char :: HNil, Char, (Char, Int :: Char :: HNil)]]
+    assertTypedEquals[(Char, Int :: Char :: HNil)](('a', 1 :: 'b' :: HNil), remover(withDuplicates))
   }
 
   @Test
@@ -1827,6 +1831,41 @@ class HListTests {
 
     val lbi = l.removeAll[Boolean :: Int :: HNil]
     assertTypedEquals[(Boolean :: Int :: HNil, String :: HNil)]((true :: 1 :: HNil, "foo" :: HNil), lbi)
+  }
+
+  @Test
+  def testReinsert {
+    type L = Int :: Boolean :: String :: HNil
+
+    val l: L = 1 :: true :: "foo" :: HNil
+
+    val (i, li) = l.removeElem[Int]
+    assertTypedEquals[L](li.reinsert[L](i), l)
+
+    val (b, lb) = l.removeElem[Boolean]
+    assertTypedEquals[L](lb.reinsert[L](b), l)
+
+    val (s, ls) = l.removeElem[String]
+    assertTypedEquals[L](ls.reinsert[L](s), l)
+  }
+
+  @Test
+  def testReinsertAll {
+    type L = Int :: Boolean :: String :: HNil
+
+    val l = 1 :: true :: "foo" :: HNil
+
+    val (nil, lnil) = l.removeAll[HNil]
+    assertTypedEquals[L](lnil.reinsertAll[L](nil), l)
+
+    val (i, li) = l.removeAll[Int :: HNil]
+    assertTypedEquals[L](li.reinsertAll[L](i), l)
+
+    val (b, lb) = l.removeAll[Boolean :: HNil]
+    assertTypedEquals[L](lb.reinsertAll[L](b), l)
+
+    val (bi, lbi) = l.removeAll[Boolean :: Int :: HNil]
+    assertTypedEquals[L](lbi.reinsertAll[L](bi), l)
   }
 
   object combine extends Poly {


### PR DESCRIPTION
This fixes two small bugs (or at least inconsistencies and annoyances) in `Remove` and adds new `reinsert` operations that "undo" `removeElem` and `removeAll`.

The first bug is just in the error message for `Remove` when the requested type to remove appears more than once:

```scala
scala> Remove[String :: Int :: Int :: HNil, Int]
<console>:15: error: Implicit not found: shapeless.Ops.Remove[shapeless.::[String,shapeless.::[Int,shapeless.::[Int,shapeless.HNil]]], Int]. You requested to remove an element of type Int, but there is none in the HList shapeless.::[String,shapeless.::[Int,shapeless.::[Int,shapeless.HNil]]].
              Remove[String :: Int :: Int :: HNil, Int]
                    ^
```

There definitely is "an element of type Int" in the list.

The second bug is an inconsistency. This compiles:

```scala
implicitly[Remove.Aux[Int :: String :: Int :: HNil, Int, (Int, String :: Int :: HNil)]]
```

But this does not:

```scala
implicitly[Remove.Aux[String :: Int :: Int :: HNil, Int, (Int, String :: Int :: HNil)]]
```

And there's no good grounds for distinguishing between the two. Moving `recurse` into a lower-priority trait fixes the issue. I've also added a test case for the version that previously didn't compile.

Finally I've added `reinsert` methods to `Remove` and `RemoveAll` that make it possible to put an item (or items) back in the removed places. This is needed for e.g. deriving "partial" type class instances for case classes (such as `DecodeJson[Id => User]` where `User` has a `Id` field).