### PR TITLE
Add Priority, and Implicit type class

### DIFF
--- a/core/src/main/scala/shapeless/implicit.scala
+++ b/core/src/main/scala/shapeless/implicit.scala
@@ -1,0 +1,63 @@
+package shapeless
+
+/**
+ * Represent a `T` made of implicits.
+ *
+ * E.g. Looking for an implicit `Implicit[A :: B :: HNil]` will
+ * trigger implicit lookups for `A` and `B`, and return these
+ * wrapped in an `Implicit[A :: B :: HNil]`.
+ *
+ * Looking for an implicit `Implicit[A :+: B :+: CNil]` will
+ * trigger first an implicit lookup for a `A`. If it fails,
+ * an implicit `B` will be looked up. The result of these lookup
+ * will be wrapped in an `Implicit[A :+: B :+: CNil]`, whose
+ * value will be either a `A` (if an implicit `A` was found),
+ * or a `B` (if no implicit `A` was found, but an implicit `B` was).
+ *
+ * `T` can also be a product or an ADT. Its generic counterpart will
+ * looked upon as described above, then converted to a `T`.
+ */
+trait Implicit[T] {
+  def value: T
+}
+
+trait LowPriorityImplicit {
+  implicit def cconsImplicitTail[H, T <: Coproduct]
+   (implicit
+     t: Lazy[Implicit[T]]
+   ): Implicit[H :+: T] =
+    Implicit.of[H :+: T](Inr(t.value.value))
+}
+
+object Implicit extends LowPriorityImplicit {
+  def apply[T](implicit impl: Implicit[T]): Implicit[T] = impl
+
+  def of[T](t: => T): Implicit[T] =
+    new Implicit[T] {
+      def value = t
+    }
+
+  implicit val hnilImplicit: Implicit[HNil] =
+    Implicit.of[HNil](HNil)
+
+  implicit def hconsImplicit[H, T <: HList]
+   (implicit
+     h: Lazy[H],
+     t: Lazy[Implicit[T]]
+   ): Implicit[H :: T] =
+    Implicit.of[H :: T](h.value :: t.value.value)
+
+  implicit def cconsImplicitHead[H, T <: Coproduct]
+   (implicit
+     h: Lazy[H]
+   ): Implicit[H :+: T] =
+    Implicit.of[H :+: T](Inl(h.value))
+
+  implicit def genericImplicit[F, G]
+   (implicit
+     gen: Generic.Aux[F, G],
+     impl: Lazy[Implicit[G]]
+   ): Implicit[F] =
+    Implicit.of[F](gen.from(impl.value.value))
+}
+

--- a/core/src/test/scala/shapeless/lazypriority.scala
+++ b/core/src/test/scala/shapeless/lazypriority.scala
@@ -1,0 +1,140 @@
+package shapeless
+
+import org.junit.Test
+
+class LazyPriorityTests {
+
+  case class CC1(i: Int)
+  case class CC2(i: Int)
+
+  sealed trait Tree0
+  object Tree0 {
+    case class Node(left: Tree0, right: Tree0, v: Int) extends Tree0
+    case object Leaf extends Tree0
+  }
+
+  sealed trait Tree
+  object Tree {
+    case class Node(left: Tree, right: Tree, v: Int) extends Tree
+    case object Leaf extends Tree
+
+    // Not always found if put in Leaf
+    implicit val tc: Definitions.TC[Leaf.type] = Definitions.TC.of[Leaf.type](_ => "Leaf")
+  }
+
+  object Definitions {
+    trait TC[T] {
+      def msg(n: Int): String
+    }
+
+    object TC {
+      def apply[T](implicit tc: TC[T]): TC[T] = tc
+
+      def of[T](msg0: Int => String): TC[T] =
+        new TC[T] {
+          def msg(n: Int) = if (n >= 0) msg0(n) else "…"
+        }
+
+      implicit val intTC: TC[Int] = of[Int](_ => "Int")
+      implicit val booleanTC: TC[Boolean] = of[Boolean](_ => "Boolean")
+      implicit def optionTC[T: TC]: TC[Option[T]] = of[Option[T]](n => s"Option[${TC[T].msg(n-1)}]")
+      implicit def tuple2TC[A: TC, B: TC]: TC[(A, B)] = of[(A, B)](n => s"(${TC[A].msg(n-1)}, ${TC[B].msg(n-1)})")
+      implicit val cc1: TC[CC1] = of[CC1](_ => "CC1")
+    }
+  }
+
+  object Deriver {
+    import Definitions._
+
+    trait MkTC[T] {
+      def tc: TC[T]
+    }
+
+    object MkTC {
+      implicit def hnilMkTC: MkTC[HNil] =
+        new MkTC[HNil] {
+          val tc = TC.of[HNil](_ => "HNil")
+        }
+      implicit def hconsTC[H, T <: HList]
+       (implicit
+         head: Lazy[TC[H]],
+         tail: Lazy[MkTC[T]]
+       ): MkTC[H :: T] =
+        new MkTC[H :: T] {
+          lazy val tc = TC.of[H :: T](n => s"${head.value.msg(n-1)} :: ${tail.value.tc.msg(n-1)}")
+        }
+      implicit def cnilMkTC: MkTC[CNil] =
+        new MkTC[CNil] {
+          val tc = TC.of[CNil](_ => "CNil")
+        }
+      implicit def cconsTC[H, T <: Coproduct]
+       (implicit
+         head: Lazy[TC[H]],
+         tail: Lazy[MkTC[T]]
+       ): MkTC[H :+: T] =
+        new MkTC[H :+: T] {
+          lazy val tc = TC.of[H :+: T](n => s"${head.value.msg(n-1)} :+: ${tail.value.tc.msg(n-1)}")
+        }
+      implicit def genericTC[F, G]
+       (implicit
+         gen: Generic.Aux[F, G],
+         underlying: Lazy[MkTC[G]]
+       ): MkTC[F] =
+        new MkTC[F] {
+          lazy val tc = TC.of[F](n => s"Generic[${underlying.value.tc.msg(n-1)}]")
+        }
+    }
+
+    implicit def mkTC[T]
+     (implicit
+       priority: Lazy[Priority[TC[T], MkTC[T]]]
+     ): TC[T] =
+      priority.value.fold(identity)(_.tc)
+  }
+
+  @Test
+  def testLazyPriority(): Unit = {
+    import Definitions._
+    import Deriver._
+
+    def validate[T: TC](expected: String, n: Int = Int.MaxValue): Unit = {
+      val msg = TC[T].msg(n)
+      assert(expected == msg)
+    }
+
+    // All orphans
+    validate[Int]("Int")
+    validate[CC1]("CC1")
+    validate[Option[Int]]("Option[Int]")
+    validate[Option[CC1]]("Option[CC1]")
+    validate[(Int, CC1)]("(Int, CC1)")
+    validate[(CC1, Int)]("(CC1, Int)")
+    validate[(CC1, Boolean)]("(CC1, Boolean)")
+
+    // Derived, then orphans
+    validate[CC2]("Generic[Int :: HNil]")
+    validate[Either[Int, CC1]]("Generic[Generic[Int :: HNil] :+: Generic[CC1 :: HNil] :+: CNil]")
+    // Fails with the current Orphan
+    validate[(Int, CC1, Boolean)]("Generic[Int :: CC1 :: Boolean :: HNil]")
+    validate[(Int, CC2, Boolean)]("Generic[Int :: Generic[Int :: HNil] :: Boolean :: HNil]")
+
+    // Orphan, then derived, then orphans
+    validate[Option[CC2]]("Option[Generic[Int :: HNil]]")
+    validate[(Int, CC2)]("(Int, Generic[Int :: HNil])")
+
+
+    // Cycles
+
+    // Derived (but for TC[Int])
+    validate[Tree0.Leaf.type]("Generic[HNil]")
+    validate[Tree0]("Generic[Generic[HNil] :+: Generic[Generic[Generic[HNil] :+: Generic[Generic[Generic[…] :+: … :+: …] :: Generic[… :+: …] :: Int :: HNil] :+: CNil] :: Generic[Generic[HNil] :+: Generic[Generic[… :+: …] :: Generic[…] :: … :: …] :+: CNil] :: Int :: HNil] :+: CNil]", 12)
+
+    // Orphan
+    validate[Tree.Leaf.type]("Leaf")
+    // Interleaved derived / orphans
+    // Fails with the current Orphan
+    validate[Tree]("Generic[Leaf :+: Generic[Generic[Leaf :+: Generic[Generic[Leaf :+: … :+: …] :: Generic[… :+: …] :: Int :: HNil] :+: CNil] :: Generic[Leaf :+: Generic[Generic[… :+: …] :: Generic[…] :: … :: …] :+: CNil] :: Int :: HNil] :+: CNil]", 12)
+  }
+
+}
+

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -93,7 +93,21 @@ object ShapelessBuild extends Build {
             ProblemFilters.exclude[MissingMethodProblem]("shapeless.CaseClassMacros.mkCoproductTypTree"),
             ProblemFilters.exclude[MissingMethodProblem]("shapeless.CaseClassMacros.isAnonOrRefinement"),
             ProblemFilters.exclude[MissingMethodProblem]("shapeless.CaseClassMacros.mkTypTree"),
-            ProblemFilters.exclude[MissingMethodProblem]("shapeless.CaseClassMacros.isAccessible")
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.CaseClassMacros.isAccessible"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext#Instance.apply"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext#Instance.copy"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext#Instance.this"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.priorityType"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.priorityTpe"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.PriorityTpe"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.highPriorityTpe"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.lowPriorityTpe"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.addNoUninitialized"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.priorityLookups"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.priorityLookups_="),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.noUninitialized"),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.noUninitialized_="),
+            ProblemFilters.exclude[MissingMethodProblem]("shapeless.DerivationContext.removeNoUninitialized")
           )
         },
 


### PR DESCRIPTION
As discussed on [gitter](https://gitter.im/milessabin/shapeless?at=559e6afb26de773708e6798a) (for `Priority`).

Types with cycles are now fine (added to the tests).

It indeed addresses issues with the current `Orphan`, see the tests marked with "Fails with the current Orphan". Don't know about `WrappedOrphan`, I don't really know how to set it up here.

I renamed the auxiliary ADT to `Attempt` and its cases `Success` and `Fallback`, and added some inline doc too.