### PR TITLE
Weaken type of implicit Generic macro to Generic.Aux[T, Repr]

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -616,7 +616,7 @@ class GenericMacros(val c: whitebox.Context) extends CaseClassMacros {
         def to(p: $tpe): Repr = (p match { case ..$toCases }).asInstanceOf[Repr]
         def from(p: Repr): $tpe = p match { case ..$fromCases }
       }
-      new $clsName()
+      new $clsName(): _root_.shapeless.Generic.Aux[$tpe, ${reprTypTree(tpe)}]
     """
   }
 


### PR DESCRIPTION
The result of the generic macro is currently:

   { class anon$1 extends Generic[T]; new anon$2} : anon$2

The type of the block has an ill-scoped reference to the anonymous
class, which ends up causing problems down the line if we summon
`implicitly[Lazy[Generic[T]]]`: the lazy macro uses the exact type
of the nested materialized `Generic`, but then retypechecks the
block that defines the `anon$1` symbol. This means that the type
doesn't point to the new symbol for the anonymous class, which is
enough to crash the new `GenBCode` of the compiler from Scala 2.11.3
onwards.

    % scalac-hash v2.11.3 -Xprint:typer -nc -Ybackend:GenBCode \
                        -classpath core/target/scala-2.12/classes \
                        -e 'import shapeless._; implicitly[Lazy[Generic[Nil.type]]]
    assertion failed: ClassBType.info not yet assigned: LMain$$anon$1$fresh$macro$3$1;

I've noted a few more details in the comments of SI-9392.

My experience with macros would lead me to rewrite `Lazy` to to avoid
the retypechecking, although this is pretty tedious to get right in
its own right. (I used this apporach in scala-async.)

This commit doesn't attempt this change, but instead weakens the type
of the `Generic` macro to hide the local anonymous class.

We will also try to tweak the compiler to be tolerant of these
incoherent trees in the backend.

After this change, the test case above compiles successfully.
It also no longer incurs warnings under the diagnostic mode of
the compiler, `-Ycheck:typer`.
