### PR TITLE
add Map toRecord method

### DIFF
--- a/core/src/main/scala/shapeless/ops/maps.scala
+++ b/core/src/main/scala/shapeless/ops/maps.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-15 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless.ops
+
+import shapeless._
+import shapeless.labelled.FieldType
+
+object maps {
+
+  /**
+   * Type class supporting type safe conversion of Map to Records.
+   *
+   *
+   */
+  trait FromMap[Out <: HList] extends Serializable {
+    def apply(l: Map[Any, Any]): Option[Out]
+  }
+
+  /**
+   * `FromMap` type class instances.
+   *
+   *
+   */
+  object FromMap {
+
+    def apply[Out <: HList](implicit from: FromMap[Out]) = from
+
+    implicit def hnilFromMap[T] = new FromMap[HNil] {
+
+      override def apply(l: Map[Any, Any]) = Some(HNil)
+    }
+
+    import labelled._
+
+    implicit def hlistFromMap[K, V, OutT <: HList](implicit flt: FromMap[OutT], oc: Typeable[V],
+                                                   wit: Witness.Aux[K]) = new
+        FromMap[FieldType[K, V] :: OutT] {
+
+      import labelled._
+
+      def apply(mm: Map[Any, Any]): Option[FieldType[K, V] :: OutT] = {
+
+        val key = wit.value
+
+        for {value <- mm.get(key)
+             typed <- oc.cast(value)
+             rest <- flt(mm)} yield field[K](typed) :: rest
+      }
+    }
+  }
+}

--- a/core/src/main/scala/shapeless/syntax/std/maps.scala
+++ b/core/src/main/scala/shapeless/syntax/std/maps.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-13 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless.syntax.std
+
+import shapeless.HList
+import shapeless.ops.maps.FromMap
+
+import scala.collection.GenTraversable
+
+/**
+ * Conversions between `Map` and `Records`.
+ *
+ *
+ */
+object maps {
+  implicit def traversableOps[T <: Map[_ <: Any, Any]](t: T) = new MapOps[T](t)
+}
+
+final class MapOps[T <: Map[_ <: Any, Any]](t: T) {
+  /**
+   * Extracts value from map to form Record L. Map must contain all the keys and the values
+   * and of the correct types.
+   * @param fl
+   * @tparam L
+   * @return Some[L] with values from Map or None if map does not match L
+   */
+  def toRecord[L <: HList](implicit fl: FromMap[L]): Option[ L] = fl(
+    t.asInstanceOf[Map[Any, Any]])
+}

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -130,6 +130,63 @@ class RecordTests {
   }
 
   @Test
+  def testFromMap {
+    import record._
+    import test._
+
+    type T1 = Record.`'stringVal -> String,'intVal->Int,'boolVal->Boolean`.T
+
+    val in = Map('intVal -> 4, 'stringVal -> "Blarr", 'boolVal -> true)
+
+    import syntax.std.maps._
+
+    val recOption = in.toRecord[T1]
+
+    assert(recOption.isDefined)
+
+    val rec: T1 = recOption.get
+
+    typed[T1](rec)
+
+    assert(rec('stringVal) == "Blarr", "stringVal mismatch")
+    assert(rec('intVal) == 4, "int val mismatch")
+    assert(rec('boolVal), "Boolean val match")
+
+    val in2 = Map('intVal -> 4, 'stringVal -> "Blarr")
+
+    val recEither2 = in2.toRecord[T1]
+
+    assert(recEither2.isEmpty)
+
+
+  }
+
+  @Test
+  def testFromMap2 {
+    import test._
+
+    type T = FieldType[intField1.type, Int] :: FieldType[stringField1.type, String] :: FieldType[boolField1.type, Boolean] :: FieldType[doubleField1.type, Double] :: HNil
+
+
+    val in = Map(intField1 -> 4, stringField1 -> "Blarr", boolField1 -> true, doubleField1 -> 5.0)
+
+    import syntax.std.maps._
+
+    val recOption = in.toRecord[T]
+
+    assert(recOption.isDefined)
+
+    val rec: T = recOption.get
+
+    typed[T](rec)
+
+    assert(rec(intField1) == 4)
+    assert(rec(stringField1) == "Blarr")
+    assert(rec(doubleField1) == 5.0)
+  }
+
+
+  @Test
   def testAtLiterals {
     val r1 =
       ("intField1"    ->>    23) ::


### PR DESCRIPTION
Add toRecord operation that fills a record with values from a map. Supports nested records