### PR TITLE
illTyped: Enable DOTALL mode so that "." matches newlines

### DIFF
--- a/core/src/main/scala/shapeless/test/typechecking.scala
+++ b/core/src/main/scala/shapeless/test/typechecking.scala
@@ -40,7 +40,7 @@ object illTyped {
     val (expPat, expMsg) = expected match {
       case null => (null, "Expected some error.")
       case Expr(Literal(Constant(s: String))) =>
-        (Pattern.compile(s, Pattern.CASE_INSENSITIVE), "Expected error matching: "+s)
+        (Pattern.compile(s, Pattern.CASE_INSENSITIVE | Pattern.DOTALL), "Expected error matching: "+s)
     }
 
     try {


### PR DESCRIPTION
This adds the `DOTALL` flag to the regex used by `illTyped` so that "." also matches newlines. This makes it easier to check errors which span over multiple lines.

I'm using `illTyped` a lot in refined to check if the compiler fails with the correct error, e.g.
```scala
illTyped("""regex("(a|b")""", "(?s)Regex predicate failed.*")
```
In this example the compile error spans over multiple lines which required to add the embedded flag expression `(?s)` that also enables the `DOTALL` mode. Without that flag, `illTyped` reports that the actual error does not match the expected error. It took me a little bit to figure out that I could enable the `DOTALL` mode from the regex itself.