### PR TITLE
Add runtimeList method to HList

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Chris Hodapp <clhodapp1@gmail.com> @clhodapp
 Cody Allen <ceedubs@gmail.com> @fourierstrick
 Dale Wijnand <dale.wijnand@gmail.com> @dwijnand
 Dario Rexin <dario.rexin@r3-tech.de> @evonox
+Dave Gurnell <d.j.gurnell@gmail.com> @davegurnell
 David Barri <japgolly@gmail.com> @japgolly
 Denis Mikhaylov <notxcain@gmail.com> @notxcain
 Eugene Burmako <xeno.by@gmail.com> @xeno_by

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -474,6 +474,18 @@ final class HListOps[L <: HList](l : L) extends Serializable {
   }
 
   /**
+   * Convert this `HList` to a `List[Any]`.
+   */
+  def runtimeList: List[Any] = {
+    def loop(l: HList): List[Any] = l match {
+      case HNil => Nil
+      case hd :: tl => hd :: loop(tl)
+    }
+
+    loop(l)
+  }
+
+  /**
    * Converts this `HList` to a - sized - `M` of elements typed as the least upper bound of the types of the elements
    * of this `HList`.
    */

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -477,12 +477,18 @@ final class HListOps[L <: HList](l : L) extends Serializable {
    * Convert this `HList` to a `List[Any]`.
    */
   def runtimeList: List[Any] = {
-    def loop(l: HList): List[Any] = l match {
-      case HNil => Nil
-      case hd :: tl => hd :: loop(tl)
+    val builder = List.newBuilder[Any]
+
+    @tailrec def loop(l: HList): Unit = l match {
+      case HNil => ()
+      case hd :: tl =>
+        builder += hd
+        loop(tl)
     }
 
     loop(l)
+
+    builder.result
   }
 
   /**

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -279,6 +279,20 @@ class HListTests {
   }
 
   @Test
+  def testRuntimeLength {
+    assertEquals(0, HNil.runtimeLength)
+    assertEquals(1, (123 :: HNil).runtimeLength)
+    assertEquals(2, ("abc" :: 123 :: HNil).runtimeLength)
+  }
+
+  @Test
+  def testRuntimeList {
+    assertEquals(Nil, HNil.runtimeList)
+    assertEquals(123 :: Nil, (123 :: HNil).runtimeList)
+    assertEquals("abc" :: 123 :: Nil, ("abc" :: 123 :: HNil).runtimeList)
+  }
+
+  @Test
   def testInitLast {
 
     val lp = apbp.last


### PR DESCRIPTION
This handy little method discards all desire for type-safety and converts an `HList` to a `List[Any]`. Potentially useful when using shapeless to add static typing over a dynamically typed library. Use cases include this part of slickless, where we interoperate with some underlying code in Slick:

https://github.com/underscoreio/slickless/blob/master/src/main/scala/slickless/HListShape.scala#L28-L32

