### PR TITLE
Fix implicit priority issues with UnaryTCConstraint, allowing better inference of type constructor

### DIFF
--- a/core/src/main/scala/shapeless/hlistconstraints.scala
+++ b/core/src/main/scala/shapeless/hlistconstraints.scala
@@ -23,7 +23,19 @@ import ops.hlist.Selector
  */
 trait UnaryTCConstraint[L <: HList, TC[_]] extends Serializable
 
-object UnaryTCConstraint {
+trait LowPriorityUnaryTCConstraint0 {
+  implicit def hlistIdUnaryTC[L <: HList] = new UnaryTCConstraint[L, Id] {}
+}
+
+trait LowPriorityUnaryTCConstraint extends LowPriorityUnaryTCConstraint0 {
+
+  implicit def hnilConstUnaryTC[H] = new UnaryTCConstraint[HNil, Const[H]#λ] {}
+
+  implicit def hlistConstUnaryTC[H, T <: HList](implicit utct : UnaryTCConstraint[T, Const[H]#λ]) =
+    new UnaryTCConstraint[H :: T, Const[H]#λ] {}
+}
+
+object UnaryTCConstraint extends LowPriorityUnaryTCConstraint {
   def apply[L <: HList, TC[_]](implicit utcc: UnaryTCConstraint[L, TC]): UnaryTCConstraint[L, TC] = utcc
 
   type *->*[TC[_]] = {
@@ -31,14 +43,8 @@ object UnaryTCConstraint {
   } 
   
   implicit def hnilUnaryTC[TC[_]] = new UnaryTCConstraint[HNil, TC] {}
-  implicit def hlistUnaryTC1[H, T <: HList, TC[_]](implicit utct : UnaryTCConstraint[T, TC]) =
+  implicit def hlistUnaryTC[H, T <: HList, TC[_]](implicit utct : UnaryTCConstraint[T, TC]) =
     new UnaryTCConstraint[TC[H] :: T, TC] {}
-  
-  implicit def hlistUnaryTC2[L <: HList] = new UnaryTCConstraint[L, Id] {}
-  
-  implicit def hlistUnaryTC3[H] = new UnaryTCConstraint[HNil, Const[H]#λ] {}
-  implicit def hlistUnaryTC4[H, T <: HList](implicit utct : UnaryTCConstraint[T, Const[H]#λ]) =
-    new UnaryTCConstraint[H :: T, Const[H]#λ] {}
 }
 
 /**

--- a/core/src/test/scala/shapeless/hlistconstraints.scala
+++ b/core/src/test/scala/shapeless/hlistconstraints.scala
@@ -55,6 +55,15 @@ class HListConstraintsTests {
     illTyped("""
     acceptConst(l5)
     """)
+
+    def acceptTypeConstructor[F[_], L <: HList : *->*[F]#λ](l : L) = true
+
+    acceptTypeConstructor(l1)  // Compiles - F = Option
+    acceptTypeConstructor(l2)  // Compiles - F = Id
+    acceptTypeConstructor(l3)  // Compiles - F = Id
+    acceptTypeConstructor(l4)  // Compiles - F = Const[String]
+    acceptTypeConstructor(l5)  // Compiles - F = Id
+    acceptTypeConstructor(HNil: HNil)
   }
   
   @Test


### PR DESCRIPTION
I noticed this issue when writing `isequence` here: https://gist.github.com/mpilquist/ba9a9fc522a2ed0a0a7b#file-inv-scala-L26-L32

In order for `F` param to be inferred, I had to define the implicit constraint *after* the the `InvariantMonoidal[F]` parameter. With this change, the order should be irrelevant (though I haven't tested that).