### PR TITLE
Various enhancements to Default

### DIFF
--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -3,6 +3,8 @@ package shapeless
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
+import shapeless.labelled.{ FieldType, field }
+
 /**
  * Provides default values of case class-like types.
  *
@@ -46,6 +48,83 @@ object Default {
   type Aux[T, Out0 <: HList] = Default[T] { type Out = Out0 }
 
   implicit def materialize[T, L <: HList]: Aux[T, L] = macro DefaultMacros.materialize[T, L]
+
+
+  /**
+   * Provides default values of case class-like types, as a record.
+   *
+   * Type `Out` is a record type, having one element per field with a default value. Labels
+   * come from the available `DefaultSymbolicLabelling[T]`, and values are the default values
+   * themselves.
+   *
+   * Method `apply` provides the record of default values, typed as `Out`.
+   *
+   * Example
+   * {{{
+   *   case class CC(i: Int, s: String = "b")
+   *
+   *   val default = Default.AsRecord[CC]
+   *
+   *   // default.Out is  Record.`'s -> String`.T
+   *   // default() returns Record(s = "b")
+   * }}}
+   *
+   * @author Alexandre Archambault
+   */
+  trait AsRecord[T] extends DepFn0 with Serializable {
+    type Out <: HList
+  }
+
+  object AsRecord {
+    def apply[T](implicit default: AsRecord[T]): Aux[T, default.Out] = default
+
+    type Aux[T, Out0 <: HList] = AsRecord[T] { type Out = Out0 }
+
+    trait Helper[L <: HList, Labels <: HList] extends DepFn1[L] with Serializable {
+      type Out <: HList
+    }
+
+    object Helper {
+      def apply[L <: HList, Labels <: HList](implicit helper: Helper[L, Labels]): Aux[L, Labels, helper.Out] = helper
+
+      type Aux[L <: HList, Labels <: HList, Out0 <: HList] = Helper[L, Labels] { type Out = Out0 }
+
+      implicit def hnilHelper: Aux[HNil, HNil, HNil] =
+        new Helper[HNil, HNil] {
+          type Out = HNil
+          def apply(l: HNil) = HNil
+        }
+
+      implicit def hconsSomeHelper[K <: Symbol, H, T <: HList, LabT <: HList, OutT <: HList]
+       (implicit
+         tailHelper: Aux[T, LabT, OutT]
+       ): Aux[Some[H] :: T, K :: LabT, FieldType[K, H] :: OutT] =
+        new Helper[Some[H] :: T, K :: LabT] {
+          type Out = FieldType[K, H] :: OutT
+          def apply(l: Some[H] :: T) = field[K](l.head.x) :: tailHelper(l.tail)
+        }
+
+      implicit def hconsNoneHelper[K <: Symbol, T <: HList, LabT <: HList, OutT <: HList]
+       (implicit
+         tailHelper: Aux[T, LabT, OutT]
+       ): Aux[None.type :: T, K :: LabT, OutT] =
+        new Helper[None.type :: T, K :: LabT] {
+          type Out = OutT
+          def apply(l: None.type :: T) = tailHelper(l.tail)
+        }
+    }
+
+    implicit def asRecord[T, Labels <: HList, Options <: HList, Rec <: HList]
+     (implicit
+       default: Default.Aux[T, Options],
+       labelling: DefaultSymbolicLabelling.Aux[T, Labels],
+       helper: Helper.Aux[Options, Labels, Rec]
+     ): Aux[T, Rec] =
+      new AsRecord[T] {
+        type Out = Rec
+        def apply() = helper(default())
+      }
+  }
 }
 
 class DefaultMacros(val c: whitebox.Context) extends shapeless.CaseClassMacros {

--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -45,7 +45,7 @@ object Default {
 
   type Aux[T, Out0 <: HList] = Default[T] { type Out = Out0 }
 
-  implicit def materialize[T, L <: HList]: Aux[T, L] = macro DefaultMacros.mkDefaultValues[T, L]
+  implicit def materialize[T, L <: HList]: Aux[T, L] = macro DefaultMacros.materialize[T, L]
 }
 
 class DefaultMacros(val c: whitebox.Context) extends shapeless.CaseClassMacros {
@@ -54,7 +54,7 @@ class DefaultMacros(val c: whitebox.Context) extends shapeless.CaseClassMacros {
   def someTpe = typeOf[Some[_]].typeConstructor
   def noneTpe = typeOf[None.type]
 
-  def mkDefaultValues[T: WeakTypeTag, L: WeakTypeTag]: Tree = {
+  def materialize[T: WeakTypeTag, L: WeakTypeTag]: Tree = {
     val tpe = weakTypeOf[T]
 
     if (!isCaseClassLike(classSym(tpe)))

--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -30,7 +30,7 @@ import scala.reflect.macros.whitebox
  *
  * @author Alexandre Archambault
  */
-trait Default[T] extends DepFn0 {
+trait Default[T] extends DepFn0 with Serializable {
   type Out <: HList
 }
 

--- a/core/src/test/scala/shapeless/default.scala
+++ b/core/src/test/scala/shapeless/default.scala
@@ -1,5 +1,7 @@
 package shapeless
 
+import shapeless.record.Record
+
 import org.junit.Test
 import shapeless.test.illTyped
 
@@ -58,6 +60,43 @@ class DefaultTests {
     illTyped(" Default[Any] ", "could not find implicit value for parameter default: .*")
     Default[AnyRef] // this one shouldn't compile - related to https://github.com/milessabin/shapeless/issues/453
     illTyped(" Default[Array[Int]] ", "could not find implicit value for parameter default: .*")
+  }
+
+  @Test
+  def simpleAsRecord {
+    {
+      val default: Record.`'s -> String, 'flagOpt -> Option[Boolean]`.T = Default.AsRecord[CC].apply()
+      assert(default == Record(s = "b", flagOpt = Some(true)))
+    }
+
+    {
+      val default = Default.AsRecord[CC].apply()
+      assert(default == Record(s = "b", flagOpt = Some(true)))
+    }
+  }
+
+  @Test
+  def simpleFromPathAsRecord {
+    {
+      val default: Record.`'s -> String, 'flagOpt -> Option[Boolean]`.T = Default.AsRecord[definitions.CC].apply()
+      assert(default == Record(s = "b", flagOpt = Some(true)))
+    }
+
+    {
+      val default = Default.AsRecord[definitions.CC].apply()
+      assert(default == Record(s = "b", flagOpt = Some(true)))
+    }
+  }
+
+  @Test
+  def invalidAsRecord {
+    illTyped(" Default.AsRecord[Base] ", "could not find implicit value for parameter default: .*")
+
+    illTyped(" Default.AsRecord[Dummy] ", "could not find implicit value for parameter default: .*")
+
+    illTyped(" Default.AsRecord[Any] ", "could not find implicit value for parameter default: .*")
+    Default.AsRecord[AnyRef] // this one shouldn't compile - related to https://github.com/milessabin/shapeless/issues/453
+    illTyped(" Default.AsRecord[Array[Int]] ", "could not find implicit value for parameter default: .*")
   }
 
 }

--- a/core/src/test/scala/shapeless/default.scala
+++ b/core/src/test/scala/shapeless/default.scala
@@ -99,4 +99,51 @@ class DefaultTests {
     illTyped(" Default.AsRecord[Array[Int]] ", "could not find implicit value for parameter default: .*")
   }
 
+  @Test
+  def simpleAsOptions {
+    illTyped(
+      " val default0: None.type :: Some[String] :: Some[Option[Boolean]] :: HNil = Default.AsOptions[CC].apply() ",
+      "type mismatch.*"
+    )
+
+    {
+      val default: Option[Int] :: Option[String] :: Option[Option[Boolean]] :: HNil = Default.AsOptions[CC].apply()
+      assert(default == None :: Some("b") :: Some(Some(true)) :: HNil)
+    }
+
+    {
+      val default = Default.AsOptions[CC].apply()
+      assert(default == None :: Some("b") :: Some(Some(true)) :: HNil)
+    }
+  }
+
+  @Test
+  def simpleFromPathAsOptions {
+    illTyped(
+      " val default0: None.type :: Some[String] :: Some[Option[Boolean]] :: HNil = Default.AsOptions[definitions.CC].apply() ",
+      "type mismatch.*"
+    )
+
+    {
+      val default: Option[Int] :: Option[String] :: Option[Option[Boolean]] :: HNil = Default.AsOptions[definitions.CC].apply()
+      assert(default == None :: Some("b") :: Some(Some(true)) :: HNil)
+    }
+
+    {
+      val default = Default[definitions.CC].apply()
+      assert(default == None :: Some("b") :: Some(Some(true)) :: HNil)
+    }
+  }
+
+  @Test
+  def invalidAsOptions {
+    illTyped(" Default.AsOptions[Base] ", "could not find implicit value for parameter default: .*")
+
+    illTyped(" Default.AsOptions[Dummy] ", "could not find implicit value for parameter default: .*")
+
+    illTyped(" Default.AsOptions[Any] ", "could not find implicit value for parameter default: .*")
+    Default.AsOptions[AnyRef] // this one shouldn't compile - related to https://github.com/milessabin/shapeless/issues/453
+    illTyped(" Default.AsOptions[Array[Int]] ", "could not find implicit value for parameter default: .*")
+  }
+
 }

--- a/core/src/test/scala/shapeless/default.scala
+++ b/core/src/test/scala/shapeless/default.scala
@@ -8,7 +8,7 @@ object DefaultTestDefinitions {
   case class CC(i: Int, s: String = "b", flagOpt: Option[Boolean] = Some(true))
 
   sealed trait Base
-  case class BaseI(i: Int)
+  case class BaseI(i: Int) extends Base
 
   trait Dummy
 
@@ -16,7 +16,7 @@ object DefaultTestDefinitions {
     case class CC(i: Int, s: String = "b", flagOpt: Option[Boolean] = Some(true))
   }
 
-  object DefinitionsObj extends Definitions
+  val definitions = new Definitions {}
 
 }
 
@@ -39,12 +39,12 @@ class DefaultTests {
   @Test
   def simpleFromPath {
     {
-      val default: None.type :: Some[String] :: Some[Option[Boolean]] :: HNil = Default[DefinitionsObj.CC].apply()
+      val default: None.type :: Some[String] :: Some[Option[Boolean]] :: HNil = Default[definitions.CC].apply()
       assert(default == None :: Some("b") :: Some(Some(true)) :: HNil)
     }
 
     {
-      val default = Default[DefinitionsObj.CC].apply()
+      val default = Default[definitions.CC].apply()
       assert(default == None :: Some("b") :: Some(Some(true)) :: HNil)
     }
   }

--- a/core/src/test/scala/shapeless/serialization.scala
+++ b/core/src/test/scala/shapeless/serialization.scala
@@ -1123,4 +1123,11 @@ class SerializationTests {
     assertSerializable(l13)
     assertSerializable(l14)
   }
+
+  @Test
+  def testDefault {
+    val d1 = Default[DefaultTestDefinitions.CC]
+
+    assertSerializable(d1)
+  }
 }

--- a/core/src/test/scala/shapeless/serialization.scala
+++ b/core/src/test/scala/shapeless/serialization.scala
@@ -1128,8 +1128,10 @@ class SerializationTests {
   def testDefault {
     val d1 = Default[DefaultTestDefinitions.CC]
     val d2 = Default.AsRecord[DefaultTestDefinitions.CC]
+    val d3 = Default.AsOptions[DefaultTestDefinitions.CC]
 
     assertSerializable(d1)
     assertSerializable(d2)
+    assertSerializable(d3)
   }
 }

--- a/core/src/test/scala/shapeless/serialization.scala
+++ b/core/src/test/scala/shapeless/serialization.scala
@@ -1127,7 +1127,9 @@ class SerializationTests {
   @Test
   def testDefault {
     val d1 = Default[DefaultTestDefinitions.CC]
+    val d2 = Default.AsRecord[DefaultTestDefinitions.CC]
 
     assertSerializable(d1)
+    assertSerializable(d2)
   }
 }


### PR DESCRIPTION
See the commit messages and content for more details.

In particular, this adds extra `Default`-like type classes, providing the default values as a record or an HList of `Option[...]` (instead of `None.type` / `Some[...]`).