### PR TITLE
Add Annotation(s) type classes

### DIFF
--- a/core/src/main/scala/shapeless/annotation.scala
+++ b/core/src/main/scala/shapeless/annotation.scala
@@ -1,0 +1,137 @@
+package shapeless
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+/**
+ * Provides the annotations of type `A` of the fields or constructors of case class-like or sum type `T`.
+ *
+ * If type `T` is case class-like, this type class inspects its fields and provides their annotations of type `A`. If
+ * type `T` is a sum type, its constructor types are looked for annotations.
+ *
+ * Type `Out` is an HList having the same number of elements as `T` (number of fields of `T` if `T` is case class-like,
+ * or number of constructors of `T` if it is a sum type). It is made of `None.type` (no annotation on corresponding
+ * field or constructor) and `Some[A]` (corresponding field or constructor is annotated).
+ *
+ * Method `apply` provides an HList of type `Out` made of `None` (corresponding field or constructor not annotated)
+ * or `Some(annotation)` (corresponding field or constructor has annotation `annotation`).
+ *
+ * Note that annotation types must be case class-like for this type class to take them into account.
+ *
+ * Example:
+ * {{{
+ *   case class First(s: String)
+ *
+ *   case class CC(i: Int, @First("a") s: String)
+ *
+ *   sealed trait Base
+ *   @First("b") case class BaseI(i: Int) extends Base
+ *   case class BaseS(s: String) extends Base
+ *
+ *
+ *   val ccFirsts = Annotations[First, CC]
+ *   val baseFirsts = Annotations[First, Base]
+ *
+ *   // ccFirsts.Out is  None.type :: Some[First] :: HNil
+ *   // ccFirsts.apply() is
+ *   //   None :: Some(First("a")) :: HNil
+ *
+ *   // baseFirsts.Out is  Some[First] :: None.type :: HNil
+ *   // baseFirsts.apply() is
+ *   //   Some(First("b")) :: None :: HNil
+ * }}}
+ *
+ * @tparam A: annotation type
+ * @tparam T: case class-like or sum type, whose fields or constructors are annotated
+ *
+ * @author Alexandre Archambault
+ */
+trait Annotations[A,T] extends DepFn0 with Serializable {
+  type Out <: HList
+}
+
+object Annotations {
+  def apply[A,T](implicit annotations: Annotations[A,T]): Aux[A, T, annotations.Out] = annotations
+
+  type Aux[A, T, Out0 <: HList] = Annotations[A, T] { type Out = Out0 }
+
+  def mkAnnotations[A, T, Out0 <: HList](annotations: => Out0): Aux[A, T, Out0] =
+    new Annotations[A, T] {
+      type Out = Out0
+      def apply() = annotations
+    }
+
+  implicit def materialize[A, T, Out <: HList]: Aux[A, T, Out] = macro AnnotationMacros.materializeAnnotations[A, T, Out]
+}
+
+class AnnotationMacros(val c: whitebox.Context) extends CaseClassMacros {
+  import c.universe._
+
+  def someTpe = typeOf[Some[_]].typeConstructor
+  def noneTpe = typeOf[None.type]
+
+    // FIXME Most of the content of this method is cut-n-pasted from generic.scala
+  def construct(tpe: Type): List[Tree] => Tree = {
+    // FIXME Cut-n-pasted from generic.scala
+    val sym = tpe.typeSymbol
+    val isCaseClass = sym.asClass.isCaseClass
+    def hasNonGenericCompanionMember(name: String): Boolean = {
+      val mSym = sym.companion.typeSignature.member(TermName(name))
+      mSym != NoSymbol && !isNonGeneric(mSym)
+    }
+
+    if(isCaseClass || hasNonGenericCompanionMember("apply"))
+      args => q"${companionRef(tpe)}(..$args)"
+    else
+      args => q"new $tpe(..$args)"
+  }
+
+  def materializeAnnotations[A: WeakTypeTag, T: WeakTypeTag, Out: WeakTypeTag]: Tree = {
+    val annTpe = weakTypeOf[A]
+
+    if (!isProduct(annTpe))
+      abort(s"$annTpe is not a case class-like type")
+
+    val construct0 = construct(annTpe)
+
+    val tpe = weakTypeOf[T]
+
+    val annTreeOpts =
+      if (isProduct(tpe)) {
+        val constructorSyms = tpe
+          .member(termNames.CONSTRUCTOR)
+          .asMethod
+          .paramLists
+          .flatten
+          .map { sym => sym.name.decodedName.toString -> sym }
+          .toMap
+
+        fieldsOf(tpe).map { case (name, _) =>
+          val paramConstrSym = constructorSyms(name.decodedName.toString)
+
+          paramConstrSym.annotations.collectFirst {
+            case ann if ann.tree.tpe =:= annTpe => construct0(ann.tree.children.tail)
+          }
+        }
+      } else if (isCoproduct(tpe))
+        ctorsOf(tpe).map { cTpe =>
+          cTpe.typeSymbol.annotations.collectFirst {
+            case ann if ann.tree.tpe =:= annTpe => construct0(ann.tree.children.tail)
+          }
+        }
+      else
+        abort(s"$tpe is not case class like or the root of a sealed family of types")
+
+    val wrapTpeTrees = annTreeOpts.map {
+      case Some(annTree) => appliedType(someTpe, annTpe) -> q"_root_.scala.Some($annTree)"
+      case None => noneTpe -> q"_root_.scala.None"
+    }
+
+    val outTpe = mkHListTpe(wrapTpeTrees.map { case (aTpe, _) => aTpe })
+    val outTree = wrapTpeTrees.foldRight(q"_root_.shapeless.HNil": Tree) {
+      case ((_, bound), acc) => pq"_root_.shapeless.::($bound, $acc)"
+    }
+
+    q"_root_.shapeless.Annotations.mkAnnotations[$annTpe, $tpe, $outTpe]($outTree)"
+  }
+}

--- a/core/src/test/scala/shapeless/annotation.scala
+++ b/core/src/test/scala/shapeless/annotation.scala
@@ -8,13 +8,18 @@ object AnnotationTestsDefinitions {
   case class First()
   case class Second(i: Int, s: String)
 
+  case class Other()
+  case class Last(b: Boolean)
+
   case class Unused()
 
-  case class CC(
+  @Other case class CC(
     @First i: Int,
     s: String,
     @Second(2, "b") ob: Option[Boolean]
   )
+
+  @Last(true) trait Something
 
   sealed trait Base
   @First case class BaseI(i: Int) extends Base
@@ -26,6 +31,30 @@ object AnnotationTestsDefinitions {
 
 class AnnotationTests {
   import AnnotationTestsDefinitions._
+
+  def simpleAnnotation {
+    {
+      val other = Annotation[Other, CC].apply()
+      assert(other == Other())
+
+      val last = Annotation[Last, Something].apply()
+      assert(last == Last(true))
+    }
+
+    {
+      val other: Other = Annotation[Other, CC].apply()
+      assert(other == Other())
+
+      val last: Last = Annotation[Last, Something].apply()
+      assert(last == Last(true))
+    }
+  }
+
+  @Test
+  def invalidAnnotation {
+    illTyped(" Annotation[Other, Dummy] ", "could not find implicit value for parameter annotation: .*")
+    illTyped(" Annotation[Dummy, CC] ", "could not find implicit value for parameter annotation: .*")
+  }
 
   @Test
   def simpleAnnotations {

--- a/core/src/test/scala/shapeless/annotation.scala
+++ b/core/src/test/scala/shapeless/annotation.scala
@@ -1,0 +1,74 @@
+package shapeless
+
+import org.junit.Test
+import shapeless.test.illTyped
+
+object AnnotationTestsDefinitions {
+
+  case class First()
+  case class Second(i: Int, s: String)
+
+  case class Unused()
+
+  case class CC(
+    @First i: Int,
+    s: String,
+    @Second(2, "b") ob: Option[Boolean]
+  )
+
+  sealed trait Base
+  @First case class BaseI(i: Int) extends Base
+  @Second(3, "e") case class BaseS(s: String) extends Base
+
+  trait Dummy
+
+}
+
+class AnnotationTests {
+  import AnnotationTestsDefinitions._
+
+  @Test
+  def simpleAnnotations {
+    {
+      val first: Some[First] :: None.type :: None.type :: HNil = Annotations[First, CC].apply()
+      assert(first == Some(First()) :: None :: None :: HNil)
+
+      val second: None.type :: None.type :: Some[Second] :: HNil = Annotations[Second, CC].apply()
+      assert(second == None :: None :: Some(Second(2, "b")) :: HNil)
+
+      val unused: None.type :: None.type :: None.type :: HNil = Annotations[Unused, CC].apply()
+      assert(unused == None :: None :: None :: HNil)
+
+      val firstSum: Some[First] :: None.type :: HNil = Annotations[First, Base].apply()
+      assert(firstSum == Some(First()) :: None :: HNil)
+
+      val secondSum: None.type :: Some[Second] :: HNil = Annotations[Second, Base].apply()
+      assert(secondSum == None :: Some(Second(3, "e")) :: HNil)
+    }
+
+    {
+      val first = Annotations[First, CC].apply()
+      assert(first == Some(First()) :: None :: None :: HNil)
+
+      val second = Annotations[Second, CC].apply()
+      assert(second == None :: None :: Some(Second(2, "b")) :: HNil)
+
+      val unused = Annotations[Unused, CC].apply()
+      assert(unused == None :: None :: None :: HNil)
+
+      val firstSum = Annotations[First, Base].apply()
+      assert(firstSum == Some(First()) :: None :: HNil)
+
+      val secondSum = Annotations[Second, Base].apply()
+      assert(secondSum == None :: Some(Second(3, "e")) :: HNil)
+    }
+  }
+
+  @Test
+  def invalidAnnotations {
+    illTyped(" Annotations[Dummy, CC] ", "could not find implicit value for parameter annotations: .*")
+    illTyped(" Annotations[Dummy, Base] ", "could not find implicit value for parameter annotations: .*")
+    illTyped(" Annotations[Second, Dummy] ", "could not find implicit value for parameter annotations: .*")
+  }
+
+}


### PR DESCRIPTION
This PR adds type classes `Annotation` and `Annotations` (latter ends with `s`).

`Annotation[A, T]` provides the annotation of type `A` on type `T`, if any, like
```scala
case class First(i: Int) // annotation type

@First(3) trait Something

val somethingFirst = Annotation[First, Something].apply()
assert(somethingFirst == First(3))
```

`Annotations[A, T]` provides annotations on the fields or constructors of `T`, a bit like `Default` provides default values. Example usage:
```scala
case class First(s: String) // annotation type

case class CC(i: Int, @First("a") s: String)

sealed trait Base
@First("b") case class BaseI(i: Int) extends Base
case class BaseS(s: String) extends Base

val ccFirsts = Annotations[First, CC]
val baseFirsts = Annotations[First, Base]

// ccFirsts.Out is  None.type :: Some[First] :: HNil
// ccFirsts.apply() is
//   None :: Some(First("a")) :: HNil

// baseFirsts.Out is  Some[First] :: None.type :: HNil
// baseFirsts.apply() is
//   Some(First("b")) :: None :: HNil
```