### PR TITLE
Grouper type class, ToCoproduct for Tuples, ToSum type class

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -911,41 +911,112 @@ object hlist {
 
   trait LowPriorityGrouper {
 
-    implicit def hlistGrouper[L <: HList, N <: Nat, OutT <: HList, OutD <: HList, T, Step <: Nat]
+    implicit def hlistGrouper[L <: HList, N <: Nat, OutT <: HList, OutD <: HList, T, Step <: Nat, LL <: Nat, M <: Nat]
     (implicit
-     takeN: ops.hlist.Take.Aux[L, N, OutT],
-     dropN: ops.hlist.Drop.Aux[L, Step, OutD],
+     len: Length.Aux[L, LL],
+     min: ops.nat.Min.Aux[LL, Step, M],
+     take: ops.hlist.Take.Aux[L, N, OutT],
+     drop: ops.hlist.Drop.Aux[L, M, OutD],
      tup: ops.hlist.Tupler.Aux[OutT, T],
      grouper: Grouper[OutD, N, Step]
       ): Grouper.Aux[L, N, Step, tup.Out :: grouper.Out] = new Grouper[L, N, Step] {
       type Out = tup.Out :: grouper.Out
 
-      def apply(l: L) = tup(takeN(l)) :: grouper(dropN(l))
+      def apply(l: L) = tup(take(l)) :: grouper(drop(l))
     }
   }
 
   object Grouper extends LowPriorityGrouper {
-    def apply[L <: HList, N <: Nat, Step <: Nat](implicit g: Grouper[L, N, Step]): Aux[L, N, Step, g.Out] = g
+    def apply[L <: HList, N <: Nat, Step <: Nat](implicit
+                                                 grouper: Grouper[L, N, Step]
+                                                  ): Aux[L, N, Step, grouper.Out] = grouper
 
     type Aux[L <: HList, N <: Nat, Step <: Nat, Out0] = Grouper[L, N, Step] {
       type Out = Out0
     }
 
-    implicit def hnilGrouper[N <: Nat]: Aux[HNil, N, N, HNil] = new Grouper[HNil, N, N] {
+    implicit def hnilGrouper[N <: Nat, Step <: Nat]: Aux[HNil, N, Step, HNil] = new Grouper[HNil, N, Step] {
       type Out = HNil
 
       def apply(l: HNil): Out = HNil
     }
 
-    implicit def hlistGrouper1[L <: HList, A <: Nat, B <: Nat, Step <: Nat](implicit
+    implicit def hlistGrouper1[L <: HList, A <: Nat, N <: Nat, Step <: Nat](implicit
                                                                             len: ops.hlist.Length.Aux[L, A],
-                                                                            lt: ops.nat.LT[A, B]
-                                                                             ): Aux[L, B, Step, HNil] = new Grouper[L, B, Step] {
+                                                                            lt: ops.nat.LT[A, N]
+                                                                             ): Aux[L, N, Step, HNil] = new Grouper[L, N, Step] {
       type Out = HNil
 
       def apply(l: L): Out = HNil
     }
   }
+
+  /**
+   * Typeclass supporting grouping this `HList` into tuples of `N` items each, at `Step`
+   * apart. If `Step` equals `N` then the groups do not overlap.
+   *
+   * Use elements in `pad` as necessary to complete last group up to `n` items.
+   * In case there are not enough padding elements, return a partition
+   * with less than `n` items.
+   *
+   * @author Andreas Koestler
+   */
+  trait LowPriorityPaddedGrouper {
+    implicit def incompletePaddedGrouper[
+    L <: HList,
+    N <: Nat,
+    Step <: Nat,
+    Pad <: HList,
+    PL <: HList,
+    LPL <: Nat,
+    S <: Nat,
+    MI <: Nat,
+    T <: HList,
+    M <: Nat,
+    LL <: Nat]
+    (implicit
+     len1: Length.Aux[L, LL],
+     prep: Prepend.Aux[L, Pad, PL],
+     len2: Length.Aux[PL, LPL],
+     mod: ops.nat.Mod.Aux[LL, Step, M],
+     sum: ops.nat.Sum.Aux[LL, M, S],
+     min: ops.nat.Min.Aux[LPL, S, MI],
+     take: Take.Aux[PL, MI, T],
+     grouper: Grouper[T, N, Step]
+      ): PaddedGrouper.Aux[L, N, Step, Pad, grouper.Out] = new PaddedGrouper[L, N, Step, Pad] {
+      type Out = grouper.Out
+
+      def apply(l: L, pad: Pad): Out = grouper(take(prep(l, pad)))
+    }
+
+  }
+  trait PaddedGrouper[L <: HList, N <: Nat, Step <: Nat, Pad <: HList] extends DepFn2[L, Pad] with Serializable {
+    type Out <: HList
+  }
+
+  object PaddedGrouper extends LowPriorityPaddedGrouper {
+    def apply[L <: HList, N <: Nat, Step <: Nat, Pad <: HList](implicit
+                                                               grouper: PaddedGrouper[L, N, Step, Pad]
+                                                                ): Aux[L, N, Step, Pad, grouper.Out] = grouper
+
+    type Aux[L <: HList, N <: Nat, Step <: Nat, Pad <: HList, Out0] = PaddedGrouper[L, N, Step, Pad] {
+      type Out = Out0
+    }
+
+    implicit def defaultPaddedGrouper[L <: HList, N <: Nat, Step <: Nat, Pad <: HList, A <: Nat, B <: Nat]
+    (implicit
+     len: Length.Aux[L, A],
+     mod: ops.nat.Mod.Aux[A, Step, B],
+     eq: B =:= _0,
+     grouper: Grouper[L, N, Step]
+      ): Aux[L, N, Step, Pad, grouper.Out] = new PaddedGrouper[L, N, Step, Pad] {
+      type Out = grouper.Out
+
+      def apply(l: L, pad: Pad): Out = grouper(l)
+    }
+
+  }
+
 
   /**
    * Type class supporting access to the all elements of this `HList` of type `U`.

--- a/core/src/main/scala/shapeless/ops/nat.scala
+++ b/core/src/main/scala/shapeless/ops/nat.scala
@@ -250,6 +250,56 @@ object nat {
   }
 
   /**
+   * Type class implementing Euclidean algorithm for calculating the GCD
+   *
+   * @author Andreas Koestler
+   */
+  trait LowPriorityGCD {
+    implicit def defaultCase[A <: Nat, B <: Nat, T <: Nat](implicit
+                                                           mod: Mod.Aux[A, B, T],
+                                                           gcd: GCD[B, T]): GCD.Aux[A, B, gcd.Out] = new GCD[A, B] {
+      type Out = gcd.Out
+    }
+  }
+  trait GCD[A <: Nat, B <: Nat] extends Serializable {
+    type Out <: Nat
+  }
+
+  object GCD extends LowPriorityGCD {
+    def apply[A <: Nat, B <: Nat](implicit gcd: GCD[A, B]): Aux[A, B, gcd.Out] = gcd
+
+    type Aux[A <: Nat, B <: Nat, Out0 <: Nat] = GCD[A, B] {type Out = Out0}
+
+    implicit def terminationCase[A <: Nat]: Aux[A, _0, A] = new GCD[A, _0] {
+      type Out = A
+    }
+  }
+
+  /**
+   * Type class for calculating the Least Common Multiple
+   *
+   * @author Andreas Koestler
+   */
+  trait LCM[A <: Nat, B <: Nat] extends Serializable {
+    type Out <: Nat
+  }
+
+  object LCM {
+    def apply[A <: Nat, B <: Nat](implicit lcm: LCM[A, B]): Aux[A, B, lcm.Out] = lcm
+
+    type Aux[A <: Nat, B <: Nat, Out0 <: Nat] = LCM[A, B] {type Out = Out0}
+
+    implicit def lcm[A <: Nat, B <: Nat, M <: Nat, N <: Nat, Res <: Nat]
+    (implicit
+     prod: Prod.Aux[A, B, M],
+     gcd: GCD.Aux[A, B, N],
+     div: Div[M, N]
+      ): Aux[A, B, div.Out] = new LCM[A, B] {
+      type Out = div.Out
+    }
+  }
+
+  /**
    * Type class supporting conversion of type-level Nats to value level Ints.
    * 
    * @author Miles Sabin

--- a/core/src/main/scala/shapeless/ops/tuples.scala
+++ b/core/src/main/scala/shapeless/ops/tuples.scala
@@ -985,6 +985,59 @@ object tuple {
   }
 
   /**
+   * Type class computing the coproduct type corresponding to this tuple.
+   *
+   * @author Andreas Koestler
+   */
+  trait ToCoproduct[T] extends Serializable { type Out <: Coproduct }
+
+  object ToCoproduct {
+    def apply[T](implicit tcp: ToCoproduct[T]): Aux[T, tcp.Out] = tcp
+
+    type Aux[T, Out0 <: Coproduct] = ToCoproduct[T] {type Out = Out0}
+
+    implicit val hnilToCoproduct: Aux[HNil, CNil] =
+      new ToCoproduct[HNil] {
+        type Out = CNil
+      }
+
+    implicit def hlistToCoproduct[T, L <: HList](implicit
+                                                 gen: Generic.Aux[T, L],
+                                                 ut: hl.ToCoproduct[L]
+                                                  ): Aux[T, ut.Out] =
+      new ToCoproduct[T] {
+        type Out = ut.Out
+      }
+  }
+
+  /**
+   * Type class computing the sum type corresponding to this tuple.
+   *
+   * @author Andreas Koestler
+   */
+  trait ToSum[T] extends Serializable { type Out <: Coproduct }
+
+  object ToSum {
+    def apply[T](implicit tcp: ToSum[T]): Aux[T, tcp.Out] = tcp
+
+    type Aux[T, Out0 <: Coproduct] = ToSum[T] {type Out = Out0}
+
+    implicit val hnilToSum: Aux[HNil, CNil] =
+      new ToSum[HNil] {
+        type Out = CNil
+      }
+
+    implicit def hlistToSum[T, L <: HList](implicit
+                                           gen: Generic.Aux[T, L],
+                                           ut: hl.ToSum[L]
+                                            ): Aux[T, ut.Out] =
+      new ToSum[T] {
+        type Out = ut.Out
+      }
+  }
+
+
+  /**
    * Type Class witnessing that this tuple can be collected with a 'Poly' to produce a new tuple
    *
    * @author Stacy Curl

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -538,7 +538,7 @@ final class HListOps[L <: HList](l : L) extends Serializable {
   }
 
   /**
-   * Converts this `HList` to a - sized - `M` of elements typed as the least upper bound of the types of the elements
+   * Converts this `HList` to a `M` of elements typed as the least upper bound of the types of the elements
    * of this `HList`.
    */
   def to[M[_]](implicit ts : ToTraversable[L, M]) : ts.Out = ts(l)

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -652,4 +652,11 @@ final class HListOps[L <: HList](l : L) extends Serializable {
    */
   def group(n: Nat, step: Nat)(implicit grouper: Grouper[L, n.N, step.N]): grouper.Out = grouper(l)
 
+  /**
+   * Groups the elements of this `HList` into tuples of `n` elements, offset by `step`
+   * Use elements in `pad` as necessary to complete last group up to `n` items.
+   * @author Andreas Koestler
+   */
+  def group[Pad <: HList](n: Nat, step: Nat, pad: Pad)(implicit grouper: PaddedGrouper[L, n.N, step.N, Pad]): grouper.Out = grouper(l, pad)
+
 }

--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -644,4 +644,12 @@ final class HListOps[L <: HList](l : L) extends Serializable {
    * Finds the first element of the HList for which the given Poly is defined, and applies the Poly to it.
    */ 
   def collectFirst[P <: Poly](p: P)(implicit collect: CollectFirst[L, p.type]): collect.Out = collect(l)
+
+  /**
+   * Groups the elements of this `HList` into tuples of `n` elements, offset by `step`
+   *
+   * @author Andreas Koestler
+   */
+  def group(n: Nat, step: Nat)(implicit grouper: Grouper[L, n.N, step.N]): grouper.Out = grouper(l)
+
 }

--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -484,4 +484,11 @@ final class TupleOps[T](t: T) extends Serializable {
   class PatchAux[N <: Nat, M <: Nat]{
     def apply[In](in: In)(implicit patcher: Patcher[N, M, T, In]): patcher.Out = patcher(t, in)
   }
+
+  /**
+   * Groups the elements of this `Tuple` into tuples of `n` elements, offset by `step`
+   *
+   * @author Andreas Koestler
+   */
+  def group(n: Nat, step: Nat)(implicit grouper: Grouper[T, n.N, step.N]): grouper.Out = grouper(t)
 }

--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -491,4 +491,11 @@ final class TupleOps[T](t: T) extends Serializable {
    * @author Andreas Koestler
    */
   def group(n: Nat, step: Nat)(implicit grouper: Grouper[T, n.N, step.N]): grouper.Out = grouper(t)
+
+  /**
+   * Groups the elements of this `Tuple` into tuples of `n` elements, offset by `step`
+   * Use elements in `pad` as necessary to complete last group up to `n` items.
+   * @author Andreas Koestler
+   */
+  def group[Pad](n: Nat, step: Nat, pad: Pad)(implicit grouper: PaddedGrouper[T, n.N, step.N, Pad]): grouper.Out = grouper(t, pad)
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -2725,6 +2725,18 @@ class HListTests {
   }
 
   @Test
+  def testToSum {
+    type PISB = Int :: String :: Boolean :: HNil
+    type CISBa = Int :+: String :+: Boolean :+: CNil
+    type SISBa = the.`ToSum[PISB]`.Out
+    implicitly[CISBa =:= SISBa]
+
+    type PIISSB = Int :: Int :: String :: String :: Boolean :: HNil
+    type SISBb = the.`ToSum[PIISSB]`.Out
+    implicitly[CISBa =:= SISBb]
+  }
+
+  @Test
   def testHListTypeSelector {
     import syntax.singleton._
 

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -2948,15 +2948,15 @@ class HListTests {
                                           mapper: ops.hlist.Mapper[toInt.type, R]
       ) = mapper(range())
 
-    def group[L <: HList](l: L, n: Nat, step: Nat)(implicit grouper: Grouper[L, n.N, step.N]) = grouper(l)
-
-    // partition a HList of 20 items into 5 (20/4) tuples of 4 items
+    // group HNil
+    assertEquals( HNil : HNil, (HNil: HNil) group (2,1) )
+    // group a HList of 20 items into 5 (20/4) tuples of 4 items
     assertEquals(
       (0, 1, 2, 3) ::(4, 5, 6, 7) ::(8, 9, 10, 11) ::(12, 13, 14, 15) ::(16, 17, 18, 19) :: HNil,
       range(0, 20) group (4, 4)
     )
 
-    // partition a HList of 22 items into 5 (20/4) tuples of 4 items
+    // group a HList of 22 items into 5 (20/4) tuples of 4 items
     // the last two items do not make a complete partition and are dropped.
     assertEquals(
       (0, 1, 2, 3) ::(4, 5, 6, 7) ::(8, 9, 10, 11) ::(12, 13, 14, 15) ::(16, 17, 18, 19) :: HNil,
@@ -2973,6 +2973,18 @@ class HListTests {
     assertEquals(
       (0, 1, 2, 3) ::(3, 4, 5, 6) ::(6, 7, 8, 9) ::(9, 10, 11, 12) ::(12, 13, 14, 15) ::(15, 16, 17, 18) :: HNil,
       range(0, 20) group (4, 3)
+    )
+
+    // when there are not enough items to fill the last partition, a pad can be supplied.
+    assertEquals(
+      (0, 1, 2) ::(6, 7, 8) ::(12, 13, 14) ::(18, 19, 'a') :: HNil,
+      range(0, 20) group (3, 6, 'a'::HNil)
+    )
+
+    // but only as many pad elements are used as necessary to fill the final partition.
+    assertEquals(
+      (0, 1, 2, 3) ::(6, 7, 8, 9) ::(12, 13, 14, 15) ::(18, 19, 'a', 'b') :: HNil,
+      range(0, 20) group (4, 6, 'a'::'b'::'c'::'d'::'e'::'f'::'g'::HNil)
     )
 
   }

--- a/core/src/test/scala/shapeless/nat.scala
+++ b/core/src/test/scala/shapeless/nat.scala
@@ -136,6 +136,21 @@ class NatTests {
     assertTypedEquals[HNil](HNil, r3())
     assertTypedEquals[_1::_2::_3::_4::HNil](_1::_2::_3::_4::HNil, r4())
 
+    // GCD tests
+
+    implicitly[GCD.Aux[_0, _0, _0]]
+    implicitly[GCD.Aux[_0, _1, _1]]
+    implicitly[GCD.Aux[_1, _0, _1]]
+    implicitly[GCD.Aux[_21, _14, _7]]
+    implicitly[GCD.Aux[_20, _10, _10]]
+
+    // LCM tests
+    implicitly[LCM.Aux[_0, _1, _0]]
+    implicitly[LCM.Aux[_1, _0, _0]]
+    implicitly[LCM.Aux[_2, _3, _6]]
+    implicitly[LCM.Aux[_4, _6, _12]]
+    implicitly[LCM.Aux[_3, _7, _21]]
+
     // Type level
     assertEquals(0, toInt[_0])
     assertEquals(1, toInt[_1])

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -516,6 +516,30 @@ class TupleTests {
   }
 
   @Test
+  def testToCoproduct {
+    import ops.tuple._
+
+    type PISB = (Int, String, Boolean)
+    type CISBa = Int :+: String :+: Boolean :+: CNil
+    type CISBb = the.`ToCoproduct[PISB]`.Out
+    implicitly[CISBa =:= CISBb]
+  }
+
+  @Test
+  def testToSum {
+    import ops.tuple._
+    
+    type PISB = (Int, String, Boolean)
+    type CISBa = Int :+: String :+: Boolean :+: CNil
+    type SISBa = the.`ToSum[PISB]`.Out
+    implicitly[CISBa =:= SISBa]
+
+    type PIISSB = (Int, Int, String, String, Boolean)
+    type SISBb = the.`ToSum[PIISSB]`.Out
+    implicitly[CISBa =:= SISBb]
+  }
+
+  @Test
   def testToList {
     import ops.tuple.ToList
 

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1775,8 +1775,8 @@ class TupleTests {
                                                             tupler: ops.hlist.Tupler.Aux[OutL, T]
       ) = tupler(mapper(range()))
 
-    //def group[T](t: T, n: Nat, step: Nat)(implicit grouper: ops.tuple.Grouper[T, n.N, step.N]) = grouper(t)
-
+    // group Unit
+    assertEquals( HNil : HNil, (HNil: HNil) group (2,1) )
 
     // partition a Tuple of 20 items into 5 (20/4) tuples of 4 items
     assertEquals(
@@ -1801,6 +1801,18 @@ class TupleTests {
     assertEquals(
       ((0, 1, 2, 3), (3, 4, 5, 6), (6, 7, 8, 9), (9, 10, 11, 12), (12, 13, 14, 15), (15, 16, 17, 18)),
       range(0, 20) group (4, 3)
+    )
+
+    // when there are not enough items to fill the last partition, a pad can be supplied.
+    assertEquals(
+      ((0, 1, 2), (6, 7, 8), (12, 13, 14), (18, 19, 'a')),
+      range(0, 20) group (3, 6, Tuple1('a'))
+    )
+
+    // but only as many pad elements are used as necessary to fill the final partition.
+    assertEquals(
+      ((0, 1, 2, 3), (6, 7, 8, 9), (12, 13, 14, 15), (18, 19, 'a', 'b')),
+      range(0, 20) group (4, 6, ('a', 'b', 'c', 'd', 'e', 'f', 'g'))
     )
 
   }


### PR DESCRIPTION
* ToSum implementation as discussed
* ToCoproduct was missing for tuples
* Grouper implementation (I would really like to call this `partition` but that one's taken already)
* PaddedGrouper implementation
* Greatest Common Divisor and Least Common Multiple for nat