### PR TITLE
Additional implicit resolutions for LT and LTEq

### DIFF
--- a/core/src/main/scala/shapeless/ops/nat.scala
+++ b/core/src/main/scala/shapeless/ops/nat.scala
@@ -148,13 +148,16 @@ object nat {
    */
   trait LTEq[A <: Nat, B <: Nat] extends Serializable
 
-  object LTEq {
+  object LTEq extends LTEq0 {
     def apply[A <: Nat, B <: Nat](implicit lteq: A <= B): LTEq[A, B] = lteq
 
+    implicit def ltEq1[A <: Nat] = new <=[A, A] {}
+  }
+
+  trait LTEq0 {
     type <=[A <: Nat, B <: Nat] = LTEq[A, B]
 
-    implicit def ltEq1 = new <=[_0, _0] {}
-    implicit def ltEq2[B <: Nat] = new <=[_0, Succ[B]] {}
+    implicit def ltEq2[B <: Nat] = new <=[_0, B] {}
     implicit def ltEq3[A <: Nat, B <: Nat](implicit lteq : A <= B) = new <=[Succ[A], Succ[B]] {}
   }
 

--- a/core/src/main/scala/shapeless/ops/nat.scala
+++ b/core/src/main/scala/shapeless/ops/nat.scala
@@ -132,13 +132,17 @@ object nat {
    */
   trait LT[A <: Nat, B <: Nat] extends Serializable
 
-  object LT {
+  object LT extends LT0 {
     def apply[A <: Nat, B <: Nat](implicit lt: A < B): LT[A, B] = lt
-
-    type <[A <: Nat, B <: Nat] = LT[A, B]
 
     implicit def lt1[B <: Nat] = new <[_0, Succ[B]] {}
     implicit def lt2[A <: Nat, B <: Nat](implicit lt : A < B) = new <[Succ[A], Succ[B]] {}
+  }
+
+  trait LT0 {
+    type <[A <: Nat, B <: Nat] = LT[A, B]
+
+    implicit def lt3[A <: Nat] = new <[A, Succ[A]] {}
   }
 
   /**
@@ -152,13 +156,14 @@ object nat {
     def apply[A <: Nat, B <: Nat](implicit lteq: A <= B): LTEq[A, B] = lteq
 
     implicit def ltEq1[A <: Nat] = new <=[A, A] {}
+    implicit def ltEq2[A <: Nat] = new <=[A, Succ[A]] {}
   }
 
   trait LTEq0 {
     type <=[A <: Nat, B <: Nat] = LTEq[A, B]
 
-    implicit def ltEq2[B <: Nat] = new <=[_0, B] {}
-    implicit def ltEq3[A <: Nat, B <: Nat](implicit lteq : A <= B) = new <=[Succ[A], Succ[B]] {}
+    implicit def ltEq3[B <: Nat] = new <=[_0, B] {}
+    implicit def ltEq4[A <: Nat, B <: Nat](implicit lteq : A <= B) = new <=[Succ[A], Succ[B]] {}
   }
 
   /**

--- a/core/src/test/scala/shapeless/nat.scala
+++ b/core/src/test/scala/shapeless/nat.scala
@@ -22,6 +22,8 @@ import org.junit.Assert._
 class NatTests {
   import nat._
   import ops.nat._
+
+  type N <: Nat
   
   trait Check[N <: Nat]
   def check(expected: Nat)(actually : => Check[expected.N]) {}
@@ -85,6 +87,8 @@ class NatTests {
     implicitly[LT[_10, _15]]
     implicitly[LTEq[_2, _2]]
     implicitly[LTEq[_2, _3]]
+    implicitly[LTEq[_0, N]]
+    implicitly[LTEq[N, N]]
 
     implicitly[Min.Aux[_0, _0, _0]]
     implicitly[Min.Aux[_5, _2, _2]]

--- a/core/src/test/scala/shapeless/nat.scala
+++ b/core/src/test/scala/shapeless/nat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-13 Miles Sabin 
+ * Copyright (c) 2011-15 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package shapeless
 
 import org.junit.Test
 import org.junit.Assert._
+import shapeless.test.illTyped
 
 class NatTests {
   import nat._
@@ -86,12 +87,20 @@ class NatTests {
     implicitly[LTEq[_2, _2]]
     implicitly[LTEq[_2, _3]]
 
+    illTyped(""" implicitly[LT[_5, _5]] """)
+    illTyped(""" implicitly[LTEq[_6, _5]] """)
+
     def relativeToN[N <: Nat]: Unit = {
       implicitly[LT[_0, Succ[N]]]
       implicitly[LT[N, Succ[N]]]
       implicitly[LTEq[_0, N]]
       implicitly[LTEq[N, N]]
       implicitly[LTEq[N, Succ[N]]]
+
+      illTyped(""" implicitly[LT[_0, N]] """)
+      illTyped(""" implicitly[LT[N, N]] """)
+      illTyped(""" implicitly[LTEq[_1, N]] """)
+      illTyped(""" implicitly[LTEq[Succ[N], N]] """)
     }
 
     implicitly[Min.Aux[_0, _0, _0]]

--- a/core/src/test/scala/shapeless/nat.scala
+++ b/core/src/test/scala/shapeless/nat.scala
@@ -87,8 +87,11 @@ class NatTests {
     implicitly[LTEq[_2, _3]]
 
     def relativeToN[N <: Nat]: Unit = {
+      implicitly[LT[_0, Succ[N]]]
+      implicitly[LT[N, Succ[N]]]
       implicitly[LTEq[_0, N]]
       implicitly[LTEq[N, N]]
+      implicitly[LTEq[N, Succ[N]]]
     }
 
     implicitly[Min.Aux[_0, _0, _0]]

--- a/core/src/test/scala/shapeless/nat.scala
+++ b/core/src/test/scala/shapeless/nat.scala
@@ -22,8 +22,6 @@ import org.junit.Assert._
 class NatTests {
   import nat._
   import ops.nat._
-
-  type N <: Nat
   
   trait Check[N <: Nat]
   def check(expected: Nat)(actually : => Check[expected.N]) {}
@@ -87,8 +85,11 @@ class NatTests {
     implicitly[LT[_10, _15]]
     implicitly[LTEq[_2, _2]]
     implicitly[LTEq[_2, _3]]
-    implicitly[LTEq[_0, N]]
-    implicitly[LTEq[N, N]]
+
+    def relativeToN[N <: Nat]: Unit = {
+      implicitly[LTEq[_0, N]]
+      implicitly[LTEq[N, N]]
+    }
 
     implicitly[Min.Aux[_0, _0, _0]]
     implicitly[Min.Aux[_5, _2, _2]]


### PR DESCRIPTION
This pull request modifies implicits for `LT` and `LTEq` so that the following cases are covered without the need for any additional knowledge about N (other than `N <: Nat`):

 - `_0 <= N`
 - `N <= N`
 - `N < Succ[N]`
 - `N <= Succ[N]`

See the added test cases.