### PR TITLE
Tiny documentation fix: use Record instead of Union in the Record example

### DIFF
--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -51,8 +51,8 @@ object record {
    * named argument syntax. Values of the type just defined can be created as follows,
    *
    * {{{
-   * val xyz = Union(x = 23, y = "foo", z = true)
-   * xyz.get('y) // == Some("foo")
+   * val xyz = Record(x = 23, y = "foo", z = true)
+   * xyz('y) // == "foo"
    * }}}
    */
   object Record extends Dynamic {


### PR DESCRIPTION
I suppose the scaladoc may have been partly copied from `Union`?