### PR TITLE
Replace global variants of Lazy / Strict by Cached

### DIFF
--- a/core/src/main/scala/shapeless/cached.scala
+++ b/core/src/main/scala/shapeless/cached.scala
@@ -1,0 +1,122 @@
+package shapeless
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+/**
+ * Wraps a cached implicit `T`.
+ *
+ * Looking for an implicit `Cached[T]` first triggers a look for an implicit `T`, caches the resulting
+ * tree, and returns it immediately and in subsequent look ups for an implicit `Cached[T]`. Thus,
+ * subsequent look ups do not trigger looking for an implicit `T`, only returning the instance kept in
+ * cache.
+ *
+ * Beware that if the contexts in which two subsequent look ups are different, so that looking for a
+ * `T` in each of them doesn't return the same result, this change would be ignored by caching. Looking
+ * for a `Cached[T]` in the first context would put the implicit `T` of this context in cache, and then
+ * looking for a `Cached[T]` in the second context would return the former instance from the first
+ * context. E.g.
+ *
+ * {{{
+ *   trait TC[T] {
+ *     def msg: String
+ *   }
+ *
+ *   object First {
+ *     implicit val tc: TC[Int] = new TC[Int] {
+ *       val msg = "first"
+ *     }
+ *
+ *     def print() = println(implicitly[TC[Int]].msg)
+ *     def printCached() = println(cached[TC[Int]].msg)
+ *   }
+ *
+ *   object Second {
+ *     implicit val tc: TC[Int] = new TC[Int] {
+ *       val msg = "second"
+ *     }
+ *
+ *     def print() = println(implicitly[TC[Int]].msg)
+ *     def printCached() = println(cached[TC[Int]].msg)
+ *   }
+ *
+ *   First.print()
+ *   Second.print()
+ *   First.printCached()
+ *   Second.printCached()
+ * }}}
+ *
+ * would print "first" then "second" (non cached `TC[Int]` instances), then "first" twice (first instance, returned
+ * the second time too through the cache).
+ *
+ * @author Alexandre Archambault
+ */
+case class Cached[+T](value: T) extends AnyVal
+
+object Cached {
+  implicit def materialize[I]: Cached[I] = macro CachedMacros.materialize[I]
+
+  def implicitly[T](implicit cached: Cached[T]): T = cached.value
+}
+
+object CachedMacros {
+  var deriving = false
+  var cache = List.empty[(Any, Any)]
+}
+
+class CachedMacros(val c: whitebox.Context) {
+  import c.universe._
+  import c.ImplicitCandidate
+
+  def materialize[T: WeakTypeTag]: Tree = {
+    // Getting the actual type parameter T, using the same trick as Lazy/Strict
+    val tpe = (c.openImplicits.headOption, weakTypeOf[T]) match {
+      case (Some(ImplicitCandidate(_, _, TypeRef(_, _, List(tpe)), _)), _) =>
+        tpe.map(_.dealias)
+      case (None, tpe) =>                                     // Non-implicit invocation
+        tpe
+      case _ =>
+        c.abort(c.enclosingPosition, s"Bad Cached materialization ${c.openImplicits.head}")
+    }
+
+    val concurrentLazy = !CachedMacros.deriving && LazyMacros.dcRef.nonEmpty
+
+    // Ensuring we are not caching trees derived during a Lazy/Strict lookup, as these trees
+    // can reference values (other entries of the Lazy/Strict derivation) that should not be
+    // accessible if re-using the tree in other contexts, after caching.
+    if (concurrentLazy)
+      println(
+        s"Warning: first Cached[$tpe] after a Lazy/Strict (at ${c.enclosingPosition})\n" +
+        "You might want to consider caching an implicit looked up for earlier, so that " +
+        "the first Lazy/Strict itself gets cached."
+      )
+
+    if (CachedMacros.deriving || concurrentLazy) {
+      // Caching only the first (root) Cached, not subsequent ones as here
+      val tree0 = c.inferImplicitValue(tpe)
+      if (tree0 == EmptyTree)
+        c.abort(c.enclosingPosition, s"Implicit $tpe not found")
+      q"_root_.shapeless.Cached($tree0)"
+    } else {
+      CachedMacros.deriving = true
+
+      try {
+        val treeOpt = CachedMacros.cache.asInstanceOf[List[(Type, Tree)]].collectFirst {
+          case (eTpe, eTree) if eTpe =:= tpe => eTree
+        }
+
+        treeOpt.getOrElse {
+          val tree0 = c.inferImplicitValue(tpe)
+          if (tree0 == EmptyTree)
+            c.abort(c.enclosingPosition, s"Implicit $tpe not found")
+          val tree = q"_root_.shapeless.Cached($tree0)"
+          CachedMacros.cache = (tpe -> tree) :: CachedMacros.cache
+          tree
+        }
+      } finally {
+        CachedMacros.deriving = false
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/shapeless/lazy.scala
+++ b/core/src/main/scala/shapeless/lazy.scala
@@ -131,33 +131,6 @@ object Lazy {
   def values[T <: HList](implicit lv: Lazy[Values[T]]): T = lv.value.values
 
   implicit def mkLazy[I]: Lazy[I] = macro LazyMacros.mkLazyImpl[I]
-
-
-  /**
-   * Wraps a lazily computed value, and circumvents implicit cycles / wrong implicit divergences, like `Lazy` does.
-   * Assumes that all the contexts it is called in are equivalent, and caches its calculations.
-   *
-   * Unlike `Lazy`, `Lazy.Global` assumes that all the contexts in which values wrapped in it are looked up, are all
-   * equivalent. This allows to cache the generated trees upon first call, and simply return the cached trees
-   * during subsequent calls.
-   *
-   * Shares its cache with `Strict.Cache`.
-   */
-  trait Global[+T] extends Lazy[T] {
-    override def map[U](f: T => U): Global[U] = Global { f(value) }
-    def flatMap[U](f: T => Global[U]): Global[U] = Global { f(value).value }
-  }
-
-  object Global {
-    implicit def apply[T](t: => T): Global[T] =
-      new Global[T] {
-        val value = t
-      }
-
-    def unapply[T](lt: Global[T]): Option[T] = Some(lt.value)
-
-    implicit def mkGlobal[I]: Global[I] = macro LazyMacros.mkGlobalLazyImpl[I]
-  }
 }
 
 object lazily {
@@ -188,33 +161,6 @@ object Strict {
   def unapply[T](lt: Strict[T]): Option[T] = Some(lt.value)
 
   implicit def mkStrict[I]: Strict[I] = macro LazyMacros.mkStrictImpl[I]
-
-
-  /**
-   * Wraps an eagerly computed value, and circumvents wrong implicit divergences, like `Strict`.
-   * Assumes all the contexts it is called are equivalent, and caches its calculations.
-   *
-   * Unlike `Strict`, `Strict.Global` assumes that all the contexts in which values wrapped in it are looked up, are all
-   * equivalent. This allows to cache the generated trees upon first call, and simply return the cached trees
-   * during subsequent calls.
-   *
-   * Shares its cache with `Lazy.Cache`.
-   */
-  trait Global[+T] extends Strict[T] {
-    override def map[U](f: T => U): Global[U] = Global { f(value) }
-    def flatMap[U](f: T => Global[U]): Global[U] = Global { f(value).value }
-  }
-
-  object Global {
-    implicit def apply[T](t: T): Global[T] =
-      new Global[T] {
-        val value = t
-      }
-
-    def unapply[T](lt: Global[T]): Option[T] = Some(lt.value)
-
-    implicit def mkGlobal[I]: Global[I] = macro LazyMacros.mkGlobalStrictImpl[I]
-  }
 }
 
 class LazyMacros(val c: whitebox.Context) {
@@ -224,39 +170,23 @@ class LazyMacros(val c: whitebox.Context) {
   def mkLazyImpl[I](implicit iTag: WeakTypeTag[I]): Tree =
     mkImpl[I](
       (tree, actualType) => q"_root_.shapeless.Lazy.apply[$actualType]($tree)",
-      q"null.asInstanceOf[_root_.shapeless.Lazy[Nothing]]",
-      None
+      q"null.asInstanceOf[_root_.shapeless.Lazy[Nothing]]"
     )
 
   def mkStrictImpl[I](implicit iTag: WeakTypeTag[I]): Tree =
     mkImpl[I](
       (tree, actualType) => q"_root_.shapeless.Strict.apply[$actualType]($tree)",
-      q"null.asInstanceOf[_root_.shapeless.Strict[Nothing]]",
-      None
+      q"null.asInstanceOf[_root_.shapeless.Strict[Nothing]]"
     )
 
-  def mkGlobalLazyImpl[I](implicit iTag: WeakTypeTag[I]): Tree =
-    mkImpl[I](
-      (tree, actualType) => q"_root_.shapeless.Lazy.Global.apply[$actualType]($tree)",
-      q"null.asInstanceOf[_root_.shapeless.Lazy.Global[Nothing]]",
-      Some("")
-    )
-
-  def mkGlobalStrictImpl[I](implicit iTag: WeakTypeTag[I]): Tree =
-    mkImpl[I](
-      (tree, actualType) => q"_root_.shapeless.Strict.Global.apply[$actualType]($tree)",
-      q"null.asInstanceOf[_root_.shapeless.Strict.Global[Nothing]]",
-      Some("")
-    )
-
-  def mkImpl[I](mkInst: (c.Tree, c.Type) => c.Tree, nullInst: => c.Tree, cacheOpt: Option[String])(implicit iTag: WeakTypeTag[I]): Tree = {
+  def mkImpl[I](mkInst: (c.Tree, c.Type) => c.Tree, nullInst: => c.Tree)(implicit iTag: WeakTypeTag[I]): Tree = {
     (c.openImplicits.headOption, iTag.tpe.dealias) match {
       case (Some(ImplicitCandidate(_, _, TypeRef(_, _, List(tpe)), _)), _) =>
-        LazyMacros.deriveInstance(c)(tpe.map(_.dealias), mkInst, cacheOpt)
+        LazyMacros.deriveInstance(c)(tpe.map(_.dealias), mkInst)
       case (None, tpe) if tpe.typeSymbol.isParameter =>       // Workaround for presentation compiler
         nullInst
       case (None, tpe) =>                                     // Non-implicit invocation
-        LazyMacros.deriveInstance(c)(tpe, mkInst, cacheOpt)
+        LazyMacros.deriveInstance(c)(tpe, mkInst)
       case _ =>
         c.abort(c.enclosingPosition, s"Bad Lazy materialization ${c.openImplicits.head}")
     }
@@ -264,50 +194,27 @@ class LazyMacros(val c: whitebox.Context) {
 }
 
 object LazyMacros {
-  var caches = Map.empty[String, List[(Any, Any)]]
-
   var dcRef: Option[DerivationContext] = None
 
-  def deriveInstance(c: whitebox.Context)(tpe: c.Type, mkInst: (c.Tree, c.Type) => c.Tree, cacheOpt: Option[String]): c.Tree = {
-    val cached =
-      if (dcRef.isEmpty)
-        cacheOpt.flatMap(caches.get).flatMap { cache =>
-          cache.collectFirst {
-            case (tpe0, v) if tpe0.asInstanceOf[c.Type] =:= tpe =>
-              v.asInstanceOf[c.Tree]
-          }
-        }
-      else
-        None
-
-    def derive: c.Tree = {
-      val (dc, root) =
-        dcRef match {
-          case None =>
-            val dc = DerivationContext(c)
-            dcRef = Some(dc)
-            (dc, true)
-          case Some(dc) =>
-            (DerivationContext.establish(dc, c), false)
-        }
-
-      if (root)
-        // Sometimes corrupted, and slows things too
-        c.universe.asInstanceOf[scala.tools.nsc.Global].analyzer.resetImplicits()
-
-      try {
-        dc.State.deriveInstance(tpe, root, mkInst)
-      } finally {
-        if(root) dcRef = None
+  def deriveInstance(c: whitebox.Context)(tpe: c.Type, mkInst: (c.Tree, c.Type) => c.Tree): c.Tree = {
+    val (dc, root) =
+      dcRef match {
+        case None =>
+          val dc = DerivationContext(c)
+          dcRef = Some(dc)
+          (dc, true)
+        case Some(dc) =>
+          (DerivationContext.establish(dc, c), false)
       }
-    }
 
-    cached.getOrElse{
-      val res = derive
-      if (dcRef.isEmpty)
-        for (cache <- cacheOpt)
-          LazyMacros.caches += cache -> ((tpe, res) :: LazyMacros.caches.getOrElse(cache, Nil))
-      res
+    if (root)
+      // Sometimes corrupted, and slows things too
+      c.universe.asInstanceOf[scala.tools.nsc.Global].analyzer.resetImplicits()
+
+    try {
+      dc.State.deriveInstance(tpe, root, mkInst)
+    } finally {
+      if(root) dcRef = None
     }
   }
 }

--- a/core/src/test/scala/shapeless/cached.scala
+++ b/core/src/test/scala/shapeless/cached.scala
@@ -1,0 +1,84 @@
+package shapeless
+
+import org.junit.Test
+
+object CachedTestsDefinitions {
+
+  trait Intermediate {
+    def repr: String
+  }
+
+  object Intermediate {
+    def apply()(implicit intm: Intermediate): Intermediate = intm
+
+    implicit val default: Intermediate =
+      new Intermediate {
+        val repr = "default"
+      }
+  }
+
+  object ScalaDocExample {
+    trait TC[T] {
+      def msg: String
+    }
+
+    object First {
+      implicit val tc: TC[Int] = new TC[Int] {
+        val msg = "first"
+      }
+
+      def msg = implicitly[TC[Int]].msg
+      def msgCached = Cached.implicitly[TC[Int]].msg
+    }
+
+    object Second {
+      implicit val tc: TC[Int] = new TC[Int] {
+        val msg = "second"
+      }
+
+      def msg = implicitly[TC[Int]].msg
+      def msgCached = Cached.implicitly[TC[Int]].msg
+    }
+  }
+
+}
+
+class CachedTests {
+  import CachedTestsDefinitions._
+
+  @Test
+  def simple {
+    val first = Intermediate()
+    val cachedFirst = Cached.implicitly[Intermediate]
+    assert(first.repr == "default")
+    assert(cachedFirst.repr == "default")
+
+    {
+      implicit val overrideIntm: Intermediate =
+        new Intermediate {
+          val repr = "override"
+        }
+
+      val second = Intermediate()
+      val cachedSecond = Cached.implicitly[Intermediate]
+      assert(second.repr == "override")
+      assert(cachedSecond.repr == "default")
+    }
+  }
+
+  @Test
+  def scalaDocExample {
+    import ScalaDocExample._
+    
+    val first = First.msg
+    val second = Second.msg
+    val firstCached = First.msgCached
+    val secondCached = Second.msgCached
+
+    assert(first == "first")
+    assert(second == "second")
+    assert(firstCached == "first")
+    assert(secondCached == "first")
+  }
+
+}

--- a/core/src/test/scala/shapeless/priority.scala
+++ b/core/src/test/scala/shapeless/priority.scala
@@ -271,9 +271,9 @@ trait ComposedDeriver[TC[_] <: {def msg(n: Int): String}] {
 
   implicit def mkTC[T]
    (implicit
-     priority: Strict.Global[Priority[TC[T], MkTC[T]]]
+     priority: Cached[Strict[Priority[TC[T], MkTC[T]]]]
    ): TC[T] =
-    priority.value.fold(identity)(_.tc)
+    priority.value.value.fold(identity)(_.tc)
 }
 
 
@@ -282,9 +282,9 @@ object SimpleTCDeriver extends SimpleDeriver[TC] {
 
   implicit def mkTC[T]
    (implicit
-     priority: Strict.Global[Priority[TC[T], MkTC[T]]]
+     priority: Cached[Strict[Priority[TC[T], MkTC[T]]]]
    ): TC[T] =
-    priority.value.fold(identity)(_.tc)
+    priority.value.value.fold(identity)(_.tc)
 }
 
 object ComposedTCDeriver extends ComposedDeriver[TC] {
@@ -296,9 +296,9 @@ object SimpleTC0Deriver extends SimpleDeriver[TC0] {
 
   implicit def mkTC[T]
    (implicit
-     priority: Strict.Global[Priority[Mask[Witness.`"TC0.defaultTC"`.T, TC0[T]], MkTC[T]]]
+     priority: Cached[Strict[Priority[Mask[Witness.`"TC0.defaultTC"`.T, TC0[T]], MkTC[T]]]]
    ): TC0[T] =
-    priority.value.fold(_.value)(_.tc)
+    priority.value.value.fold(_.value)(_.tc)
 }
 
 


### PR DESCRIPTION
This PR replaces `Strict.Global` and `Lazy.Global` from https://github.com/milessabin/shapeless/pull/435 by a more explicit type class, `Cached`. It is not necessarily summoned by `Lazy` / `Strict`, so it's put it at the root of the `shapeless` namespace.