### PR TITLE
Add new Remove and RemoveAll type classes for records

### DIFF
--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -29,7 +29,7 @@ class HListTests {
   import syntax.singleton._
   import syntax.typeable._
   import ops.hlist._
-  import ops.record._
+  import ops.record.SelectAll
 
   type SI = Set[Int] :: HNil
   type OI = Option[Int] :: HNil

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -25,6 +25,7 @@ class RecordTests {
   import syntax.singleton._
   import test._
   import testutil._
+  import ops.record.RemoveAll
 
   object intField1 extends FieldOf[Int]
   object intField2 extends FieldOf[Int]
@@ -423,6 +424,44 @@ class RecordTests {
     val r5 = r1 - "doubleField1"
     typed[FieldType[wIntField1.T, Int] :: FieldType[wStringField1.T, String] :: FieldType[wBoolField1.T, Boolean] :: HNil](r5)
     assertEquals(("intField1" ->> 23) :: ("stringField1" ->> "foo") :: ("boolField1" ->> true) :: HNil, r5)
+  }
+
+  @Test
+  def testRemoveAll {
+    type R = Record.`'i -> Int, 's -> String, 'c -> Char, 'j -> Int`.T
+    type L = Record.`'c -> Char, 'j -> Int`.T
+
+    type A1 = Record.`'i -> Int, 's -> String`.T
+    type A2 = Int :: String :: HNil
+
+    val r = 'i ->> 10 :: 's ->> "foo" :: 'c ->> 'x' :: 'j ->> 42 :: HNil
+
+    val removeAll1 = RemoveAll[R, A1]
+    val removeAll2 = RemoveAll[R, A2]
+
+    val (removed1, remaining1) = removeAll1(r)
+    val (removed2, remaining2) = removeAll2(r)
+
+    val r1 = removeAll1.reinsert((removed1, remaining1))
+    val r2 = removeAll2.reinsert((removed2, remaining2))
+
+    typed[A1](removed1)
+    assertEquals('i ->> 10 :: 's ->> "foo" :: HNil, removed1)
+
+    typed[A2](removed2)
+    assertEquals(10 :: "foo" :: HNil, removed2)
+
+    typed[L](remaining1)
+    assertEquals('c ->> 'x' :: 'j ->> 42 :: HNil, remaining1)
+
+    typed[L](remaining2)
+    assertEquals('c ->> 'x' :: 'j ->> 42 :: HNil, remaining2)
+
+    typed[R](r1)
+    assertEquals(r, r1)
+
+    typed[R](r2)
+    assertEquals(r, r2)
   }
 
   @Test


### PR DESCRIPTION
As discussed in #476. I've not added any syntax for these type classes, since `rec.remove(...)` would collide with the method for the `Remover` type class. I could add syntax if people think it would be useful and if we can come up with acceptable names.

I have [a branch of circe](https://github.com/travisbrown/circe/commit/564528fd05c8b9b0617ef89dde5d2207c94cf4d7) that uses this change instead of its own `Complement` type class.