### PR TITLE
Add Widen type class

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -257,7 +257,7 @@ object HasCoproductGeneric {
 
 trait ReprTypes {
   val c: blackbox.Context
-  import c.universe._
+  import c.universe.{ Symbol => _, _ }
 
   def hlistTpe = typeOf[HList]
   def hnilTpe = typeOf[HNil]
@@ -269,6 +269,7 @@ trait ReprTypes {
   def atatTpe = typeOf[tag.@@[_,_]].typeConstructor
   def fieldTypeTpe = typeOf[shapeless.labelled.FieldType[_, _]].typeConstructor
   def keyTagTpe = typeOf[shapeless.labelled.KeyTag[_, _]].typeConstructor
+  def symbolTpe = typeOf[Symbol]
 }
 
 trait CaseClassMacros extends ReprTypes {


### PR DESCRIPTION
Fixes https://github.com/milessabin/shapeless/issues/432.

Note that, as a peculiarity, there's no `Widen` instance available for types of singleton objects (like `case object O`), as these can't really be widen to another super type. This might be changed, but I'm fearing this would be inconvenient when using this to derive type classes for them (as type classes both as a singleton and as an empty case class through `Generic` would be available).