### PR TITLE
Introduced FieldType constructor on Witness

### DIFF
--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -181,8 +181,14 @@ trait SingletonTypeUtils extends ReprTypes {
   def parseType(typeStr: String): Option[c.Type] =
     parseStandardType(typeStr) orElse parseLiteralType(typeStr)
 
-  def typeCarrier(tpe: c.Type) = {
-    val carrier = c.typecheck(tq"{ type T = $tpe }", mode = c.TYPEmode).tpe
+  def typeCarrier(tpe: c.Type) =
+    mkTypeCarrier(tq"{ type T = $tpe }")
+
+  def fieldTypeCarrier(tpe: c.Type) =
+    mkTypeCarrier(tq"{ type T = $tpe ; type ->>[V] = Field[V] ; type Field[V] = shapeless.labelled.FieldType[$tpe,V] }")
+
+  def mkTypeCarrier(tree:c.Tree) = {
+    val carrier = c.typecheck(tree, mode = c.TYPEmode).tpe
 
     // We can't yield a useful value here, so return Unit instead which is at least guaranteed
     // to result in a runtime exception if the value is used in term position.
@@ -339,7 +345,7 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
       parseLiteralType(tpeString)
         .getOrElse(c.abort(c.enclosingPosition, s"Malformed literal $tpeString"))
 
-    typeCarrier(tpe)
+    fieldTypeCarrier(tpe)
   }
 
   def materializeWiden[T: WeakTypeTag, Out: WeakTypeTag]: Tree = {

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -36,7 +36,7 @@ class UnionTests {
   val sB = Witness('b)
   type b = sB.T
 
-  type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
+  type U = Witness.`'i`.Field[Int] :+: Witness.`'s`.Field[String] :+: Witness.`'b`.Field[Boolean] :+: CNil
 
   @Test
   def testGetLiterals {
@@ -132,7 +132,7 @@ class UnionTests {
     }
 
     {
-      type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
+      type U = Witness.`'i`.->>[Int] :+: Witness.`'s`.->>[String] :+: Witness.`'b`.->>[Boolean] :+: CNil
 
       val u0 = Inl('i ->> 23)
       val u1 = Inr(Inl('s ->> "foo"))
@@ -229,7 +229,7 @@ class UnionTests {
       assertTypedEquals(Coproduct[UF]('b.narrow -> true), f3)
     }
 
-    type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
+    type US = Witness.`"first"`.->>[Option[Int]] :+: Witness.`"second"`.->>[Option[Boolean]] :+: Witness.`"third"`.->>[Option[String]] :+: CNil
     val us1 = Coproduct[US]("first" ->> Option(2))
     val us2 = Coproduct[US]("second" ->> Option(true))
     val us3 = Coproduct[US]("third" ->> Option.empty[String])
@@ -273,7 +273,8 @@ class UnionTests {
       assertTypedEquals(Map[Symbol, Any]('b -> true), m3)
     }
 
-    type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
+    type US = Witness.`"first"`.->>[Option[Int]] :+: Witness.`"second"`.->>[Option[Boolean]] :+: Witness.`"third"`.->>[Option[String]] :+: CNil
+
     val us1 = Coproduct[US]("first" ->> Option(2))
     val us2 = Coproduct[US]("second" ->> Option(true))
     val us3 = Coproduct[US]("third" ->> Option.empty[String])
@@ -312,7 +313,7 @@ class UnionTests {
       val u2 = Union[U](s = "foo")
       val u3 = Union[U](b = true)
 
-      type R = Union.`'i -> Boolean, 's -> String, 'b -> String`.T
+      type R = Witness.`'i`.->>[Boolean] :+: Witness.`'s`.->>[String] :+: Witness.`'b`.->>[String] :+: CNil
 
       val res1 = u1.mapValues(f)
       val res2 = u2.mapValues(f)
@@ -329,7 +330,7 @@ class UnionTests {
         implicit def otherTypes[X] = at[X](identity)
       }
 
-      type U = Union.`"foo" -> String, "bar" -> Boolean, "baz" -> Double`.T
+      type U = Witness.`"foo"`.->>[String] :+: Witness.`"bar"`.->>[Boolean] :+: Witness.`"baz"`.->>[Double] :+: CNil
       val u1 = Coproduct[U]("foo" ->> "joe")
       val u2 = Coproduct[U]("bar" ->> true)
       val u3 = Coproduct[U]("baz" ->> 2.0)

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -36,7 +36,7 @@ class UnionTests {
   val sB = Witness('b)
   type b = sB.T
 
-  type U = Witness.`'i`.Field[Int] :+: Witness.`'s`.Field[String] :+: Witness.`'b`.Field[Boolean] :+: CNil
+  type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
 
   @Test
   def testGetLiterals {
@@ -132,7 +132,7 @@ class UnionTests {
     }
 
     {
-      type U = Witness.`'i`.->>[Int] :+: Witness.`'s`.->>[String] :+: Witness.`'b`.->>[Boolean] :+: CNil
+      type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
 
       val u0 = Inl('i ->> 23)
       val u1 = Inr(Inl('s ->> "foo"))
@@ -229,7 +229,7 @@ class UnionTests {
       assertTypedEquals(Coproduct[UF]('b.narrow -> true), f3)
     }
 
-    type US = Witness.`"first"`.->>[Option[Int]] :+: Witness.`"second"`.->>[Option[Boolean]] :+: Witness.`"third"`.->>[Option[String]] :+: CNil
+    type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
     val us1 = Coproduct[US]("first" ->> Option(2))
     val us2 = Coproduct[US]("second" ->> Option(true))
     val us3 = Coproduct[US]("third" ->> Option.empty[String])
@@ -273,8 +273,7 @@ class UnionTests {
       assertTypedEquals(Map[Symbol, Any]('b -> true), m3)
     }
 
-    type US = Witness.`"first"`.->>[Option[Int]] :+: Witness.`"second"`.->>[Option[Boolean]] :+: Witness.`"third"`.->>[Option[String]] :+: CNil
-
+    type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
     val us1 = Coproduct[US]("first" ->> Option(2))
     val us2 = Coproduct[US]("second" ->> Option(true))
     val us3 = Coproduct[US]("third" ->> Option.empty[String])
@@ -313,7 +312,7 @@ class UnionTests {
       val u2 = Union[U](s = "foo")
       val u3 = Union[U](b = true)
 
-      type R = Witness.`'i`.->>[Boolean] :+: Witness.`'s`.->>[String] :+: Witness.`'b`.->>[String] :+: CNil
+      type R = Union.`'i -> Boolean, 's -> String, 'b -> String`.T
 
       val res1 = u1.mapValues(f)
       val res2 = u2.mapValues(f)
@@ -330,7 +329,7 @@ class UnionTests {
         implicit def otherTypes[X] = at[X](identity)
       }
 
-      type U = Witness.`"foo"`.->>[String] :+: Witness.`"bar"`.->>[Boolean] :+: Witness.`"baz"`.->>[Double] :+: CNil
+      type U = Union.`"foo" -> String, "bar" -> Boolean, "baz" -> Double`.T
       val u1 = Coproduct[U]("foo" ->> "joe")
       val u2 = Coproduct[U]("bar" ->> true)
       val u3 = Coproduct[U]("baz" ->> 2.0)
@@ -343,5 +342,19 @@ class UnionTests {
       assertTypedEquals[U](Coproduct[U]("bar" ->> true), r2)
       assertTypedEquals[U](Coproduct[U]("baz" ->> 2.0), r3)
     }
+  }
+
+  @Test
+  def testAltSyntax: Unit = {
+    type U0 =
+    Witness.`"foo"`.->>[String] :+:
+      Witness.`"bar"`.->>[Boolean] :+:
+      Witness.`"baz"`.->>[Double] :+:
+      CNil
+
+    type U = Union.`"foo" -> String, "bar" -> Boolean, "baz" -> Double`.T
+
+    implicitly[U =:= U0]
+
   }
 }


### PR DESCRIPTION
Just added simple addition to Witness syntax to allow arbitrary Union and Record Types. Modified Union tests to take benefits of this syntax. 
```scala
//before
Union.`'a -> Int, 'b -> String, 'c–>Double`.T
// now
Witness.`'a`.->>[Int] :+:  Witness.`'a`.->>[Int]  :+: Witness.`'a`.->>[Int]  :+: CNil
// -- or --
Witness.`'a`.Field[Int] :+:  Witness.`'a`.Field[Int]  :+: Witness.`'a`.Field[Int]  :+: CNil 

```