### PR TITLE
Remove WitnessWith.Out in 2.10.x.

### DIFF
--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -61,7 +61,6 @@ object Witness extends Dynamic {
 
 trait WitnessWith[TC[_]] extends Witness {
   val instance: TC[T]
-  type Out
 }
 
 trait LowPriorityWitnessWith {
@@ -223,17 +222,12 @@ class SingletonTypeMacros[C <: Context](val c: C) extends SingletonTypeUtils[C] 
         case NullaryMethodType(resTpe) => resTpe
         case other => other
       }).normalize
-    val iOut = iTpe.member(newTypeName("Out")) match {
-      case NoSymbol => definitions.NothingClass
-      case other => other
-    }
 
     q"""
       {
         final class $name extends $parent {
           val instance: $iTpe = $i
           type T = $sTpe
-          type Out = $iOut
           val value: $sTpe = $s
         }
         new $name

--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -60,7 +60,8 @@ final class RecordOps[L <: HList](val l : L) extends AnyVal with Serializable {
   /**
    * Updates a field having a value with type A by given function.
    */
-  def updateWith[W](k: WitnessWith[FSL])(f: k.Out => W)(implicit modifier: Modifier[L, k.T, k.Out, W]): modifier.Out = modifier(l, f)
+  def updateWith[W](k: WitnessWith[FSL])(f: k.instance.Out => W)
+    (implicit modifier: Modifier[L, k.T, k.instance.Out, W]): modifier.Out = modifier(l, f)
   type FSL[K] = Selector[L, K]
 
   /**

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -519,7 +519,7 @@ class SingletonTypesTests {
     implicit def relFalse: Rel[False] { type Out = String } = new Rel[False] { type Out = String }
   }
 
-  def check(w: WitnessWith[Rel])(v: w.Out) = v
+  def check(w: WitnessWith[Rel])(v: w.instance.Out) = v
 
   @Test
   def testWitnessWithOut {


### PR DESCRIPTION
Fixed in 2.10.5 in https://github.com/scala/scala/pull/4303