### PR TITLE
Add macro-compat to enable Scala 2.10 in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 
 scala:
+- 2.10.6
 - 2.11.7
 - 2.12.0-M3
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ being [good candidates to take on][lowhangingfruit]. No contribution is too smal
 ## Using shapeless
 
 Binary release artefacts are published to the [Sonatype OSS Repository Hosting service][sonatype] and synced to Maven
-Central. Snapshots of the master and scala-2.10.x branches are built using [Travis CI][ci] and automatically published
-to the Sonatype OSS Snapshot repository. To include the Sonatype repositories in your SBT build you should add,
+Central. Snapshots of the master branch are built using [Travis CI][ci] and automatically published to the Sonatype
+OSS Snapshot repository. To include the Sonatype repositories in your SBT build you should add,
 
 ```scala
 resolvers ++= Seq(
@@ -179,10 +179,8 @@ releases][olderusage] on the shapeless wiki.
 
 ## Building shapeless
 
-shapeless is built with SBT 0.13.8 or later, and its master branch is built with Scala 2.11.7 by default. To build
-with Scala 2.10.x you should check out the scala-2.10.x branch. As a general rule all new features and bugfixes are
-made against master and Scala 2.11.7 and merged into the scala-2.10.x branch with only the minimal changes needed for
-forwards compatibility.
+shapeless is built with SBT 0.13.9 or later, and its master branch is built with Scala 2.11.7 by default but also
+cross-builds for 2.10.6 and 2.12.x.
 
 [namehashing]: https://github.com/sbt/sbt/issues/1640
 

--- a/core/src/main/scala/shapeless/annotation.scala
+++ b/core/src/main/scala/shapeless/annotation.scala
@@ -101,6 +101,7 @@ object Annotations {
   implicit def materialize[A, T, Out <: HList]: Aux[A, T, Out] = macro AnnotationMacros.materializeAnnotations[A, T, Out]
 }
 
+@macrocompat.bundle
 class AnnotationMacros(val c: whitebox.Context) extends CaseClassMacros {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/cached.scala
+++ b/core/src/main/scala/shapeless/cached.scala
@@ -64,6 +64,7 @@ object CachedMacros {
   var cache = List.empty[(Any, Any)]
 }
 
+@macrocompat.bundle
 class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) {
   import c.universe._
   import c.ImplicitCandidate

--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -208,6 +208,7 @@ object Default {
   }
 }
 
+@macrocompat.bundle
 class DefaultMacros(val c: whitebox.Context) extends CaseClassMacros {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -652,7 +652,7 @@ trait CaseClassMacros extends ReprTypes {
 
   def isAccessible(tpe: Type): Boolean = {
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c.asInstanceOf[reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val typerContext = typer.context
     typerContext.isAccessible(
       tpe.typeSymbol.asInstanceOf[global.Symbol],
@@ -667,7 +667,7 @@ trait CaseClassMacros extends ReprTypes {
     // also see https://github.com/scalamacros/paradise/issues/64
 
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c.asInstanceOf[reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val ctx = typer.context
     val owner = original.owner
 

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-15 Lars Hupel, Miles Sabin
+ * Copyright (c) 2012-16 Lars Hupel, Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,6 +255,7 @@ object HasCoproductGeneric {
   implicit def apply[T]: HasCoproductGeneric[T] = macro GenericMacros.mkHasCoproductGeneric[T]
 }
 
+@macrocompat.bundle
 trait ReprTypes {
   val c: blackbox.Context
   import c.universe.{ Symbol => _, _ }
@@ -272,7 +273,8 @@ trait ReprTypes {
   def symbolTpe = typeOf[Symbol]
 }
 
-trait CaseClassMacros extends ReprTypes {
+@macrocompat.bundle
+trait CaseClassMacros extends ReprTypes with CaseClassMacrosMixin {
   val c: whitebox.Context
 
   import c.universe._
@@ -340,7 +342,10 @@ trait CaseClassMacros extends ReprTypes {
     if(tSym.isClass && isAnonOrRefinement(tSym)) Nil
     else
       tpe.decls.toList collect {
-        case sym: TermSymbol if isCaseAccessorLike(sym) => (sym.name, sym.typeSignatureIn(tpe).finalResultType)
+        case sym: TermSymbol if isCaseAccessorLike(sym) =>
+          // BACKPORT: .toTermName is redundant and .finalResultType does the right things in 2.11+
+        //(sym.name, sym.typeSignatureIn(tpe).finalResultType)
+          (sym.name.toTermName, sym.typeSignatureIn(tpe).finalResultTpeForNullaryMethodType)
       }
   }
 
@@ -348,7 +353,9 @@ trait CaseClassMacros extends ReprTypes {
 
   def accessiblePrimaryCtorOf(tpe: Type): Option[Symbol] = {
     for {
-      ctor <- tpe.decls.find { sym => sym.isMethod && sym.asMethod.isPrimaryConstructor && isAccessible(sym.info) }
+      // BACKPORT: isAccessible requires 2.11+
+    //ctor <- tpe.decls.find { sym => sym.isMethod && sym.asMethod.isPrimaryConstructor && isAccessible(sym.info) }
+      ctor <- tpe.decls.find { sym => sym.isMethod && sym.asMethod.isPrimaryConstructor && isAccessibleOpt(sym.info) }
       if !ctor.isJava || productCtorsOf(tpe).size == 1
     } yield ctor
   }
@@ -652,7 +659,7 @@ trait CaseClassMacros extends ReprTypes {
 
   def isAccessible(tpe: Type): Boolean = {
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c2.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val typerContext = typer.context
     typerContext.isAccessible(
       tpe.typeSymbol.asInstanceOf[global.Symbol],
@@ -667,7 +674,7 @@ trait CaseClassMacros extends ReprTypes {
     // also see https://github.com/scalamacros/paradise/issues/64
 
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c2.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val ctx = typer.context
     val owner = original.owner
 
@@ -817,7 +824,9 @@ trait CaseClassMacros extends ReprTypes {
         def unapply(tpe: Type): Option[List[(TermName, Type)]] = {
           val companionTpe = sym.companion.info
           val applySym = companionTpe.member(TermName("apply"))
-          if(applySym.isTerm && !applySym.asTerm.isOverloaded && applySym.isMethod && !isNonGeneric(applySym) && isAccessible(applySym.info)) {
+          // BACKPORT: In 2.11+ can use the single param isAccessible
+        //if(applySym.isTerm && !applySym.asTerm.isOverloaded && applySym.isMethod && !isNonGeneric(applySym) && isAccessible(applySym.info)) {
+          if(applySym.isTerm && !applySym.asTerm.isOverloaded && applySym.isMethod && !isNonGeneric(applySym) && isAccessible(companionTpe, applySym)) {
             val applyParamss = applySym.asMethod.paramLists
             if(applyParamss.length == 1)
               alignFields(tpe, applyParamss.head.map(tpe => unByName(tpe.infoIn(companionTpe))))
@@ -830,7 +839,9 @@ trait CaseClassMacros extends ReprTypes {
         def unapply(tpe: Type): Option[List[Type]] = {
           val companionTpe = sym.companion.info
           val unapplySym = companionTpe.member(TermName("unapply"))
-          if(unapplySym.isTerm && !unapplySym.asTerm.isOverloaded && unapplySym.isMethod && !isNonGeneric(unapplySym) && isAccessible(unapplySym.info))
+          // BACKPORT: In 2.11+ can use the single param isAccessible
+        //if(unapplySym.isTerm && !unapplySym.asTerm.isOverloaded && unapplySym.isMethod && !isNonGeneric(unapplySym) && isAccessible(unapplySym.info))
+          if(unapplySym.isTerm && !unapplySym.asTerm.isOverloaded && unapplySym.isMethod && !isNonGeneric(unapplySym) && isAccessible(companionTpe, unapplySym))
             unapplySym.asMethod.infoIn(companionTpe).finalResultType.baseType(symbolOf[Option[_]]) match {
               case TypeRef(_, _, List(o @ TypeRef(_, _, args))) if o <:< typeOf[Product] => Some(args)
               case TypeRef(_, _, args @ List(arg)) => Some(args)
@@ -842,7 +853,9 @@ trait CaseClassMacros extends ReprTypes {
 
       object HasUniqueCtor {
         def unapply(tpe: Type): Option[List[(TermName, Type)]] = {
-          val ctorSym = tpe.decls.find { sym => sym.isMethod && sym.asMethod.isPrimaryConstructor && isAccessible(sym.info) }.getOrElse(NoSymbol)
+          // BACKPORT: In 2.11+ can use the single param isAccessible
+        //val ctorSym = tpe.decls.find { sym => sym.isMethod && sym.asMethod.isPrimaryConstructor && isAccessible(sym.info) }.getOrElse(NoSymbol)
+          val ctorSym = tpe.decls.find { sym => sym.isMethod && sym.asMethod.isPrimaryConstructor && isAccessible(tpe, sym) }.getOrElse(NoSymbol)
           if(!isNonGeneric(ctorSym)) {
             val ctorParamss = ctorSym.asMethod.infoIn(tpe).paramLists
             if(ctorParamss.length == 1)
@@ -949,6 +962,7 @@ trait CaseClassMacros extends ReprTypes {
   }
 }
 
+@macrocompat.bundle
 class GenericMacros(val c: whitebox.Context) extends CaseClassMacros {
   import c.universe._
   import internal.constantType

--- a/core/src/main/scala/shapeless/generic1.scala
+++ b/core/src/main/scala/shapeless/generic1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Miles Sabin
+ * Copyright (c) 2015-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,7 @@ trait Split10 {
     macro Split1Macros.mkSplit1Impl[L, FO, ({ type λ[t[_]] = FI[U, t] })#λ]
 }
 
+@macrocompat.bundle
 class Generic1Macros(val c: whitebox.Context) extends CaseClassMacros {
   import c.ImplicitCandidate
   import c.universe._
@@ -244,6 +245,7 @@ class Generic1Macros(val c: whitebox.Context) extends CaseClassMacros {
   }
 }
 
+@macrocompat.bundle
 class IsHCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
   import c.universe._
 
@@ -265,6 +267,7 @@ class IsHCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
     )
 }
 
+@macrocompat.bundle
 class IsCCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
   import c.universe._
 
@@ -292,6 +295,7 @@ class IsCCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
     )
 }
 
+@macrocompat.bundle
 trait IsCons1Macros extends CaseClassMacros {
   import c.ImplicitCandidate
   import c.universe._
@@ -346,6 +350,7 @@ trait IsCons1Macros extends CaseClassMacros {
   }
 }
 
+@macrocompat.bundle
 class Split1Macros(val c: whitebox.Context) extends CaseClassMacros {
   import c.ImplicitCandidate
   import c.universe._

--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin 
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,6 +198,7 @@ trait SingletonProductArgs extends Dynamic {
   def applyDynamic(method: String)(args: Any*): Any = macro ProductMacros.forwardSingletonImpl
 }
 
+@macrocompat.bundle
 class ProductMacros(val c: whitebox.Context) extends SingletonTypeUtils with NatMacroDefns {
   import c.universe._
   import internal.constantType
@@ -255,7 +256,7 @@ class ProductMacros(val c: whitebox.Context) extends SingletonTypeUtils with Nat
   def mkProductNatImpl(args: Seq[Tree]): Tree = {
     args.foldRight((hnilTpe, q"_root_.shapeless.HNil: $hnilTpe": Tree)) {
       case(elem, (accTpe, accTree)) =>
-        val matElem = c.typecheck(materializeWidened(elem))
+        val matElem = c.typecheck(materializeWidenedFn(elem))
         val (neTpe, neTree) = (matElem.tpe, matElem)
         (appliedType(hconsTpe, List(neTpe, accTpe)), q"""_root_.shapeless.::[$neTpe, $accTpe]($neTree, $accTree)""")
     }._2
@@ -264,7 +265,7 @@ class ProductMacros(val c: whitebox.Context) extends SingletonTypeUtils with Nat
   def mkProductNatTypeParamsImpl(args: Seq[Tree]): Tree = {
     args.foldRight((hnilTpe, tq"_root_.shapeless.HNil": Tree)) {
       case (elem, (accTpe, _)) =>
-        val matElem = c.typecheck(materializeWidened(elem))
+        val matElem = c.typecheck(materializeWidenedFn(elem))
         val neTpe = matElem.tpe
         (appliedType(hconsTpe, List(neTpe, accTpe)), tq"""_root_.shapeless.::[$neTpe, $accTpe]""")
     }._2

--- a/core/src/main/scala/shapeless/labelled.scala
+++ b/core/src/main/scala/shapeless/labelled.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-15 Miles Sabin
+ * Copyright (c) 2014-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ trait FieldOf[V] {
   def ->>(v: V): FieldType[this.type, V] = field[this.type](v)
 }
 
+@macrocompat.bundle
 class LabelledMacros(val c: whitebox.Context) extends SingletonTypeUtils with CaseClassMacros {
   import labelled._
   import c.universe._

--- a/core/src/main/scala/shapeless/lazy.scala
+++ b/core/src/main/scala/shapeless/lazy.scala
@@ -353,7 +353,7 @@ trait LazyDefinitions {
 
 }
 
-trait DerivationContext extends shapeless.CaseClassMacros with LazyDefinitions { ctx =>
+trait DerivationContext extends CaseClassMacros with LazyDefinitions { ctx =>
   import c.universe._
 
   object State {

--- a/core/src/main/scala/shapeless/nat.scala
+++ b/core/src/main/scala/shapeless/nat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,8 +72,16 @@ object Nat extends Nats {
   implicit def natOps[N <: Nat](n : N) : NatOps[N] = new NatOps(n)
 }
 
-class NatMacros(val c: whitebox.Context) extends NatMacroDefns
+@macrocompat.bundle
+class NatMacros(val c: whitebox.Context) extends NatMacroDefns {
+  import c.universe._
 
+  // BACKPORT: No need to hand-foward in 2.11+ (macro-compat bug milessabin/macro-compat#47)
+  def materializeSingleton(i: Tree): Tree = materializeSingletonFn(i)
+  def materializeWidened(i: Tree): Tree = materializeWidenedFn(i)
+}
+
+@macrocompat.bundle
 trait NatMacroDefns {
   val c: whitebox.Context
   import c.universe._
@@ -100,7 +108,7 @@ trait NatMacroDefns {
     mkNatTpt(n, Ident(_0Sym))
   }
 
-  def materializeSingleton(i: Tree): Tree = {
+  def materializeSingletonFn(i: Tree): Tree = {
     val natTpt = mkNatTpt(i)
     val moduleName = TermName(c.freshName("nat_"))
 
@@ -110,7 +118,7 @@ trait NatMacroDefns {
     """
   }
 
-  def materializeWidened(i: Tree): Tree = {
+  def materializeWidenedFn(i: Tree): Tree = {
     val natTpt = mkNatTpt(i)
 
     q""" new $natTpt """

--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ package record {
     def apply(l: HList): Any = HList.unsafeGet(l, i)
   }
 
+  @macrocompat.bundle
   class SelectorMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 
@@ -129,6 +130,7 @@ package record {
     def apply(l: HList, f: Any): HList = HList.unsafeUpdate(l, i, f)
   }
 
+  @macrocompat.bundle
   class UpdaterMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 

--- a/core/src/main/scala/shapeless/orphans.scala
+++ b/core/src/main/scala/shapeless/orphans.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Miles Sabin
+ * Copyright (c) 2015-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ trait OrphanDeriver[F[_], D] {
   implicit def materialize[T]: F[T] = macro OrphanMacros.materializeImpl[F, D, T]
 }
 
+@macrocompat.bundle
 class OrphanMacros(val c: whitebox.Context) extends CaseClassMacros {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/package.scala
+++ b/core/src/main/scala/shapeless/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14 Miles Sabin
+ * Copyright (c) 2013-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,7 @@ package object shapeless {
 }
 
 package shapeless {
+  @macrocompat.bundle
   class CachedImplicitMacros(val c: whitebox.Context) {
     import c.universe._
 

--- a/core/src/main/scala/shapeless/package.scala
+++ b/core/src/main/scala/shapeless/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14, 2016 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,7 @@ trait Poly0 extends Poly {
   }
 }
 
+@macrocompat.bundle
 class PolyMacros(val c: whitebox.Context) {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/priority.scala
+++ b/core/src/main/scala/shapeless/priority.scala
@@ -40,7 +40,7 @@ object Priority extends LazyExtensionCompanion {
 
   implicit def init[H, L]: Priority[H, L] = macro initImpl
 
-  def instantiate(ctx0: DerivationContext) =
+  def instantiate(ctx0: DerivationContext): LazyExtension { type Ctx = ctx0.type } =
     new PriorityLookupExtension {
       type Ctx = ctx0.type
       val ctx: ctx0.type = ctx0
@@ -75,7 +75,7 @@ object Mask {
 }
 
 
-trait PriorityTypes {
+trait PriorityTypes extends MacroCompatLite {
   type C <: whitebox.Context
   val c: C
 
@@ -171,7 +171,7 @@ trait PriorityLookupExtension extends LazyExtension with PriorityTypes {
               (tree0, actualTpe)
             else {
               val mTpe = internal.constantType(Constant(mask))
-              (q"_root_.shapeless.Mask.mkMask[$mTpe, $actualTpe]($tree0)", appliedType(maskTpe, List(mTpe, actualTpe)))
+              (q"_root_.shapeless.Mask.mkMask[$mTpe, $actualTpe]($tree0)", c.universe.appliedType(maskTpe, List(mTpe, actualTpe)))
             }
 
           val extState2 = extState1
@@ -180,7 +180,7 @@ trait PriorityLookupExtension extends LazyExtension with PriorityTypes {
           (
             update(state2, extState2),
             q"_root_.shapeless.Priority.High[$actualType]($tree)",
-            appliedType(highPriorityTpe, List(actualType))
+            c.universe.appliedType(highPriorityTpe, List(actualType))
           )
         }
     }
@@ -189,7 +189,7 @@ trait PriorityLookupExtension extends LazyExtension with PriorityTypes {
       ctx.derive(state)(lowInstTpe)
         .right.toOption
         .map{case (state1, inst) =>
-          (state1, q"_root_.shapeless.Priority.Low[${inst.actualTpe}](${inst.ident})", appliedType(lowPriorityTpe, List(inst.actualTpe)))
+          (state1, q"_root_.shapeless.Priority.Low[${inst.actualTpe}](${inst.ident})", c.universe.appliedType(lowPriorityTpe, List(inst.actualTpe)))
         }
 
     high.orElse(low) .map {case (state1, extInst, actualTpe) =>

--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-14 Miles Sabin
+ * Copyright (c) 2011-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ trait RecordArgs extends Dynamic {
   def applyDynamicNamed(method: String)(rec: Any*): Any = macro RecordMacros.forwardNamedImpl
 }
 
+@macrocompat.bundle
 class RecordMacros(val c: whitebox.Context) {
   import c.universe._
   import internal.constantType
@@ -142,7 +143,9 @@ class RecordMacros(val c: whitebox.Context) {
       q"$value.asInstanceOf[${mkFieldTpe(keyTpe, value.tpe)}]"
 
     def promoteElem(elem: Tree): Tree = elem match {
-      case q""" (${Literal(k: Constant)}, $v) """ => mkElem(mkSingletonSymbolType(k), v)
+      // BACKPORT: Requires 2.11
+      //case q""" (${Literal(k: Constant)}, $v) """ => mkElem(mkSingletonSymbolType(k), v)
+      case Apply(TypeApply(Select(_, _), List(_, _)), List(Literal(k: Constant), v)) => mkElem(mkSingletonSymbolType(k), v)
       case _ =>
         c.abort(c.enclosingPosition, s"$elem has the wrong shape for a record field")
     }

--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-14, 2016 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -202,9 +202,6 @@ trait SingletonTypeUtils extends ReprTypes {
 }
 
 class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
-  import syntax.SingletonOps
-  type SingletonOpsLt[Lub] = SingletonOps { type T <: Lub }
-
   import c.universe._
   import internal._
   import decorators._
@@ -270,7 +267,7 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
   }
 
   def extractResult(t: Tree)(mkResult: (Type, Tree) => Tree): Tree =
-    (t.tpe, t.tree) match {
+    (t.tpe, t) match {
       case (tpe @ ConstantType(c: Constant), _) =>
         mkResult(tpe, Literal(c))
 
@@ -287,7 +284,7 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
         mkResult(symTpe, q"$sym.asInstanceOf[$symTpe]")
 
       case _ =>
-        c.abort(c.enclosingPosition, s"Expression ${t.tree} does not evaluate to a constant or a stable reference value")
+        c.abort(c.enclosingPosition, s"Expression $t does not evaluate to a constant or a stable reference value")
     }
 
   def convertImpl(t: Tree): Tree = extractResult(t)(mkWitness)
@@ -331,11 +328,11 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
     extractResult(t) { (tpe, tree) => mkOps(tpe, mkWitness(tpe, tree)) }
 
   def narrowSymbol[S <: String : WeakTypeTag](t: Tree): Tree = {
-    (weakTypeOf[S], t.tree) match {
+    (weakTypeOf[S], t) match {
       case (ConstantType(Constant(s1: String)), LiteralSymbol(s2)) if s1 == s2 =>
         mkSingletonSymbol(s1)
       case _ =>
-        c.abort(c.enclosingPosition, s"Expression ${t.tree} is not an appropriate Symbol literal")
+        c.abort(c.enclosingPosition, s"Expression $t is not an appropriate Symbol literal")
     }
   }
 

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-15 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,7 @@ object Widen {
   implicit def materialize[T, Out]: Aux[T, Out] = macro SingletonTypeMacros.materializeWiden[T, Out]
 }
 
+@macrocompat.bundle
 trait SingletonTypeUtils extends ReprTypes {
   import c.universe.{ Try => _, _ }
   import internal._, decorators._
@@ -201,6 +202,7 @@ trait SingletonTypeUtils extends ReprTypes {
   }
 }
 
+@macrocompat.bundle
 class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
   import c.universe._
   import internal._
@@ -315,7 +317,7 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils {
 
         val parent = weakTypeOf[WitnessWith[({ type λ[X] = TC2[S, X] })#λ]].map {
           case TypeRef(prefix, sym, args) if sym.isFreeType =>
-            typeRef(NoPrefix, tc2.typeSymbol, args)
+            internal.typeRef(NoPrefix, tc2.typeSymbol, args)
           case tpe => tpe
         }
 

--- a/core/src/main/scala/shapeless/sized.scala
+++ b/core/src/main/scala/shapeless/sized.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin 
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import scala.collection.generic.{ CanBuildFrom, IsTraversableLike }
  * 
  * @author Miles Sabin
  */
-final class Sized[+Repr, L <: Nat] private (val unsized : Repr) extends AnyVal {
+final class Sized[+Repr, L <: Nat] private (val unsized : Repr) {
+  // BACKPORT: Cannot extend AnyVal in 2.10, see https://issues.scala-lang.org/browse/SI-6260
   override def toString = unsized.toString
 }
 

--- a/core/src/main/scala/shapeless/test/package.scala
+++ b/core/src/main/scala/shapeless/test/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016 Miles Sabin
+ * Copyright (c) 2014-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/shapeless/test/package.scala
+++ b/core/src/main/scala/shapeless/test/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Miles Sabin 
+ * Copyright (c) 2014, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ package object test {
   def showType[T](t: => T): String = macro TestMacros.showType[T]
 }
 
+@macrocompat.bundle
 class TestMacros(val c: blackbox.Context) {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/test/typechecking.scala
+++ b/core/src/main/scala/shapeless/test/typechecking.scala
@@ -38,8 +38,6 @@ class IllTypedMacros(val c: whitebox.Context) {
   def applyImplNoExp(code: Tree): Tree = applyImpl(code, null)
 
   def applyImpl(code: Tree, expected: Tree): Tree = {
-    import c.universe._
-
     val Literal(Constant(codeStr: String)) = code
     val (expPat, expMsg) = expected match {
       case null => (null, "Expected some error.")

--- a/core/src/main/scala/shapeless/test/typechecking.scala
+++ b/core/src/main/scala/shapeless/test/typechecking.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14, 2016 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/shapeless/test/typechecking.scala
+++ b/core/src/main/scala/shapeless/test/typechecking.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14 Miles Sabin
+ * Copyright (c) 2013-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ object illTyped {
   def apply(code: String, expected: String): Unit = macro IllTypedMacros.applyImpl
 }
 
+@macrocompat.bundle
 class IllTypedMacros(val c: whitebox.Context) {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/test/typetrace.scala
+++ b/core/src/main/scala/shapeless/test/typetrace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Miles Sabin 
+ * Copyright (c) 2015-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ object TypeTrace {
   implicit def apply[T]: TypeTrace[T] = macro TypeTraceMacros.applyImpl[T]
 }
 
+@macrocompat.bundle
 class TypeTraceMacros(val c: blackbox.Context) {
   import c.universe._
 

--- a/core/src/main/scala/shapeless/typeoperators.scala
+++ b/core/src/main/scala/shapeless/typeoperators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,7 @@ object the extends Dynamic {
   def selectDynamic(tpeSelector: String): Any = macro TheMacros.implicitlyImpl
 }
 
+@macrocompat.bundle
 class TheMacros(val c: whitebox.Context) {
   import c.universe.{ Try => _, _ }
   import internal._, decorators._

--- a/core/src/main/scala/shapeless/unions.scala
+++ b/core/src/main/scala/shapeless/unions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14, 2016 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/shapeless/unions.scala
+++ b/core/src/main/scala/shapeless/unions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14 Miles Sabin
+ * Copyright (c) 2013-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ object union {
   }
 }
 
+@macrocompat.bundle
 class UnionMacros(val c: whitebox.Context) {
   import c.universe._
   import internal.constantType
@@ -77,7 +78,9 @@ class UnionMacros(val c: whitebox.Context) {
       q"$value.asInstanceOf[${mkFieldTpe(keyTpe, value.tpe)}]"
 
     def promoteElem(elem: Tree): Tree = elem match {
-      case q""" (${Literal(k: Constant)}, $v) """ => mkElem(mkSingletonSymbolType(k), v)
+      // Backport: the quasiquote variant requires 2.11+
+    //case q""" (${Literal(k: Constant)}, $v) """ => mkElem(mkSingletonSymbolType(k), v)
+      case Apply(TypeApply(Select(_, _), List(_, _)), List(Literal(k: Constant), v)) => mkElem(mkSingletonSymbolType(k), v)
       case _ =>
         c.abort(c.enclosingPosition, s"$elem has the wrong shape for a record field")
     }

--- a/core/src/main/scala/shapeless/zipper.scala
+++ b/core/src/main/scala/shapeless/zipper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14 Miles Sabin
+ * Copyright (c) 2012-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,8 @@ object Zipper {
 
   def apply[L <: HList](l : L) : Zipper[L, HNil, L, None.type] = Zipper[L, HNil, L, None.type](HNil, l, None)
 
-  implicit class Modifier[C, L <: HList, RH, RT <: HList, P](private val zipper: Zipper[C, L, RH :: RT, P]) extends AnyVal {
+  // BACKPORT: Can't make the wrapped zipper a private val until 2.11+
+  implicit class Modifier[C, L <: HList, RH, RT <: HList, P](val zipper: Zipper[C, L, RH :: RT, P]) extends AnyVal {
     import ops.zipper._
     /** Modifies the element at the cursor by the use of function f. Available only if the underlying `HList` is non-empty. */
     def modify[E](f: RH => E)(implicit modify: Modify[zipper.Self, RH, E]): modify.Out = modify(zipper, f)

--- a/core/src/main/scala/shapeless/zipper.scala
+++ b/core/src/main/scala/shapeless/zipper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14, 2016 Miles Sabin
+ * Copyright (c) 2012-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala_2.10/shapeless/compat.scala
+++ b/core/src/main/scala_2.10/shapeless/compat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Miles Sabin
+ * Copyright (c) 2016 Miles Sabin, Dale Wijnand
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala_2.10/shapeless/compat.scala
+++ b/core/src/main/scala_2.10/shapeless/compat.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import scala.reflect.macros.{ blackbox, whitebox }
+
+trait DerivationContextCreator {
+  type Aux[C] = DerivationContext { val c: C }
+
+  def apply(c1: whitebox.Context): Aux[c1.type] = {
+    val c2 = c1.asInstanceOf[macrocompat.CompatContext[c1.type]]
+    class DerivationContextClass(val c: macrocompat.CompatContext[c1.type]) extends DerivationContext {
+      type C = c1.type
+    }
+    establish(new DerivationContextClass(c2), c1)
+  }
+
+  def establish(dc: DerivationContext, c: whitebox.Context): Aux[c.type] =
+    dc.asInstanceOf[Aux[c.type]]
+}
+
+trait MacroCompatLite {
+  val c: blackbox.Context
+  import c.universe._
+
+  implicit class TypeOps(tpe: Type) {
+    def dealias: Type = tpe.normalize
+  }
+
+  object internal {
+    def constantType(c: Constant): ConstantType = ConstantType(c)
+  }
+}
+
+trait CaseClassMacrosMixin {
+  val c: blackbox.Context
+  import c.universe._
+
+  protected def c2: blackbox.Context = c.asInstanceOf[macrocompat.CompatContext[c.type]].c
+
+  def isAccessibleOpt(tpe: Type): Boolean = true
+
+  def isAccessible(tpe: Type): Boolean
+
+  def isAccessible(pre: Type, sym: Symbol): Boolean = {
+    val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+    val typer = c2.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typerContext = typer.context
+    typerContext.isAccessible(
+      sym.asInstanceOf[global.Symbol],
+      pre.asInstanceOf[global.Type]
+    )
+  }
+
+  implicit class TypeWithFinalResultTpeForNullaryMethodType(tpe: Type) {
+    def finalResultTpeForNullaryMethodType: Type = {
+      val NullaryMethodType(restpe) = tpe
+      restpe
+    }
+  }
+}
+
+trait TypeableMacrosMixin {
+  val c: blackbox.Context
+  import c.universe._
+
+  implicit class TypeWrapperForExistentialType(tpe: Type) {
+    def dealiasForExistentialType: Type = tpe match {
+      case existential: ExistentialType => existential
+      case other => other.normalize
+    }
+
+    def typeArgsForExistentialType: List[Type] = {
+      val ExistentialType(_, underlying) = tpe
+      // From macro-compat
+      val typeArgs = underlying match {
+        case TypeRef(_, _, args) => args
+        case _ => Nil
+      }
+      typeArgs.map { tpe => if(tpe.typeSymbol.asType.isExistential) typeOf[Any] else tpe }
+    }
+  }
+}

--- a/core/src/main/scala_2.11+/shapeless/compat.scala
+++ b/core/src/main/scala_2.11+/shapeless/compat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Miles Sabin
+ * Copyright (c) 2016 Miles Sabin, Dale Wijnand
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala_2.11+/shapeless/compat.scala
+++ b/core/src/main/scala_2.11+/shapeless/compat.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import scala.reflect.macros.{ blackbox, whitebox }
+
+trait DerivationContextCreator {
+  type Aux[C] = DerivationContext { val c: C }
+
+  def apply(c1: whitebox.Context): Aux[c1.type] =
+    new DerivationContext { val c: c1.type = c1 }
+
+  def establish(dc: DerivationContext, c: whitebox.Context): Aux[c.type] =
+    dc.asInstanceOf[Aux[c.type]]
+}
+
+trait MacroCompatLite {
+  val c: blackbox.Context
+}
+
+trait CaseClassMacrosMixin {
+  val c: blackbox.Context
+  import c.universe._
+
+  protected def c2: blackbox.Context = c
+
+  def isAccessibleOpt(tpe: Type): Boolean = isAccessible(tpe)
+
+  def isAccessible(tpe: Type): Boolean
+
+  def isAccessible(pre: Type, sym: Symbol): Boolean = isAccessible(sym.info)
+
+  implicit class TypeWithFinalResultTpeForNullaryMethodType(tpe: Type) {
+    def finalResultTpeForNullaryMethodType: Type = tpe.finalResultType
+  }
+}
+
+trait TypeableMacrosMixin {
+  val c: blackbox.Context
+  import c.universe._
+
+  implicit class TypeWrapperForExistentialType(tpe: Type) {
+    def dealiasForExistentialType: Type = tpe.dealias
+    def typeArgsForExistentialType: List[Type] = tpe.typeArgs
+  }
+}

--- a/core/src/test/scala/shapeless/annotation.scala
+++ b/core/src/test/scala/shapeless/annotation.scala
@@ -1,17 +1,20 @@
 package shapeless
 
+import scala.annotation.{ Annotation => saAnnotation }
 import org.junit.Test
 import shapeless.test.illTyped
 
 object AnnotationTestsDefinitions {
 
-  case class First()
-  case class Second(i: Int, s: String)
+  // BACKPORT: No need to extend scala.annotation.Annotation in 2.11+
 
-  case class Other()
-  case class Last(b: Boolean)
+  case class First() extends saAnnotation
+  case class Second(i: Int, s: String) extends saAnnotation
 
-  case class Unused()
+  case class Other() extends saAnnotation
+  case class Last(b: Boolean) extends saAnnotation
+
+  case class Unused() extends saAnnotation
 
   @Other case class CC(
     @First i: Int,

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14 Miles Sabin
+ * Copyright (c) 2013-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import test._
 import testutil._
 
 import ops.coproduct._
+import ops.union._
+import union._
 
 class CoproductTests {
   type ISB = Int :+: String :+: Boolean :+: CNil
@@ -325,10 +327,6 @@ class CoproductTests {
   }
   @Test
   def testWithKeys {
-    import syntax.singleton._
-    import union._
-    import ops.union._
-
     type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
     val cKeys = Keys[U].apply()
 

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14, 2016 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala/shapeless/labelledgeneric.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-15 Miles Sabin
+ * Copyright (c) 2014-15, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,13 +77,6 @@ object LabelledGenericTestsAux {
     lazy val prev = prev0
     lazy val next = next0
   }
-}
-
-object ShapelessTaggedAux {
-  import tag.@@
-
-  trait CustomTag
-  case class Dummy(i: Int @@ CustomTag)
 }
 
 object ScalazTaggedAux {
@@ -388,15 +381,6 @@ class LabelledGenericTests {
   }
 
   @Test
-  def testShapelessTagged {
-    import ShapelessTaggedAux._
-
-    val lgen = LabelledGeneric[Dummy]
-    val s = s"${lgen from Record(i=tag[CustomTag](0))}"
-    assertEquals(s, "Dummy(0)")
-  }
-
-  @Test
   def testScalazTagged {
     import ScalazTaggedAux._
 
@@ -408,16 +392,8 @@ class LabelledGenericTests {
 
     implicitly[TC[Dummy]]
 
-    type R = Record.`'i -> Int @@ CustomTag`.T
-    val lgen = LabelledGeneric[Dummy]
-    implicitly[lgen.Repr =:= R]
-    implicitly[TC[R]]
-
     implicitly[TC[DummyTagged]]
 
-    type RT = Record.`'b -> Boolean, 'i -> Int @@ CustomTag`.T
-    val lgent = LabelledGeneric[DummyTagged]
-    implicitly[lgent.Repr =:= RT]
-    implicitly[TC[RT]]
+    // Note: Further tests in LabelledGeneric211Tests
   }
 }

--- a/core/src/test/scala/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala/shapeless/labelledgeneric.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-15, 2016 Miles Sabin
+ * Copyright (c) 2014-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/shapeless/priority.scala
+++ b/core/src/test/scala/shapeless/priority.scala
@@ -327,7 +327,7 @@ class PriorityTests {
     validateTC[(CC1, Int)]("(CC1, Int)")
     validateTC[(CC1, Boolean)]("(CC1, Boolean)")
 
-    Lazy.mkLazy[TC[CC2]]
+    // Note: Further tests in Priority211Tests
 
     // Derived, then orphans
     validateTC[CC2]("Generic[Int :: HNil]")

--- a/core/src/test/scala/shapeless/product.scala
+++ b/core/src/test/scala/shapeless/product.scala
@@ -237,14 +237,14 @@ class ProductTests {
       val l = e.toSized[List]
       val expected = Sized[List]()
       equalInferredTypes(expected, l)
-      assertTypedEquals(expected, l)
+      assertTypedEquals(expected.unsized, l.unsized)
     }
 
     {
       val a = e.toSized[Array]
       val expected = Sized[Array]()
       equalInferredTypes(expected, a)
-      assertArrayEquals0(expected, a)
+      assertArrayEquals0(expected.unsized, a.unsized)
     }
 
     val foo = Foo(1, "b")
@@ -253,14 +253,14 @@ class ProductTests {
       val l = foo.toSized[List]
       val expected = Sized[List](1, "b")
       equalInferredTypes(expected, l)
-      assertTypedEquals(expected, l)
+      assertTypedEquals(expected.unsized, l.unsized)
     }
 
     {
       val a = foo.toSized[Array]
       val expected = Sized[Array](1, "b")
       equalInferredTypes(expected, a)
-      assertArrayEquals0(expected, a)
+      assertArrayEquals0(expected.unsized, a.unsized)
     }
 
     val baz = Baz("a", foo)
@@ -269,14 +269,14 @@ class ProductTests {
       val l = baz.toSized[List]
       val expected = Sized[List]("a", foo)
       equalInferredTypes(expected, l)
-      assertTypedEquals(expected, l)
+      assertTypedEquals(expected.unsized, l.unsized)
     }
 
     {
       val a = baz.toSized[Array]
       val expected = Sized[Array]("a", foo)
       equalInferredTypes(expected, a)
-      assertArrayEquals0(expected, a)
+      assertArrayEquals0(expected.unsized, a.unsized)
     }
   }
   

--- a/core/src/test/scala/shapeless/serialization.scala
+++ b/core/src/test/scala/shapeless/serialization.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Miles Sabin
+ * Copyright (c) 2015-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,14 @@ object SerializationTestDefns {
   case class Wibble(i: Int, s: String)
 
   case class Box[T](t: T)
+
+  type K = HList.`'a, 'b, 'c`.T
+  type R = Record.`'a -> Int, 'b -> String, 'c -> Boolean`.T
+  type U = Union.`'a -> Int, 'b -> String, 'c -> Boolean`.T
+  type RM = Record.`'c -> Boolean, 'd -> Double`.T
+  type KA = Witness.`'a`.T
+  type KB = Witness.`'b`.T
+  type KC = Witness.`'c`.T
 
   sealed trait Tree[T]
   case class Leaf[T](t: T) extends Tree[T]
@@ -308,7 +316,6 @@ class SerializationTests {
     type LT = (Int, String) :: (Boolean, Double) :: (Char, Float) :: HNil
     type AL = (Int => Double) :: (String => Char) :: (Boolean => Float) :: HNil
     type I3 = Int :: Int :: Int :: HNil
-    type K = HList.`'a, 'b, 'c`.T
 
     assertSerializable(IsHCons[L])
 
@@ -502,11 +509,6 @@ class SerializationTests {
   def testRecords {
     import ops.record._
 
-    type R = Record.`'a -> Int, 'b -> String, 'c -> Boolean`.T
-    type RM = Record.`'c -> Boolean, 'd -> Double`.T
-    type KA = Witness.`'a`.T
-    type KB = Witness.`'b`.T
-    type KC = Witness.`'c`.T
     type FA = FieldType[KA, Int]
     type FB = FieldType[KB, String]
     type FC = FieldType[KC, Boolean]
@@ -557,7 +559,6 @@ class SerializationTests {
     type L = Int :+: String :+: Boolean :+: CNil
     type LP = String :+: Boolean :+: Int :+: CNil
     type BS = Boolean :+: String :+: CNil
-    type K = HList.`'a, 'b, 'c`.T
 
     assertSerializable(Inject[L, Int])
     assertSerializable(Inject[L, String])
@@ -665,10 +666,6 @@ class SerializationTests {
   def testUnions {
     import ops.union._
 
-    type U = Union.`'a -> Int, 'b -> String, 'c -> Boolean`.T
-    type KA = Witness.`'a`.T
-    type KB = Witness.`'b`.T
-
     assertSerializable(Selector[U, KA])
     assertSerializable(Selector[U, KB])
 
@@ -701,7 +698,6 @@ class SerializationTests {
     type LT = ((Int, String), (Boolean, Double), (Char, Float))
     type AL = ((Int => Double), (String => Char), (Boolean => Float))
     type I3 = (Int, Int, Int)
-    type K = HList.`'a, 'b, 'c`.T
 
     assertSerializable(IsComposite[L])
 

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14 Miles Sabin
+ * Copyright (c) 2013-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -273,8 +273,7 @@ class SingletonTypesTests {
     val wFoo = Witness(Foo)
     val wBar = Witness(bar)
 
-    typed[Foo.type](wFoo.value)
-    typed[bar.type](wBar.value)
+    // Note: Further tests in SingletonTypes211Tests
 
     val cFoo = convert(Foo)
     val cBar = convert(bar)
@@ -287,34 +286,6 @@ class SingletonTypesTests {
 
     sameTyped(bcFoo)(Witness(Foo))
     sameTyped(bcBar)(Witness(bar))
-  }
-
-  class PathDependentSingleton1 {
-    val o: AnyRef = new Object {}
-    val wO = Witness(o)
-    type OT = wO.T
-    implicitly[OT =:= o.type]
-
-    val x0: OT = wO.value
-    val x1: o.type = wO.value
-
-    val x2 = wO.value
-    typed[o.type](x2)
-    typed[OT](x2)
-  }
-
-  object PathDependentSingleton2 {
-    val o: AnyRef = new Object {}
-    val wO = Witness(o)
-    type OT = wO.T
-    implicitly[OT =:= o.type]
-
-    val x0: OT = wO.value
-    val x1: o.type = wO.value
-
-    val x2 = wO.value
-    typed[o.type](x2)
-    typed[OT](x2)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14, 2016 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -528,7 +528,7 @@ class TupleTests {
   @Test
   def testToSum {
     import ops.tuple._
-    
+
     type PISB = (Int, String, Boolean)
     type CISBa = Int :+: String :+: Boolean :+: CNil
     type SISBa = the.`ToSum[PISB]`.Out

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14 Miles Sabin
+ * Copyright (c) 2013-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -521,8 +521,10 @@ class TupleTests {
 
     type PISB = (Int, String, Boolean)
     type CISBa = Int :+: String :+: Boolean :+: CNil
-    type CISBb = the.`ToCoproduct[PISB]`.Out
-    implicitly[CISBa =:= CISBb]
+    val CISBb = ToCoproduct[PISB]
+    implicitly[CISBa =:= CISBb.Out]
+
+    // Note: Slightly different tests in Tuple211Tests
   }
 
   @Test
@@ -531,12 +533,14 @@ class TupleTests {
 
     type PISB = (Int, String, Boolean)
     type CISBa = Int :+: String :+: Boolean :+: CNil
-    type SISBa = the.`ToSum[PISB]`.Out
-    implicitly[CISBa =:= SISBa]
+    val SISBa = ToSum[PISB]
+    implicitly[CISBa =:= SISBa.Out]
 
     type PIISSB = (Int, Int, String, String, Boolean)
-    type SISBb = the.`ToSum[PIISSB]`.Out
-    implicitly[CISBa =:= SISBb]
+    val SISBb = ToSum[PIISSB]
+    implicitly[CISBa =:= SISBb.Out]
+
+    // Note: Slightly different tests in Tuple211Tests
   }
 
   @Test
@@ -1769,11 +1773,14 @@ class TupleTests {
     object toInt extends Poly1 {
       implicit def default[N <: Nat](implicit toi: ops.nat.ToInt[N]) = at[N](_ => toi())
     }
-    def range[R <: HList, T, OutL <: HList](a: Nat, b: Nat)(implicit
+
+    def range[R <: HList, OutL <: HList](a: Nat, b: Nat)(implicit
                                                             range: ops.nat.Range.Aux[a.N, b.N, R],
                                                             mapper: ops.hlist.Mapper.Aux[toInt.type, R, OutL],
-                                                            tupler: ops.hlist.Tupler.Aux[OutL, T]
-      ) = tupler(mapper(range()))
+                                                            tupler: ops.hlist.Tupler[OutL]
+      ): tupler.Out = tupler(mapper(range()))
+
+    // Note: Slightly different method signature in Tuple211Tests
 
     // group Unit
     assertEquals( (), () group (2,1) )

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-14, 2016 Miles Sabin
+ * Copyright (c) 2013-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/shapeless/typeoperators.scala
+++ b/core/src/test/scala/shapeless/typeoperators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-14, 2016 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/shapeless/typeoperators.scala
+++ b/core/src/test/scala/shapeless/typeoperators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-14 Miles Sabin
+ * Copyright (c) 2011-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,8 @@ class TypeOperatorTests {
       res
     }
 
-    def bar1[T, U0](implicit b: Bar[T] { type U = U0 }): Option[b.U] = {
+    // Note: Slightly different method signature in TypeOperator211Tests
+    def bar1[T, U0](implicit b: Bar[T] { type U = U0 }): Option[U0] = {
       val res: Option[the.`Bar[T]`.U] = None
       res
     }

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016 Miles Sabin
+ * Copyright (c) 2014-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Miles Sabin
+ * Copyright (c) 2014, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import org.junit.Test
 import org.junit.Assert._
 
 import labelled.FieldType
+import union._
+import syntax.singleton._
+import test._
+import testutil._
 
 class UnionTests {
-  import union._
-  import syntax.singleton._
-  import test._
-  import testutil._
 
   val wI = Witness('i)
   type i = wI.T

--- a/core/src/test/scala_2.11+/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala_2.11+/shapeless/labelledgeneric.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Test
+import org.junit.Assert._
+
+import record._
+
+object ShapelessTaggedAux {
+  import tag.@@
+
+  trait CustomTag
+  case class Dummy(i: Int @@ CustomTag)
+}
+
+class LabelledGeneric211Tests {
+
+  @Test
+  def testShapelessTagged {
+    import ShapelessTaggedAux._
+
+    val lgen = LabelledGeneric[Dummy]
+    val s = s"${lgen from Record(i=tag[CustomTag](0))}"
+    assertEquals(s, "Dummy(0)")
+  }
+
+  @Test
+  def testScalazTagged {
+    import ScalazTaggedAux._
+
+    type R = Record.`'i -> Int @@ CustomTag`.T
+    val lgen = LabelledGeneric[Dummy]
+    implicitly[lgen.Repr =:= R]
+    implicitly[TC[R]]
+
+    type RT = Record.`'b -> Boolean, 'i -> Int @@ CustomTag`.T
+    val lgent = LabelledGeneric[DummyTagged]
+    implicitly[lgent.Repr =:= RT]
+    implicitly[TC[RT]]
+  }
+
+}

--- a/core/src/test/scala_2.11+/shapeless/priority.scala
+++ b/core/src/test/scala_2.11+/shapeless/priority.scala
@@ -1,0 +1,16 @@
+package shapeless
+
+import Definitions._
+
+import org.junit.Test
+
+
+class Priority211Tests {
+
+  @Test
+  def simple {
+    import SimpleTCDeriver._
+    Lazy.mkLazy[TC[CC2]]
+  }
+
+}

--- a/core/src/test/scala_2.11+/shapeless/singletons.scala
+++ b/core/src/test/scala_2.11+/shapeless/singletons.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import shapeless.test._
+
+class SingletonTypes211Tests {
+
+  class NestingBug {
+    val o: AnyRef = new Object {}
+
+    val wO = {
+      final class W extends _root_.shapeless.Witness {
+        type T = o.type
+        val value: T = o
+      }
+      new W
+    }
+
+    // This fails on 2.10.x unless W is moved out of the block
+    // on the RHS of wO
+    val x1: o.type = wO.value
+  }
+
+  def testSingletonWitness {
+    trait Bound
+    object Foo extends Bound
+    val bar = "bar"
+    val wFoo = Witness(Foo)
+    val wBar = Witness(bar)
+
+    typed[Foo.type](wFoo.value)
+    typed[bar.type](wBar.value)
+  }
+
+  class PathDependentSingleton1 {
+    val o: AnyRef = new Object {}
+    val wO = Witness(o)
+    type OT = wO.T
+    implicitly[OT =:= o.type]
+
+    val x0: OT = wO.value
+    val x1: o.type = wO.value
+
+    val x2 = wO.value
+    typed[o.type](x2)
+    typed[OT](x2)
+  }
+
+  object PathDependentSingleton2 {
+    val o: AnyRef = new Object {}
+    val wO = Witness(o)
+    type OT = wO.T
+    implicitly[OT =:= o.type]
+
+    val x0: OT = wO.value
+    val x1: o.type = wO.value
+
+    val x2 = wO.value
+    typed[o.type](x2)
+    typed[OT](x2)
+  }
+
+}

--- a/core/src/test/scala_2.11+/shapeless/tuples.scala
+++ b/core/src/test/scala_2.11+/shapeless/tuples.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Test
+import org.junit.Assert._
+
+class Tuple211Tests {
+  import nat._
+  import syntax.std.tuple._
+
+  @Test
+  def testToCoproduct {
+    import ops.tuple._
+
+    type PISB = (Int, String, Boolean)
+    type CISBa = Int :+: String :+: Boolean :+: CNil
+    type CISBb = the.`ToCoproduct[PISB]`.Out
+    implicitly[CISBa =:= CISBb]
+  }
+
+  @Test
+  def testToSum {
+    import ops.tuple._
+
+    type PISB = (Int, String, Boolean)
+    type CISBa = Int :+: String :+: Boolean :+: CNil
+    type SISBa = the.`ToSum[PISB]`.Out
+    implicitly[CISBa =:= SISBa]
+
+    type PIISSB = (Int, Int, String, String, Boolean)
+    type SISBb = the.`ToSum[PIISSB]`.Out
+    implicitly[CISBa =:= SISBb]
+  }
+
+  @Test
+  def testGrouper {
+    object toInt extends Poly1 {
+      implicit def default[N <: Nat](implicit toi: ops.nat.ToInt[N]) = at[N](_ => toi())
+    }
+
+    def range[R <: HList, T, OutL <: HList](a: Nat, b: Nat)(implicit
+                                                            range: ops.nat.Range.Aux[a.N, b.N, R],
+                                                            mapper: ops.hlist.Mapper.Aux[toInt.type, R, OutL],
+                                                            tupler: ops.hlist.Tupler.Aux[OutL, T]
+      ) = tupler(mapper(range()))
+
+    // group Unit
+    assertEquals( (), () group (2,1) )
+
+    // partition a Tuple of 4 items into 2 (4/2) tuples of 2 items
+    assertEquals(
+      ((0, 1), (2, 3)),
+      range(0, 4) group(2, 2)
+    )
+
+    // partition a Tuple of 5 items into 2 (5/2) tuples of 2 items
+    // the last item does not make a complete partition and is dropped.
+    assertEquals(
+      ((0, 1), (2, 3)),
+      range(0, 5) group(2, 2)
+    )
+
+    // uses the step to select the starting point for each partition
+    assertEquals(
+      ((0, 1), (4, 5)),
+      range(0, 6) group(2, 4)
+    )
+
+    // if the step is smaller than the partition size, items will be reused
+    assertEquals(
+      ((0, 1), (1, 2), (2, 3)),
+      range(0, 4) group(2, 1)
+    )
+
+    // when there are not enough items to fill the last partition, a pad can be supplied.
+    assertEquals(
+      ((0, 1), (2, 3), (4, 'a')),
+      range(0, 5) group(2, 2, Tuple1('a'))
+    )
+
+    // but only as many pad elements are used as necessary to fill the final partition.
+    assertEquals(
+      ((0, 1), (2, 3), (4, 'a')),
+      range(0, 5) group(2, 2, ('a', 'b', 'c'))
+    )
+
+  }
+}

--- a/core/src/test/scala_2.11+/shapeless/typeoperators.scala
+++ b/core/src/test/scala_2.11+/shapeless/typeoperators.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Test
+
+import test._
+
+class TypeOperator211Tests {
+
+  trait Bar[T] {
+    type U
+    val tu: Either[T, U]
+  }
+
+  object Bar {
+    implicit def mkBar1: Bar[Boolean] { type U = Int } = new Bar[Boolean] { type U = Int ; val tu = Right(23) }
+    implicit def mkBar2: Bar[String] { type U = Double } = new Bar[String] { type U = Double ; val tu = Right(13.0) }
+  }
+
+  @Test
+  def testTheQuantifiers {
+    def bar0[T, U0](implicit b: Bar[T] { type U = U0 }): Bar[T] { type U = U0 } = {
+      val res = the[Bar[T]]
+      res
+    }
+
+    def bar1[T, U0](implicit b: Bar[T] { type U = U0 }): Option[b.U] = {
+      val res: Option[the.`Bar[T]`.U] = None
+      res
+    }
+
+    val b0 = bar0[Boolean, Int]
+    typed[Bar[Boolean] { type U = Int }](b0)
+
+    val b1 = bar1[Boolean, Int]
+    typed[Option[Int]](b1)
+  }
+
+}

--- a/examples/src/main/scala/shapeless/examples/partition.scala
+++ b/examples/src/main/scala/shapeless/examples/partition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14 Miles Sabin
+ * Copyright (c) 2012-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ object ADTPartitionExample extends App {
    * Partition a list into a record of lists for each constructor.
    */
   def partitionRecord[A, C <: Coproduct, Out <: HList](as: List[A])
-    (implicit gen: LabelledGeneric.Aux[A, C], partitioner: Partitioner.Aux[C, Out]) =
+    (implicit gen: LabelledGeneric.Aux[A, C], partitioner: Partitioner.Aux[C, Out]): Out =
       partitioner(as.map(gen.to))
 
   import ADTPartitionExampleTypes._

--- a/examples/src/main/scala/shapeless/examples/partition.scala
+++ b/examples/src/main/scala/shapeless/examples/partition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14, 2016 Miles Sabin
+ * Copyright (c) 2012-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/shapeless/examples/unfold.scala
+++ b/examples/src/main/scala/shapeless/examples/unfold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14 Miles Sabin 
+ * Copyright (c) 2012-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ object UnfoldExamples extends App {
         fsn : Case.Aux[Succ[N], (FSN, Succ[Succ[N]])],
         sum : Sum.Aux[FN, FSN, FSSN],
         fssn : Witness.Aux[FSSN]) =
-      at[Succ[Succ[N]]](_ => (fssn.value, Succ[Succ[Succ[N]]]))
+      at[Succ[Succ[N]]](_ => ((fssn.value: FSSN), Succ[Succ[Succ[N]]]))
   }
 
   object toInt extends Poly1 {

--- a/examples/src/main/scala/shapeless/examples/unfold.scala
+++ b/examples/src/main/scala/shapeless/examples/unfold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-14, 2016 Miles Sabin
+ * Copyright (c) 2012-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-14, 2016 Miles Sabin
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-14 Miles Sabin
+ * Copyright (c) 2011-14, 2016 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +61,10 @@ object ShapelessBuild extends Build {
         libraryDependencies ++= Seq(
           "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
           "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+          paradisePlugin,
+          "org.typelevel" %% "macro-compat" % "1.1.1-SNAPSHOT",
           "com.novocode" % "junit-interface" % "0.7" % "test"
-        ),
+        ) ++ quasiquotesLib.value.toSeq,
 
         (sourceGenerators in Compile) <+= (sourceManaged in Compile) map Boilerplate.gen,
         (sourceGenerators in Compile) <+= buildInfo,
@@ -135,6 +137,7 @@ object ShapelessBuild extends Build {
       libraryDependencies ++= Seq(
         // needs compiler for `scala.tools.reflect.Eval`
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+        paradisePlugin,
         "com.novocode" % "junit-interface" % "0.7" % "test"
       ),
 
@@ -152,8 +155,9 @@ object ShapelessBuild extends Build {
       libraryDependencies ++= Seq(
         // needs compiler for `scala.tools.reflect.Eval`
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+        paradisePlugin,
         "com.novocode" % "junit-interface" % "0.7" % "test"
-      ),
+      ) ++ quasiquotesLib.value.toSeq,
 
       runAllIn(Compile),
 
@@ -174,7 +178,7 @@ object ShapelessBuild extends Build {
     Seq(
       organization        := "com.chuusai",
       scalaVersion        := "2.11.7",
-      crossScalaVersions  := Seq("2.11.7", "2.12.0-M3"),
+      crossScalaVersions  := Seq("2.10.6", "2.11.7", "2.12.0-M3"),
 
       (unmanagedSourceDirectories in Compile) <<= (scalaSource in Compile)(Seq(_)),
       (unmanagedSourceDirectories in Test) <<= (scalaSource in Test)(Seq(_)),
@@ -187,6 +191,33 @@ object ShapelessBuild extends Build {
         "-deprecation",
         "-unchecked"),
 
+      resolvers += Opts.resolver.sonatypeSnapshots, // temp, for macro-compat
+
       initialCommands in console := """import shapeless._"""
-    )
+    ) ++ crossVersionSharedSources
+
+  val paradisePlugin = ("org.scalamacros"  % "paradise"    % "2.1.0").compilerPlugin cross CrossVersion.full
+  val quasiquotesLib = ("org.scalamacros" %% "quasiquotes" % "2.1.0").ifScala210
+
+  def scalaPartV = Def setting (CrossVersion partialVersion scalaVersion.value)
+
+  implicit final class AnyWithIfScala10[A](val __x: A) {
+    def ifScala210 = Def setting (scalaPartV.value collect { case (2, 10) => __x })
+  }
+
+  implicit final class ModuleIdWithCompilerPlugin(val __x: ModuleID) {
+    def compilerPlugin = sbt.compilerPlugin(__x)
+  }
+
+  lazy val crossVersionSharedSources: Seq[Setting[_]] =
+    Seq(Compile, Test).map { sc =>
+      (unmanagedSourceDirectories in sc) ++= {
+        (unmanagedSourceDirectories in sc ).value.map { dir: File =>
+          scalaPartV.value match {
+            case Some((2, y)) if y == 10 => new File(dir.getPath + "_2.10")
+            case Some((2, y)) if y >= 11 => new File(dir.getPath + "_2.11+")
+          }
+        }
+      }
+    }
 }


### PR DESCRIPTION
Required the creation of a compat.scala for 2.10/2.11+ for exceptions.

---

Given this depends on macro-compat version "1.2.0-SNAPSHOT", Travis will fail. Perhaps after an initial review, we can cut some kind of release of macro-compat and I'll update this pull request.

As always, I'm happy to rework even minor things, so feel free to review aggressively.

For a bit of scary trivial, `git grep` tells me that's 33 instances of "BACKPORT" added..