### PR TITLE
Fully qualify types in quasiquotes

### DIFF
--- a/core/src/main/scala/shapeless/cached.scala
+++ b/core/src/main/scala/shapeless/cached.scala
@@ -112,7 +112,7 @@ class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) {
           // https://github.com/fommil/spray-json-shapeless/issues/14.
           val tree = mkImpl[T](
             (tree, actualType) => q"_root_.shapeless.Cached[$actualType]($tree)",
-            q"null.asInstanceOf[_root_.shapeless.Cached[Nothing]]"
+            q"null.asInstanceOf[_root_.shapeless.Cached[_root_.scala.Nothing]]"
           )
 
           CachedMacros.cache = (tpe -> tree) :: CachedMacros.cache

--- a/core/src/main/scala/shapeless/lazy.scala
+++ b/core/src/main/scala/shapeless/lazy.scala
@@ -170,13 +170,13 @@ class LazyMacros(val c: whitebox.Context) {
   def mkLazyImpl[I](implicit iTag: WeakTypeTag[I]): Tree =
     mkImpl[I](
       (tree, actualType) => q"_root_.shapeless.Lazy.apply[$actualType]($tree)",
-      q"null.asInstanceOf[_root_.shapeless.Lazy[Nothing]]"
+      q"null.asInstanceOf[_root_.shapeless.Lazy[_root_.scala.Nothing]]"
     )
 
   def mkStrictImpl[I](implicit iTag: WeakTypeTag[I]): Tree =
     mkImpl[I](
       (tree, actualType) => q"_root_.shapeless.Strict.apply[$actualType]($tree)",
-      q"null.asInstanceOf[_root_.shapeless.Strict[Nothing]]"
+      q"null.asInstanceOf[_root_.shapeless.Strict[_root_.scala.Nothing]]"
     )
 
   def mkImpl[I](mkInst: (Tree, Type) => Tree, nullInst: => Tree)(implicit iTag: WeakTypeTag[I]): Tree = {

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -185,7 +185,7 @@ trait SingletonTypeUtils extends ReprTypes {
     mkTypeCarrier(tq"{ type T = $tpe }")
 
   def fieldTypeCarrier(tpe: Type) =
-    mkTypeCarrier(tq"{ type T = $tpe ; type ->>[V] = Field[V] ; type Field[V] = shapeless.labelled.FieldType[$tpe,V] }")
+    mkTypeCarrier(tq"{ type T = $tpe ; type ->>[V] = Field[V] ; type Field[V] = _root_.shapeless.labelled.FieldType[$tpe,V] }")
 
   def mkTypeCarrier(tree: Tree) = {
     val carrier = c.typecheck(tree, mode = c.TYPEmode).tpe


### PR DESCRIPTION
While browsing the sources I noticed some unqualified types in quasiquotes. They haven't caused any hygiene issues for me but I think those are potential bugs.