### PR TITLE
Add Unwrapped typeclass for unwrapping in codecs

### DIFF
--- a/core/src/main/scala/shapeless/syntax/unwrapped.scala
+++ b/core/src/main/scala/shapeless/syntax/unwrapped.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 Miles Sabin 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+package syntax
+
+object unwrapped {
+  implicit class UnwrappedSyntax[T](val t: T) extends AnyVal {
+    def unwrap[U](implicit uw: Unwrapped.Aux[T, U]): U = uw.unwrap(t)
+    def wrap[W](implicit uw: Unwrapped.Aux[W, T]): W = uw.wrap(t)
+  }
+}

--- a/core/src/main/scala/shapeless/unwrapped.scala
+++ b/core/src/main/scala/shapeless/unwrapped.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import newtype._
+
+trait Unwrapped[W] extends Serializable {
+  type U
+  def unwrap(w: W): U
+  def wrap(u: U): W
+}
+
+object Unwrapped extends UnwrappedInstances {
+  type Aux[W, U0] = Unwrapped[W] { type U = U0 }
+}
+
+trait UnwrappedInstances extends LowPriorityUnwrappedInstances {
+  implicit def unwrapAnyVal[W <: AnyVal, Repr, UI, UF](implicit
+    gen: Generic.Aux[W, Repr],
+    avh: AnyValHelper.Aux[Repr, UI],
+    chain: Strict[Unwrapped.Aux[UI, UF]]
+  ) = new Unwrapped[W] {
+    type U = UF
+    def unwrap(w: W): U = chain.value.unwrap(avh.unwrap(gen.to(w)))
+    def wrap(u: U): W = gen.from(avh.wrap(chain.value.wrap(u)))
+  }
+
+  sealed trait AnyValHelper[Repr] extends Serializable {
+    type U
+    def unwrap(r: Repr): U
+    def wrap(u: U): Repr
+  }
+  object AnyValHelper {
+    type Aux[Repr, U0] = AnyValHelper[Repr] { type U = U0 }
+    implicit def sizeOneHListHelper[T] = new AnyValHelper[T :: HNil] {
+      type U = T
+      def unwrap(hl: T :: HNil): T = hl.head
+      def wrap(t: T): T :: HNil = t :: HNil
+    }
+  }
+
+  implicit def newtypeUnwrapped[UI, Ops, UF](implicit chain: Strict[Unwrapped.Aux[UI, UF]])=
+    new Unwrapped[Newtype[UI, Ops]] {
+      type U = UF
+      def unwrap(n: Newtype[UI, Ops]): UF = chain.value.unwrap(n.asInstanceOf[UI])
+      def wrap(u: UF): Newtype[UI, Ops] = chain.value.wrap(u).asInstanceOf[Newtype[UI, Ops]]
+    }
+
+}
+
+trait LowPriorityUnwrappedInstances {
+  implicit def selfUnwrapped[T] =
+    new Unwrapped[T] {
+      type U = T
+      def unwrap(t: T) = t
+      def wrap(t: T) = t
+    }
+}

--- a/core/src/main/scala/shapeless/unwrapped.scala
+++ b/core/src/main/scala/shapeless/unwrapped.scala
@@ -47,27 +47,28 @@ trait UnwrappedInstances extends LowPriorityUnwrappedInstances {
   }
   object AnyValHelper {
     type Aux[Repr, U0] = AnyValHelper[Repr] { type U = U0 }
-    implicit def sizeOneHListHelper[T] = new AnyValHelper[T :: HNil] {
-      type U = T
-      def unwrap(hl: T :: HNil): T = hl.head
-      def wrap(t: T): T :: HNil = t :: HNil
+    implicit def sizeOneHListHelper[T] =
+      SizeOneHListHelper.asInstanceOf[AnyValHelper.Aux[T :: HNil, T]]
+    val SizeOneHListHelper = new AnyValHelper[Any :: HNil] {
+      type U = Any
+      def unwrap(hl: Any :: HNil): Any = hl.head
+      def wrap(t: Any): Any :: HNil = t :: HNil
     }
   }
 
-  implicit def newtypeUnwrapped[UI, Ops, UF](implicit chain: Strict[Unwrapped.Aux[UI, UF]])=
-    new Unwrapped[Newtype[UI, Ops]] {
-      type U = UF
-      def unwrap(n: Newtype[UI, Ops]): UF = chain.value.unwrap(n.asInstanceOf[UI])
-      def wrap(u: UF): Newtype[UI, Ops] = chain.value.wrap(u).asInstanceOf[Newtype[UI, Ops]]
-    }
+  implicit def newtypeUnwrapped[UI, Ops, UF](implicit
+    chain: Strict[Unwrapped.Aux[UI, UF]]
+  ) = chain.value.asInstanceOf[Unwrapped.Aux[Newtype[UI, Ops], UF]]
 
 }
 
 trait LowPriorityUnwrappedInstances {
-  implicit def selfUnwrapped[T] =
-    new Unwrapped[T] {
-      type U = T
-      def unwrap(t: T) = t
-      def wrap(t: T) = t
+  val theSelfUnwrapped =
+    new Unwrapped[Any] {
+      type U = Any
+      def unwrap(t: Any) = t
+      def wrap(t: Any) = t
     }
+  implicit def selfUnwrapped[T] =
+    theSelfUnwrapped.asInstanceOf[Unwrapped.Aux[T, T]]
 }

--- a/core/src/main/scala/shapeless/unwrapped.scala
+++ b/core/src/main/scala/shapeless/unwrapped.scala
@@ -26,6 +26,7 @@ trait Unwrapped[W] extends Serializable {
 
 object Unwrapped extends UnwrappedInstances {
   type Aux[W, U0] = Unwrapped[W] { type U = U0 }
+  def apply[W](implicit w: Unwrapped[W]): Aux[W, w.U] = w
 }
 
 trait UnwrappedInstances extends LowPriorityUnwrappedInstances {

--- a/core/src/test/scala/shapeless/unwrapped.scala
+++ b/core/src/test/scala/shapeless/unwrapped.scala
@@ -1,0 +1,150 @@
+
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Test
+
+object WrappedTests {
+  trait TestTag
+  case class AvWrapper(stringValue: String) extends AnyVal
+}
+import WrappedTests._
+
+class UnwrappedTests {
+
+  sealed trait Pass[T] {
+    type U
+    def actual(t: T): T
+    def unwrapped(t: T): U
+    def wrapped(u: U): T
+  }
+  object Pass {
+    type Aux[T, U0] = Pass[T] { type U = U0 }
+    implicit def unwrappedPasses[W, U0](implicit uw: Unwrapped.Aux[W, U0]): Pass.Aux[W, U0] =
+      new Pass[W] {
+        type U = U0
+        def actual(w: W): W = w
+        def unwrapped(w: W): U = uw.unwrap(w)
+        def wrapped(u: U): W = uw.wrap(u)
+      }
+  }
+
+  @Test
+  def testAnyVal: Unit = {
+    val pass = the[Pass[AvWrapper]]
+    the[pass.U =:= String]
+    val avw = AvWrapper("testing")
+    val actual = pass.actual(avw)
+    val wrapped = pass.wrapped(avw.stringValue)
+    val unwrapped = pass.unwrapped(avw)
+    assert((actual: AvWrapper) == avw)
+    assert((wrapped: AvWrapper) == avw)
+    assert((unwrapped: String) == avw.stringValue)
+  }
+
+  @Test
+  def testNewtype: Unit = {
+    import newtype._
+    case class MyStringOps(s: String) {
+      def stringValue: String = s
+    }
+    type MyString = Newtype[String, MyStringOps]
+    def MyString(s : String) : MyString = newtype(s)
+    implicit val mkOps = MyStringOps
+
+    val pass = the[Pass[MyString]]
+    the[pass.U =:= String]
+    val ms = MyString("testing")
+    val actual = pass.actual(ms)
+    val wrapped = pass.wrapped(ms.stringValue)
+    val unwrapped = pass.unwrapped(ms)
+    assert((actual: MyString) == ms)
+    assert((wrapped: MyString) == ms)
+    assert((unwrapped: String) == ms.stringValue)
+  }
+
+  @Test
+  def testScalazTagged: Unit = {
+
+    type Tagged[A, T] = { type Tag = T; type Self = A }
+    type @@[T, Tag] = Tagged[T, Tag]
+
+    def tag[U] = new Tagger[U]
+    class Tagger[U] {
+      def apply[T](t : T) : T @@ U = t.asInstanceOf[T @@ U]
+    }
+    def value[T](t: Tagged[T, _]): T = t.asInstanceOf[T]
+
+    implicit def taggedUnwrapped[UI, T, UF](implicit chain: Lazy[Unwrapped.Aux[UI, UF]]) =
+      new Unwrapped[UI @@ T] {
+        type U = UF
+        def unwrap(w: UI @@ T) = chain.value.unwrap(value(w))
+        def wrap(u: UF) = tag[T](chain.value.wrap(u))
+      }
+
+    val pass = the[Pass[String @@ TestTag]]
+    the[pass.U =:= String]
+    val tagged = tag[TestTag]("testing")
+    val actual = pass.actual(tagged)
+    val wrapped = pass.wrapped(value(tagged))
+    val unwrapped = pass.unwrapped(tagged)
+    assert((actual: String @@ TestTag) == tagged)
+    assert((wrapped: String @@ TestTag) == tagged)
+    assert((unwrapped: String) == value(tagged))
+    test.illTyped("unwrapped: String @@ TestTag")
+  }
+
+  @Test
+  def testAlreadyUnwrapped: Unit = {
+
+    val pass = the[Pass[String]]
+    the[pass.U =:= String]
+    val raw = "testing"
+    val actual = pass.actual(raw)
+    val wrapped = pass.wrapped(raw)
+    val unwrapped = pass.unwrapped(raw)
+    assert((actual: String) == raw)
+    assert((wrapped: String) == raw)
+    assert((unwrapped: String) == raw)
+  }
+
+  @Test
+  def unwrapsChain: Unit = {
+    import newtype._
+
+    case class MyStringOps(s: AvWrapper) {
+      def stringValue: String = s.stringValue
+    }
+    type MyString = Newtype[AvWrapper, MyStringOps]
+    def MyString(a: AvWrapper): MyString = newtype(a)
+    implicit val mkOps = MyStringOps
+
+
+    val ms = MyString(AvWrapper("testing"))
+
+    val pass = the[Pass[MyString]]
+    the[pass.U =:= String]
+    val actual = pass.actual(ms)
+    val wrapped = pass.wrapped(ms.stringValue)
+    val unwrapped = pass.unwrapped(ms)
+    assert((actual: MyString) == ms)
+    assert((wrapped: MyString) == ms)
+    assert((unwrapped: String) == ms.stringValue)
+  }
+
+}

--- a/core/src/test/scala/shapeless/unwrapped.scala
+++ b/core/src/test/scala/shapeless/unwrapped.scala
@@ -147,4 +147,13 @@ class UnwrappedTests {
     assert((unwrapped: String) == ms.stringValue)
   }
 
+  @Test
+  def testSyntax: Unit = {
+    import syntax.unwrapped._
+    val w = "testing".wrap[AvWrapper]
+    test.typed(w: AvWrapper)
+    val u = w.unwrap
+    test.typed(u: String)
+  }
+
 }

--- a/examples/src/main/scala/shapeless/examples/unwrapped.scala
+++ b/examples/src/main/scala/shapeless/examples/unwrapped.scala
@@ -1,0 +1,148 @@
+
+/*
+ * Copyright (c) 2016 Miles Sabin 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless.examples
+
+/**
+  * Using the Unwrapped typeclass to support serializing wrapper types in their
+  * unwrapped form
+  *
+  * @author Chris Hodapp
+  */
+object UnwrappedExamples {
+  import shapeless._
+  import shapeless.labelled._
+
+  // When working with data, it is useful to define types to help you keep track
+  // of what's what. For example, maybe users in your system have a numeric
+  // ID and two stringish attributes: a handle and an email address. That is,
+  // rather than defining your users as `case class User(id: String, Email: String)`,
+  // you might want to define them as:
+  case class Email(stringValue: String) extends AnyVal
+  case class UserHandle(stringValue: String) extends AnyVal
+  case class UserId(intValue: Int) extends AnyVal
+  case class User(id: UserId, handle: UserHandle, email: Email)
+
+  // This way, you can easily keep track of what's an email address and what's
+  // a handle as these things flow through your code. So far, so good. But... If
+  // you're using Shapeless, there's a good chance that one of the things you're
+  // doing with it is writing a system to automatically generate serialization
+  // codecs. For example:
+  trait Encode[-T] {
+    def toJson(t: T): String =
+      fields(t).map { case (k, v) => s""""$k":$v""" }.mkString("{", ",", "}")
+    def fields(t: T): Map[String, String]
+  }
+  object Encode {
+    implicit def encodeHNil = new Encode[HNil] {
+      def fields(hnil: HNil) = Map.empty
+    }
+    implicit def encodeHCons[
+      K <: Symbol,
+      V,
+      Rest <: HList
+    ](implicit
+      key: Witness.Aux[K],
+      encodeV: Lazy[EncodeValue[V]],
+      encodeRest: Strict[Encode[Rest]]
+    ) = new Encode[FieldType[K, V] :: Rest] {
+      def fields(hl: FieldType[K, V] :: Rest) =
+        encodeRest.value.fields(hl.tail) +
+          (key.value.name -> encodeV.value.toJsonFragment(hl.head))
+    }
+    // the magic one!
+    implicit def encodeGeneric[T, Repr](implicit
+      gen: LabelledGeneric.Aux[T, Repr],
+      encodeRepr: Lazy[Encode[Repr]]
+    ) = new Encode[T] {
+      def fields(t: T) = encodeRepr.value.fields(gen.to(t))
+    }
+  }
+
+  trait EncodeValue[-T] {
+    def toJsonFragment(t: T): String
+  }
+  object EncodeValue {
+    implicit lazy val encodeString =
+      new EncodeValue[String] {
+        def toJsonFragment(s: String) = s""""$s""""
+      }
+    implicit lazy val encodeInt =
+      new EncodeValue[Int] {
+        def toJsonFragment(i: Int) = s"""$i"""
+      }
+    implicit def encodeRoot[T](implicit r: Lazy[Encode[T]]) =
+      new EncodeValue[T] {
+        def toJsonFragment(t: T) = r.value.toJson(t)
+      }
+  }
+
+  // OK! Yay! Let's try it out!
+  val user = User(UserId(1234), UserHandle("jeffe"), Email("jeff@email.com"))
+  val encoder = the[Encode[User]]
+  println(encoder.toJson(user))
+  // {"email":{"stringValue":"jeff@email.com"},"handle":{"stringValue":"jeffe"},"id":{"intValue":1234}}
+
+  // Ah! Our wrapper types are bleeding into our serialized JSON! Well, I
+  // I guess maybe wrapper types aren't practical after all... Or maybe it's
+  // shapeless-generated codecs that aren't practical?!? Just kidding, everything's
+  // fine. We just need to use the Unwrapped typeclass in our serializers to cut
+  // through the wrapper types:
+
+  trait Encode2[-T] {
+    def toJson(t: T): String =
+      fields(t).map { case (k, v) => s""""$k":$v""" }.mkString("{", ",", "}")
+    def fields(t: T): Map[String, String]
+  }
+  object Encode2 {
+    implicit def encodeHNil = new Encode2[HNil] {
+      def fields(hnil: HNil) = Map.empty
+    }
+    implicit def encodeHCons[
+      K <: Symbol,
+      V,
+      U,
+      Rest <: HList
+    ](implicit
+      key: Witness.Aux[K],
+      uw: Strict[Unwrapped.Aux[V, U]],
+      encodeV: Lazy[EncodeValue[U]],
+      encodeRest: Strict[Encode2[Rest]]
+    ) = new Encode2[FieldType[K, V] :: Rest] {
+      def fields(hl: FieldType[K, V] :: Rest) =
+        encodeRest.value.fields(hl.tail) +
+          (key.value.name -> encodeV.value.toJsonFragment(uw.value.unwrap(hl.head)))
+    }
+    implicit def encodeGeneric[T, Repr](implicit
+      gen: LabelledGeneric.Aux[T, Repr],
+      encodeRepr: Lazy[Encode2[Repr]]
+    ) = new Encode2[T] {
+      def fields(t: T) = encodeRepr.value.fields(gen.to(t))
+    }
+  }
+  // OK! Let's try again
+  val encoder2 = the[Encode2[User]]
+  println(encoder2.toJson(user))
+  // {"email":"jeff@email.com","handle":"jeffe","id":1234}
+
+  // That's better.
+
+  // Note that there are a few more places you'd probably want to insert unwrapping
+  // if this was a real codec generator (basically, you'd likely want to remove
+  // wrappers on objects too, not just wrappers on their fields)
+
+}


### PR DESCRIPTION
This adds a new typeclass in order to support getting at the unwrapped thing inside of wrapper types (e.g. AnyVal wrappers and shapeless newtypes).

The key use case is codec generation, as most existing codec generators handle these types pretty terribly.

Check the included example for... well... an example