### PR TITLE
Remove path-dependent types in ops.hlists.Fill

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -2529,7 +2529,7 @@ object hlist {
   trait Fill[N, A] extends DepFn1[A] with Serializable { type Out <: HList }
 
   object Fill {
-    def apply[N, A](implicit fill: Fill[N, A]) = fill
+    def apply[N, A](implicit fill: Fill[N, A]): Aux[N, A, fill.Out] = fill
 
     type Aux[N, A, Out0] = Fill[N, A] { type Out = Out0 }
 
@@ -2539,17 +2539,17 @@ object hlist {
         def apply(elem: A) = HNil
       }
 
-    implicit def fill1Succ[N <: Nat, A]
-      (implicit prev: Fill[N, A]): Aux[Succ[N], A, A :: prev.Out] =
+    implicit def fill1Succ[N <: Nat, A, OutT <: HList]
+      (implicit prev: Aux[N, A, OutT]): Aux[Succ[N], A, A :: OutT] =
         new Fill[Succ[N], A] {
-          type Out = A :: prev.Out
+          type Out = A :: OutT
           def apply(elem: A) = elem :: prev(elem)
         }
 
-    implicit def fill2[A, N1 <: Nat, N2 <: Nat, SubOut]
-      (implicit subFill: Fill.Aux[N2, A, SubOut], fill: Fill[N1, SubOut]): Aux[(N1, N2), A, fill.Out] =
+    implicit def fill2[A, N1 <: Nat, N2 <: Nat, SubOut, OutT <: HList]
+      (implicit subFill: Aux[N2, A, SubOut], fill: Aux[N1, SubOut, OutT]): Aux[(N1, N2), A, OutT] =
         new Fill[(N1, N2), A] {
-          type Out = fill.Out
+          type Out = OutT
           def apply(elem: A) = fill(subFill(elem))
         }
   }


### PR DESCRIPTION
This fixes the issue I discussed today on Gitter, which is that the following code compilation time is exponential in the number of `Int`s in `HListOfInts`:

```
import shapeless.{HList, ::, HNil, Nat}
import shapeless.ops.hlist.{Length, Fill}

object Example {
  trait Exp[L]

  implicit def mkExp[L <: HList, N <: Nat]
    (implicit
      l: Length.Aux[L, N],
      f: Fill[N, Any]
    ): Exp[L] =
      new Object with Exp[L]

  type HListOfInts =
    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
    Int :: Int :: Int :: Int :: HNil

  val a = implicitly[Exp[HListOfInts]]
}
```

Thank you @alexarchambault for the solution :smile: