### PR TITLE
Fix #508: Perform a customized implicit search

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,10 +160,11 @@ lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
 lazy val crossVersionSharedSources: Seq[Setting[_]] =
   Seq(Compile, Test).map { sc =>
     (unmanagedSourceDirectories in sc) ++= {
-      (unmanagedSourceDirectories in sc ).value.map { dir: File =>
+      (unmanagedSourceDirectories in sc ).value.flatMap { dir: File =>
         CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((2, y)) if y == 10 => new File(dir.getPath + "_2.10")
-          case Some((2, y)) if y >= 11 => new File(dir.getPath + "_2.11+")
+          case Some((2, y)) if y == 10 => List(new File(dir.getPath + "_2.10"))
+          case Some((2, y)) if y >= 11 => List(new File(dir.getPath + "_2.11+"))
+          case Some((2, y)) if y >= 12 => List(new File(dir.getPath + "_2.11+"), new File(dir.getPath + "_2.12+"))
         }
       }
     }

--- a/core/shared/src/main/scala/shapeless/package.scala
+++ b/core/shared/src/main/scala/shapeless/package.scala
@@ -134,7 +134,9 @@ package shapeless {
       // the thing we are enclosed in
       val sCtx = tCtx.makeImplicit(true)
 
-      trait ImplicitSearchCompat extends analyzer.ImplicitsContextErrors { self: analyzer.ImplicitSearch =>
+      // 2.12 changed the signature on a method we need to override. In order to allow us to define
+      // both versions below with the "override" modifier, we need an interface that contains both.
+      trait CompatImplicitSearch extends analyzer.ImplicitsContextErrors { self: analyzer.ImplicitSearch =>
         import analyzer.global.{Type, Tree}
         import analyzer.{ImplicitInfo, Context}
         def AmbiguousImplicitError(
@@ -158,7 +160,7 @@ package shapeless {
         isView=false,
         context0=sCtx,
         pos0=c.enclosingPosition.asInstanceOf[global.Position]
-      ) with ImplicitSearchCompat {
+      ) with CompatImplicitSearch {
 
         import analyzer.global.{Type, Tree}
         import analyzer.{ImplicitInfo, Context}
@@ -193,11 +195,10 @@ package shapeless {
               s"""| $pre1 ${info1.sym.fullLocationString} of type ${info1.tpe}
                   | $pre2 ${info2.sym.fullLocationString} of type ${info2.tpe}
                   | $trailer""".stripMargin.trim
-            val msg = s"ambiguous implicit values:\n${coreMsg}match expected type $pt"
+            val msg = s"ambiguous implicit values:\n${coreMsg}\nmatch expected type $pt"
             c.abort(c.enclosingPosition, msg)
           }
         }
-
       }
 
       val best = is.bestImplicit

--- a/core/shared/src/main/scala/shapeless/package.scala
+++ b/core/shared/src/main/scala/shapeless/package.scala
@@ -115,27 +115,58 @@ package shapeless {
   class CachedImplicitMacros(val c: whitebox.Context) {
     import c.universe._
 
-    def dropLocal(nme: TermName): TermName = {
-      val LOCAL_SUFFIX_STRING = " "
-      val TermName(nmeString) = nme
-      if(nmeString endsWith LOCAL_SUFFIX_STRING)
-        TermName(nmeString.dropRight(LOCAL_SUFFIX_STRING.length))
-      else
-        nme
-    }
-
     def cachedImplicitImpl[T](implicit tTag: WeakTypeTag[T]): Tree = {
+      val casted = c.asInstanceOf[reflect.macros.runtime.Context]
+      val typer = casted.callsiteTyper
+      val global: casted.universe.type = casted.universe
+      val analyzer: global.analyzer.type = global.analyzer
+      val tCtx = typer.context
+      val owner = tCtx.owner
       val tTpe = weakTypeOf[T]
-      val owner = c.internal.enclosingOwner
-      val ownerNme = dropLocal(owner.name.toTermName)
-      val tpe = if(tTpe.typeSymbol.isParameter) owner.typeSignature else tTpe
-
-      q"""
-        {
-          def $ownerNme = ???
-          _root_.scala.Predef.implicitly[$tpe]
+      val application = casted.macroApplication
+      val tpe = {
+        if (tTpe.typeSymbol.isParameter) owner.tpe
+        else tTpe
+      }.asInstanceOf[global.Type]
+      // Run our own custom implicit search that isn't allowed to find
+      // the thing we are enclosed in
+      val sCtx = tCtx.makeImplicit(true)
+      val is = new analyzer.ImplicitSearch(
+        tree=application,
+        pt=tpe,
+        isView=false,
+        context0=sCtx,
+        pos0=c.enclosingPosition.asInstanceOf[global.Position]
+      ) {
+        override def searchImplicit(
+          implicitInfoss: List[List[analyzer.ImplicitInfo]],
+          isLocalToCallsite: Boolean
+        ): analyzer.SearchResult = {
+          val filteredInput = implicitInfoss.map { infos =>
+            infos.filter(_.sym.accessedOrSelf != owner)
+          }
+          super.searchImplicit(filteredInput, isLocalToCallsite)
         }
-      """
+      }
+      val best = is.bestImplicit
+      if (best.isFailure) {
+        val errs = sCtx.reporter.errors
+        errs.foreach { err =>
+          c.error(
+            err.errPos.asInstanceOf[Position],
+            err.errMsg
+          )
+        }
+        val errorMsg = tpe.typeSymbolDirect match {
+          case analyzer.ImplicitNotFoundMsg(msg) =>
+            msg.format(TermName("evidence").asInstanceOf[global.TermName], tpe)
+          case _ =>
+            s"Could not find an implict $tpe to cache"
+        }
+        c.abort(c.enclosingPosition, errorMsg)
+      } else {
+        best.tree.asInstanceOf[Tree]
+      }
     }
   }
 }

--- a/core/shared/src/main/scala/shapeless/package.scala
+++ b/core/shared/src/main/scala/shapeless/package.scala
@@ -115,6 +115,7 @@ package shapeless {
   class CachedImplicitMacros(val c: whitebox.Context) {
     import c.universe._
     import scala.reflect.macros.TypecheckException
+    import scala.util.matching.Regex
 
     def cachedImplicitImpl[T](implicit tTag: WeakTypeTag[T]): Tree = {
       val casted = c.asInstanceOf[reflect.macros.runtime.Context]
@@ -175,13 +176,50 @@ package shapeless {
           super.searchImplicit(filteredInput, isLocalToCallsite)
         }
 
+        // Lift a little bit of compiler code. This could be avoided
+        // by using variant sources
+        object ImplicitAmbiguousMsg {
+          import global._
+          val ImplicitAmbiguousClass = global.rootMirror.getClassIfDefined("scala.annotation.implicitAmbiguous")
+          def unapply(sym: global.Symbol): Option[Message] = {
+            val msg = sym.getAnnotation(ImplicitAmbiguousClass).flatMap { _.stringArg(0) }
+            msg.map(new Message(sym, _))
+          }
+          class Message(sym: Symbol, msg: String) {
+            private val Intersobralator = """\$\{\s*([^}\s]+)\s*\}""".r
+            private def interpolate(text: String, vars: Map[String, String]) =
+              Intersobralator.replaceAllIn(text, (_: Regex.Match) match {
+                  case Regex.Groups(v) => Regex quoteReplacement vars.getOrElse(v, "")
+              })
+            private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
+            def format(typeArgs: List[String]): String =
+              interpolate(msg, Map((typeParamNames zip typeArgs): _*))
+          }
+        }
+
         override def AmbiguousImplicitError(
           info1: ImplicitInfo, tree1: Tree,
           info2: ImplicitInfo, tree2: Tree,
           pre1: String, pre2: String,
           trailer: String
         )(isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context): Unit = {
-          AmbiguousImplicitError(info1, info2, pre1, pre2, trailer)(isView, pt, tree)
+
+          import global._
+
+          def treeTypeArgs(annotatedTree: Tree): List[String] = annotatedTree match {
+            case TypeApply(_, args) => args.map(_.toString)
+            case Block(_, Function(_, treeInfo.Applied(_, targs, _))) => targs.map(_.toString)
+            case _ => Nil
+          }
+
+          (info1.sym, info2.sym) match {
+            case (ImplicitAmbiguousMsg(msg), _) =>
+              c.abort(c.enclosingPosition, msg.format(treeTypeArgs(tree1)))
+            case (_, ImplicitAmbiguousMsg(msg)) =>
+              c.abort(c.enclosingPosition, msg.format(treeTypeArgs(tree2)))
+            case (_, _) =>
+              AmbiguousImplicitError(info1, info2, pre1, pre2, trailer)(isView, pt, tree)
+          }
         }
 
         override def AmbiguousImplicitError(

--- a/core/shared/src/main/scala/shapeless/package.scala
+++ b/core/shared/src/main/scala/shapeless/package.scala
@@ -133,27 +133,7 @@ package shapeless {
 
       // Run our own custom implicit search that isn't allowed to find
       // the thing we are enclosed in
-      val sCtx = tCtx.makeImplicit(true)
-
-      // 2.12 changed the signature on a method we need to override. In order to allow us to define
-      // both versions below with the "override" modifier, we need an interface that contains both.
-      trait CompatImplicitSearch extends analyzer.ImplicitsContextErrors { self: analyzer.ImplicitSearch =>
-        import analyzer.global.{Type, Tree}
-        import analyzer.{ImplicitInfo, Context}
-        def AmbiguousImplicitError(
-          info1: ImplicitInfo,
-          info2: ImplicitInfo,
-          pre1: String, pre2: String,
-          trailer: String
-        )(isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context): Unit
-
-        def AmbiguousImplicitError(
-            info1: ImplicitInfo, tree1: Tree,
-            info2: ImplicitInfo, tree2: Tree,
-            pre1: String, pre2: String,
-            trailer: String
-        )(isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context): Unit
-      }
+      val sCtx = tCtx.makeImplicit(false)
 
       val is = new analyzer.ImplicitSearch(
         tree=application,
@@ -161,7 +141,7 @@ package shapeless {
         isView=false,
         context0=sCtx,
         pos0=c.enclosingPosition.asInstanceOf[global.Position]
-      ) with CompatImplicitSearch {
+      ) {
 
         import analyzer.global.{Type, Tree}
         import analyzer.{ImplicitInfo, Context}
@@ -175,68 +155,6 @@ package shapeless {
           }
           super.searchImplicit(filteredInput, isLocalToCallsite)
         }
-
-        // Lift a little bit of compiler code. This could be avoided
-        // by using variant sources
-        object ImplicitAmbiguousMsg {
-          import global._
-          val ImplicitAmbiguousClass = global.rootMirror.getClassIfDefined("scala.annotation.implicitAmbiguous")
-          def unapply(sym: global.Symbol): Option[Message] = {
-            val msg = sym.getAnnotation(ImplicitAmbiguousClass).flatMap { _.stringArg(0) }
-            msg.map(new Message(sym, _))
-          }
-          class Message(sym: Symbol, msg: String) {
-            private val Intersobralator = """\$\{\s*([^}\s]+)\s*\}""".r
-            private def interpolate(text: String, vars: Map[String, String]) =
-              Intersobralator.replaceAllIn(text, (_: Regex.Match) match {
-                  case Regex.Groups(v) => Regex quoteReplacement vars.getOrElse(v, "")
-              })
-            private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
-            def format(typeArgs: List[String]): String =
-              interpolate(msg, Map((typeParamNames zip typeArgs): _*))
-          }
-        }
-
-        override def AmbiguousImplicitError(
-          info1: ImplicitInfo, tree1: Tree,
-          info2: ImplicitInfo, tree2: Tree,
-          pre1: String, pre2: String,
-          trailer: String
-        )(isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context): Unit = {
-
-          import global._
-
-          def treeTypeArgs(annotatedTree: Tree): List[String] = annotatedTree match {
-            case TypeApply(_, args) => args.map(_.toString)
-            case Block(_, Function(_, treeInfo.Applied(_, targs, _))) => targs.map(_.toString)
-            case _ => Nil
-          }
-
-          (info1.sym, info2.sym) match {
-            case (ImplicitAmbiguousMsg(msg), _) =>
-              c.abort(c.enclosingPosition, msg.format(treeTypeArgs(tree1)))
-            case (_, ImplicitAmbiguousMsg(msg)) =>
-              c.abort(c.enclosingPosition, msg.format(treeTypeArgs(tree2)))
-            case (_, _) =>
-              AmbiguousImplicitError(info1, info2, pre1, pre2, trailer)(isView, pt, tree)
-          }
-        }
-
-        override def AmbiguousImplicitError(
-          info1: ImplicitInfo,
-          info2: ImplicitInfo,
-          pre1: String, pre2: String,
-          trailer: String
-        )(isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context): Unit = {
-          if (!info1.tpe.isErroneous && !info2.tpe.isErroneous) {
-            val coreMsg =
-              s"""| $pre1 ${info1.sym.fullLocationString} of type ${info1.tpe}
-                  | $pre2 ${info2.sym.fullLocationString} of type ${info2.tpe}
-                  | $trailer""".stripMargin.trim
-            val msg = s"ambiguous implicit values:\n${coreMsg}\nmatch expected type $pt"
-            c.abort(c.enclosingPosition, msg)
-          }
-        }
       }
 
       val best = is.bestImplicit
@@ -245,7 +163,7 @@ package shapeless {
         c.abort(err.errPos.asInstanceOf[c.Position], err.errMsg)
       }
 
-      if (best.isFailure) {
+      if (best.isFailure || best.isAmbiguousFailure) {
 
         val errorMsg = tpe.typeSymbolDirect match {
           case analyzer.ImplicitNotFoundMsg(msg) =>

--- a/core/shared/src/test/scala/shapeless/implicits.scala
+++ b/core/shared/src/test/scala/shapeless/implicits.scala
@@ -69,7 +69,7 @@ class CachedTest {
     implicit val b = new Foo[String] { }
     illTyped(
       "cachedImplicit[Foo[String]]",
-      """ambiguous implicit values:.*"""
+      """ambiguous implicit values:.*|could not find an implicit.*"""
     )
   }
 

--- a/core/shared/src/test/scala/shapeless/implicits.scala
+++ b/core/shared/src/test/scala/shapeless/implicits.scala
@@ -22,6 +22,7 @@ import org.junit.Assert._
 trait CachedTC[T]
 object CachedTC {
   implicit def mkTC[T] = new CachedTC[T] {}
+  implicit val cached: CachedTC[String] = cachedImplicit
 }
 
 object CachedTest {
@@ -34,5 +35,21 @@ class CachedTest {
   @Test
   def testBasics {
     assertTrue(CachedTest.i != null)
+  }
+
+  trait Foo[A]
+  object Foo {
+    implicit def materialize[A]: Foo[A] = new Foo[A] {}
+  }
+
+  case class Bar(x: Int)
+  object Bar {
+    implicit val foo: Foo[Bar] = cachedImplicit
+  }
+
+  @Test
+  def testCompanion {
+    assertTrue(CachedTC.cached != null)
+    assertTrue(Bar.foo != null)
   }
 }

--- a/core/shared/src/test/scala/shapeless/implicits.scala
+++ b/core/shared/src/test/scala/shapeless/implicits.scala
@@ -19,6 +19,8 @@ package shapeless
 import org.junit.Test
 import org.junit.Assert._
 
+import test.illTyped
+
 trait CachedTC[T]
 object CachedTC {
   implicit def mkTC[T] = new CachedTC[T] {}
@@ -51,5 +53,32 @@ class CachedTest {
   def testCompanion {
     assertTrue(CachedTC.cached != null)
     assertTrue(Bar.foo != null)
+  }
+
+  @Test
+  def testDivergent {
+    illTyped(
+      "cachedImplicit[math.Ordering[Ordered[Int]]]",
+      "diverging implicit expansion for type .*"
+    )
+  }
+
+  @Test
+  def testAmbiguous {
+    implicit val a = new Foo[String] { }
+    implicit val b = new Foo[String] { }
+    illTyped(
+      "cachedImplicit[Foo[String]]",
+      """ambiguous implicit values:.*"""
+    )
+  }
+
+  @Test
+  def testNotFound {
+    trait T[X]
+    illTyped(
+      "cachedImplicit[T[String]]",
+      "could not find an implicit.*"
+    )
   }
 }

--- a/core/shared/src/test/scala/shapeless/implicits.scala
+++ b/core/shared/src/test/scala/shapeless/implicits.scala
@@ -81,4 +81,14 @@ class CachedTest {
       "could not find an implicit.*"
     )
   }
+
+  @Test
+  def testCustomMessage {
+    @annotation.implicitNotFound("custom message")
+    trait T[X]
+    illTyped(
+      "cachedImplicit[T[String]]",
+      "custom message"
+    )
+  }
 }

--- a/core/src/test/scala_2.12+/shapeless/implicits.scala
+++ b/core/src/test/scala_2.12+/shapeless/implicits.scala
@@ -29,8 +29,8 @@ class CachedTest212 {
   @Test
   def testAmbiguous {
     @annotation.implicitAmbiguous("Custom ambiguous message")
-    implicit val a = new Foo[String] { }
-    implicit val b = new Foo[String] { }
+    implicit def a = new Foo[String] { }
+    implicit def b = new Foo[String] { }
     illTyped(
       "cachedImplicit[Foo[String]]",
       "Custom ambiguous message"

--- a/core/src/test/scala_2.12+/shapeless/implicits.scala
+++ b/core/src/test/scala_2.12+/shapeless/implicits.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Test
+import org.junit.Assert._
+
+import test.illTyped
+
+class CachedTest212 {
+  import CachedTest._
+
+  trait Foo[A]
+
+  @Test
+  def testAmbiguous {
+    @annotation.implicitAmbiguous("Custom ambiguous message")
+    implicit val a = new Foo[String] { }
+    implicit val b = new Foo[String] { }
+    illTyped(
+      "cachedImplicit[Foo[String]]",
+      "Custom ambiguous message"
+    )
+  }
+
+}


### PR DESCRIPTION
This changes cachedImplicit to cause it to perform a customized implicit search that is not allowed to find the owner. Unfortunately, it makes us depend on compiler internals a bit, but that's the price you pay for doing advanced things in macros, I think.

Question, though: should this be merged with `the`?