### PR TITLE
Drop c2 in CaseClassMacrosMixin (compat.scala)

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -659,7 +659,7 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosMixin {
 
   def isAccessible(tpe: Type): Boolean = {
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c2.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val typerContext = typer.context
     typerContext.isAccessible(
       tpe.typeSymbol.asInstanceOf[global.Symbol],
@@ -674,7 +674,7 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosMixin {
     // also see https://github.com/scalamacros/paradise/issues/64
 
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c2.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val ctx = typer.context
     val owner = original.owner
 

--- a/core/src/main/scala_2.10/shapeless/compat.scala
+++ b/core/src/main/scala_2.10/shapeless/compat.scala
@@ -22,11 +22,11 @@ trait DerivationContextCreator {
   type Aux[C] = DerivationContext { val c: C }
 
   def apply(c1: whitebox.Context): Aux[c1.type] = {
-    val c2 = c1.asInstanceOf[macrocompat.CompatContext[c1.type]]
+    val cc = c1.asInstanceOf[macrocompat.CompatContext[c1.type]]
     class DerivationContextClass(val c: macrocompat.CompatContext[c1.type]) extends DerivationContext {
       type C = c1.type
     }
-    establish(new DerivationContextClass(c2), c1)
+    establish(new DerivationContextClass(cc), c1)
   }
 
   def establish(dc: DerivationContext, c: whitebox.Context): Aux[c.type] =
@@ -50,15 +50,13 @@ trait CaseClassMacrosMixin {
   val c: blackbox.Context
   import c.universe._
 
-  protected def c2: blackbox.Context = c.asInstanceOf[macrocompat.CompatContext[c.type]].c
-
   def isAccessibleOpt(tpe: Type): Boolean = true
 
   def isAccessible(tpe: Type): Boolean
 
   def isAccessible(pre: Type, sym: Symbol): Boolean = {
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val typer = c2.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
     val typerContext = typer.context
     typerContext.isAccessible(
       sym.asInstanceOf[global.Symbol],

--- a/core/src/main/scala_2.11+/shapeless/compat.scala
+++ b/core/src/main/scala_2.11+/shapeless/compat.scala
@@ -36,8 +36,6 @@ trait CaseClassMacrosMixin {
   val c: blackbox.Context
   import c.universe._
 
-  protected def c2: blackbox.Context = c
-
   def isAccessibleOpt(tpe: Type): Boolean = isAccessible(tpe)
 
   def isAccessible(tpe: Type): Boolean


### PR DESCRIPTION
.. given that now macrocompat.CompatContext is-a scala.reflect.macros.runtime.Context