### PR TITLE
Add ToSizedHList

### DIFF
--- a/core/src/main/scala/shapeless/ops/sizeds.scala
+++ b/core/src/main/scala/shapeless/ops/sizeds.scala
@@ -9,7 +9,7 @@ object sized {
    *
    * @author Alexandre Archambault
    */
-  trait ToHList[-Repr, L <: Nat] {
+  trait ToHList[-Repr, L <: Nat] extends Serializable {
     type Out <: HList
     def apply(s: Sized[Repr, L]): Out
   }

--- a/core/src/main/scala/shapeless/ops/traversables.scala
+++ b/core/src/main/scala/shapeless/ops/traversables.scala
@@ -57,7 +57,7 @@ object traversable {
    * 
    * @author Rob Norris
    */
-  trait ToSizedHList[CC[T] <: GenTraversable[T], A, N <: Nat] {
+  trait ToSizedHList[CC[T] <: GenTraversable[T], A, N <: Nat] extends Serializable {
     type Out
     def apply(cc: CC[A]): Out
   }

--- a/core/src/main/scala/shapeless/ops/traversables.scala
+++ b/core/src/main/scala/shapeless/ops/traversables.scala
@@ -51,4 +51,50 @@ object traversable {
           else for(h <- l.head.cast[OutH]; t <- flt(l.tail)) yield h :: t
     }
   }
+
+  /**
+   * Type class supporting type safe conversion of `Traversables` to `HLists` of a specific length.
+   * 
+   * @author Rob Norris
+   */
+  trait ToSizedHList[CC[T] <: GenTraversable[T], A, N <: Nat] {
+    type Out
+    def apply(cc: CC[A]): Out
+  }
+
+  /**
+   * `ToSizedHList` type class instances.
+   * 
+   * @author Rob Norris
+   */
+  object ToSizedHList {
+
+    def apply[CC[T] <: GenTraversable[T], A, N <: Nat](
+      implicit ev: ToSizedHList[CC, A, N]
+    ): ToSizedHList.Aux[CC, A, N, ev.Out] = 
+      ev
+
+    import syntax.sized._
+    import ops.nat._
+    import ops.sized._
+
+    type Aux[CC[T] <: GenTraversable[T], A, N <: Nat, Out0] =
+      ToSizedHList[CC, A, N] {
+        type Out = Out0
+      }
+
+    implicit def instance[CC[T] <: GenTraversable[T], A, N <: Nat](
+      implicit gt: CC[A] => GenTraversableLike[A, CC[A]], 
+               ac: AdditiveCollection[CC[A]],
+               ti: ToInt[N], 
+               th: ToHList[CC[A], N]
+    ): Aux[CC, A, N, Option[th.Out]] =
+      new ToSizedHList[CC, A, N] {
+        type Out = Option[th.Out]
+        def apply(as: CC[A]): Out =
+          as.sized[N].map(_.toHList)
+      }
+
+  }
+
 }

--- a/core/src/main/scala/shapeless/syntax/std/traversables.scala
+++ b/core/src/main/scala/shapeless/syntax/std/traversables.scala
@@ -27,13 +27,21 @@ import scala.collection.GenTraversable
  * typed [[shapeless.HList]] if possible. 
  * 
  * @author Miles Sabin
+ * @author Rob Norris
  */
 object traversable {
   implicit def traversableOps[T <% GenTraversable[_]](t : T) = new TraversableOps(t)
+  implicit def traversableOps2[CC[T] <: GenTraversable[T], A](as: CC[A]) = new TraversableOps2(as)
 }
 
 final class TraversableOps[T <% GenTraversable[_]](t : T) {
   import ops.traversable._
 
   def toHList[L <: HList](implicit fl : FromTraversable[L]) : Option[L] = fl(t)
+}
+
+final class TraversableOps2[CC[T] <: GenTraversable[T], A](as: CC[A]) {
+  import ops.traversable._
+
+  def toSizedHList(n: Nat)(implicit ts: ToSizedHList[CC, A, n.N]): ts.Out = ts(as)
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -34,6 +34,8 @@ class HListTests {
   type SI = Set[Int] :: HNil
   type OI = Option[Int] :: HNil
 
+  type III = Int :: Int :: Int :: HNil
+
   type SISS = Set[Int] :: Set[String] :: HNil
   type OIOS = Option[Int] :: Option[String] :: HNil
 
@@ -3136,4 +3138,12 @@ class HListTests {
     illTyped(""" (1 :: "a" :: 3 :: HNil).slice(0, 4) """)
     illTyped(""" (1 :: "a" :: 3 :: HNil).slice(1, 0) """)
   }
+
+  @Test
+  def testToSizedHList {
+    val ns = List(1,2,3,4)
+    assertTypedEquals[Option[III]](None, ns.toSizedHList(3))
+    assertTypedEquals[Option[IIII]](Some(1 :: 2 :: 3 :: 4 :: HNil), ns.toSizedHList(4))
+  }
+
 }

--- a/core/src/test/scala/shapeless/serialization.scala
+++ b/core/src/test/scala/shapeless/serialization.scala
@@ -900,6 +900,15 @@ class SerializationTests {
   def testTraversable {
     type L = Int :: String :: Boolean :: HNil
     assertSerializable(FromTraversable[L])
+
+    // To satisfy serialization of `ToSizedHList` we must provide a serializable `IsTraversableLike`
+    // that will get picked up for the `ops.sized.ToHList` we're using. I'm not convinced that this
+    // is entirely ethical since real-life usage will almost certainly fail, or at least until the
+    // instance in stdlib is fixed. - rob/tpolecat
+    import scala.collection.generic.IsTraversableLike
+    implicit val hack: IsTraversableLike[List[Int]] { type A = Int } = null
+    assertSerializable(ToSizedHList[List, Int, _4])
+
   }
 
   @Test


### PR DESCRIPTION
This adds a `ToSizedHList` type class witnessing that a stdlib collection can be turned into a uniform `HList` of a specific size.

```scala
scala> import syntax.std.traversable._
import syntax.std.traversable._

scala> List("fox", "banana", "penguin").toSizedHList(2)
res1: Option[shapeless.::[String,shapeless.::[String,shapeless.HNil]]] = None

scala> List("fox", "banana", "penguin").toSizedHList(3)
res2: Option[shapeless.::[String,shapeless.::[String,shapeless.::[String,shapeless.HNil]]]] = Some(fox :: banana :: penguin :: HNil)
```

It doesn't look like this can be serializable, because I use an `ops.sized.ToHList` which can't be made serializable because its implementation closes over a `scala.collection.generic.IsTraversableLike` which isn't serializable.