### PR TITLE
FIx #457 : Add ToPreciseTraversable type class and tests

### DIFF
--- a/core/shared/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/shared/src/main/scala/shapeless/ops/hlists.scala
@@ -630,13 +630,13 @@ object hlist {
     *
     * @author Valentin Kasas
     */
-  trait ToPreciseTraversable[L <: HList, M[_]] extends DepFn1[L] with Serializable {
+  trait ToCoproductTraversable[L <: HList, M[_]] extends DepFn1[L] with Serializable {
     type Cop <: Coproduct
     type Out = M[Cop]
   }
 
-  trait LowPriorityToPreciseTraversable {
-    type Aux[L <: HList, M[_], C <: Coproduct] = ToPreciseTraversable[L, M] {type Cop = C}
+  trait LowPriorityToCoproductTraversable {
+    type Aux[L <: HList, M[_], C <: Coproduct] = ToCoproductTraversable[L, M] {type Cop = C}
 
     /**
       * Auxiliary type class witnessing that type `T` is not a member of `Coproduct` `C`
@@ -652,13 +652,13 @@ object hlist {
          notInTail: NotIn[CT, T]): NotIn[CH :+: CT, T] = new NotIn[CH :+: CT, T]{}
     }
 
-    implicit def hconsToPreciseTraversable1[LH, LT <: HList, M[_], CT <: Coproduct]
+    implicit def hconsToCoproductTraversable1[LH, LT <: HList, M[_], CT <: Coproduct]
       (implicit
        coproductOfT  : Aux[LT, M, CT],
        cbf           : CanBuildFrom[M[CT], CT, M[CT]],
        asTraversable : M[CT] <:< Traversable[CT],
        injectOut     : coproduct.Inject[CT, LH]): Aux[LH :: LT, M, CT] =
-        new ToPreciseTraversable[LH :: LT, M] {
+        new ToCoproductTraversable[LH :: LT, M] {
           type Cop = CT
           def apply(l : LH :: LT): Out = {
             val builder = cbf()
@@ -669,17 +669,17 @@ object hlist {
         }
   }
 
-  object ToPreciseTraversable extends LowPriorityToPreciseTraversable{
+  object ToCoproductTraversable extends LowPriorityToCoproductTraversable{
 
-    implicit def hnilToPreciseTraversable[L <: HNil, M[_]]
+    implicit def hnilToCoproductTraversable[L <: HNil, M[_]]
     (implicit cbf: CanBuildFrom[M[CNil], CNil, M[CNil]]): Aux[L, M, CNil] =
-      new ToPreciseTraversable[L, M] {
+      new ToCoproductTraversable[L, M] {
         type Cop = CNil
         def apply(l: L) = cbf().result()
       }
 
 
-    implicit def hconsToPreciseTraversable0[LH, LT <: HList, M[_], CT <: Coproduct]
+    implicit def hconsToCoproductTraversable0[LH, LT <: HList, M[_], CT <: Coproduct]
       (implicit
        coproductOfT  : Aux[LT, M, CT],
        cbf           : CanBuildFrom[M[CT], LH :+: CT, M[LH :+: CT]],
@@ -687,7 +687,7 @@ object hlist {
        notIn         : NotIn[CT, LH],
        injectOut     : coproduct.Inject[LH :+: CT, LH],
        basisTail     : coproduct.Basis[LH :+: CT,CT]): Aux[LH :: LT, M, LH :+: CT] =
-        new ToPreciseTraversable[LH :: LT, M] {
+        new ToCoproductTraversable[LH :: LT, M] {
           type Cop = LH :+: CT
           def apply(l : LH :: LT): Out = {
             val builder = cbf()

--- a/core/shared/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/shared/src/main/scala/shapeless/syntax/hlists.scala
@@ -593,6 +593,20 @@ final class HListOps[L <: HList](l : L) extends Serializable {
   def toArray[Lub](implicit toTraversableAux : ToTraversable.Aux[L, Array, Lub]) : toTraversableAux.Out = toTraversableAux(l)
 
   /**
+    * Converts this `HList` to a `M` of elements embedded in a minimal `Coproduct` encompassing the types of every
+    * elements of this `HList`.
+    *
+    * For example :
+    *
+    *   (1 :: "qux" :: 42 :: "bar" :: HNil).toPrecise[Vector]
+    *
+    * Would return a Vector[Int :+: String :+: CNil]
+    *
+    * Note that the `M` container must extend `Traversable`, which means that `Array` cannot be used.
+    */
+  def toPrecise[M[_] <: Traversable[_]](implicit toPreciseTraversable: ToPreciseTraversable[L, M]): toPreciseTraversable.Out = toPreciseTraversable(l)
+
+  /**
    * Converts this `HList` to a - sized - `M` of elements typed as the least upper bound of the types of the elements
    * of this `HList`.
    */

--- a/core/shared/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/shared/src/main/scala/shapeless/syntax/hlists.scala
@@ -598,13 +598,13 @@ final class HListOps[L <: HList](l : L) extends Serializable {
     *
     * For example :
     *
-    *   (1 :: "qux" :: 42 :: "bar" :: HNil).toPrecise[Vector]
+    *   (1 :: "qux" :: 42 :: "bar" :: HNil).toCoproduct[Vector]
     *
     * Would return a Vector[Int :+: String :+: CNil]
     *
     * Note that the `M` container must extend `Traversable`, which means that `Array` cannot be used.
     */
-  def toPrecise[M[_] <: Traversable[_]](implicit toPreciseTraversable: ToPreciseTraversable[L, M]): toPreciseTraversable.Out = toPreciseTraversable(l)
+  def toCoproduct[M[_] <: Traversable[_]](implicit toCoproductTraversable: ToCoproductTraversable[L, M]): toCoproductTraversable.Out = toCoproductTraversable(l)
 
   /**
    * Converts this `HList` to a - sized - `M` of elements typed as the least upper bound of the types of the elements

--- a/core/shared/src/test/scala/shapeless/hlist.scala
+++ b/core/shared/src/test/scala/shapeless/hlist.scala
@@ -735,32 +735,32 @@ class HListTests {
 
   @Test
   def testToPreciseList {
-    val r1 = HNil.toPrecise[List]
+    val r1 = HNil.toCoproduct[List]
     assertTypedEquals[List[CNil]](Nil, r1)
 
-    val r2 = ap.toPrecise[List]
+    val r2 = ap.toCoproduct[List]
     assertTypedEquals[List[APc]](List(Coproduct[APc](a), Coproduct[APc](p)), r2)
 
-    val r3 = apap.toPrecise[List]
+    val r3 = apap.toCoproduct[List]
     assertTypedEquals[List[APc]](List(Coproduct[APc](a), Coproduct[APc](p), Coproduct[APc](a), Coproduct[APc](p)), r3)
 
-    val r4 = apbp.toPrecise[Vector]
+    val r4 = apbp.toCoproduct[Vector]
     assertTypedEquals[Vector[ABPc]](Vector[ABPc](Coproduct[ABPc](a), Coproduct[ABPc](p), Coproduct[ABPc](b), Coproduct[ABPc](p)), r4)
 
     def equalInferedCoproducts[A <: Coproduct, B <: Coproduct](a: A, b: B)(implicit bInA: ops.coproduct.Basis[A, B], aInB: ops.coproduct.Basis[B, A]){}
     val abpc = Coproduct[ABPc](a)
 
-    val r5 = (a :: b :: a :: p :: b :: a :: HNil).toPrecise[Set]
+    val r5 = (a :: b :: a :: p :: b :: a :: HNil).toCoproduct[Set]
     equalInferedCoproducts(abpc, r5.head)
 
-    val r6 = (p :: a :: a :: p :: p :: b :: HNil).toPrecise[Set]
+    val r6 = (p :: a :: a :: p :: p :: b :: HNil).toCoproduct[Set]
     equalInferedCoproducts(abpc, r6.head)
 
-    val r7 = (a :: b :: p :: HNil).toPrecise[Seq]
+    val r7 = (a :: b :: p :: HNil).toCoproduct[Seq]
     equalInferedCoproducts(abpc, r7.head)
 
 
-    val r8 = (a :: b :: HNil).toPrecise[Seq]
+    val r8 = (a :: b :: HNil).toCoproduct[Seq]
 
     illTyped{
       """equalInferedCoproducts(abpc, r8.head)"""

--- a/core/shared/src/test/scala/shapeless/hlist.scala
+++ b/core/shared/src/test/scala/shapeless/hlist.scala
@@ -747,6 +747,25 @@ class HListTests {
     val r4 = apbp.toPrecise[Vector]
     assertTypedEquals[Vector[ABPc]](Vector[ABPc](Coproduct[ABPc](a), Coproduct[ABPc](p), Coproduct[ABPc](b), Coproduct[ABPc](p)), r4)
 
+    def equalInferedCoproducts[A <: Coproduct, B <: Coproduct](a: A, b: B)(implicit bInA: ops.coproduct.Basis[A, B], aInB: ops.coproduct.Basis[B, A]){}
+    val abpc = Coproduct[ABPc](a)
+
+    val r5 = (a :: b :: a :: p :: b :: a :: HNil).toPrecise[Set]
+    equalInferedCoproducts(abpc, r5.head)
+
+    val r6 = (p :: a :: a :: p :: p :: b :: HNil).toPrecise[Set]
+    equalInferedCoproducts(abpc, r6.head)
+
+    val r7 = (a :: b :: p :: HNil).toPrecise[Seq]
+    equalInferedCoproducts(abpc, r7.head)
+
+
+    val r8 = (a :: b :: HNil).toPrecise[Seq]
+
+    illTyped{
+      """equalInferedCoproducts(abpc, r8.head)"""
+    }
+
     illTyped{
       """(1 :: "foo" :: HNil).toPrecise[Array]"""
     }

--- a/core/shared/src/test/scala/shapeless/hlist.scala
+++ b/core/shared/src/test/scala/shapeless/hlist.scala
@@ -67,6 +67,9 @@ class HListTests {
   type PBPA = Pear :: Banana :: Pear :: Apple :: HNil
   type PABP = Pear :: Apple :: Banana :: Pear :: HNil
 
+  type APc = Apple :+: Pear :+: CNil
+  type ABPc = Apple :+: Banana :+: Pear :+: CNil
+
   val a : Apple = Apple()
   val p : Pear = Pear()
   val b : Banana = Banana()
@@ -728,6 +731,26 @@ class HListTests {
     val m2e = m2eim2esm2eim2eem2ed.to[List]
     // equalType(m2eim2esm2eim2eem2edList, m2e)
     assertTypedEquals[List[M2[_ >: Int with String with Double, _]]](m2eim2esm2eim2eem2edList, m2e)
+  }
+
+  @Test
+  def testToPreciseList {
+    val r1 = HNil.toPrecise[List]
+    assertTypedEquals[List[CNil]](Nil, r1)
+
+    val r2 = ap.toPrecise[List]
+    assertTypedEquals[List[APc]](List(Coproduct[APc](a), Coproduct[APc](p)), r2)
+
+    val r3 = apap.toPrecise[List]
+    assertTypedEquals[List[APc]](List(Coproduct[APc](a), Coproduct[APc](p), Coproduct[APc](a), Coproduct[APc](p)), r3)
+
+    val r4 = apbp.toPrecise[Vector]
+    assertTypedEquals[Vector[ABPc]](Vector[ABPc](Coproduct[ABPc](a), Coproduct[ABPc](p), Coproduct[ABPc](b), Coproduct[ABPc](p)), r4)
+
+    illTyped{
+      """(1 :: "foo" :: HNil).toPrecise[Array]"""
+    }
+
   }
 
   @Test


### PR DESCRIPTION
In the absence of an accessible `Monoid` definition, this should be ok for now.

The name is debatable (I tried to find a name close to `ToTraversable` since both type classes perform similar work).

Tests could be enhanced, especially if I were able (or aware of a way) to express "equality" of Coproducts (e.g. expressing that `A :+: B :+: CNil == B :+: A :+: CNil`). 
