### PR TITLE
Bump sbt-buildinfo & enable buildInfoUsePackageAsPath

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.15"
 
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"       % "0.1.8")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-osgi"              % "0.6.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"         % "0.3.2")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"         % "0.6.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"               % "0.8.5")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"           % "0.6.7")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"           % "1.0.0")


### PR DESCRIPTION
Allows the removal of the hand-rolled `mappings` manipulation.

Also upgrades to the more modern AutoPlugin setup, and switched `BuildInfoOption.BuildTime`.

The output under both:

    core/jvm/target/scala-2.11/src_managed/main/shapeless/BuildInfo.scala
    core/js/target/scala-2.11/src_managed/main/shapeless/BuildInfo.scala

looks like this:

```scala
package shapeless

/** This object was generated by sbt-buildinfo. */
case object BuildInfo {
  /** The value is "2.3.0-SNAPSHOT". */
  val version: String = "2.3.0-SNAPSHOT"
  /** The value is "2.11.7". */
  val scalaVersion: String = "2.11.7"
  /** The value is Some("49bb32ff5051b9b2650b37106d9925b7b92fcb43"). */
  val gitHeadCommit: Option[String] = Some("49bb32ff5051b9b2650b37106d9925b7b92fcb43")
  /** The value is "2016-02-15 07:29:39.323". */
  val builtAtString: String = "2016-02-15 07:29:39.323"
  /** The value is 1455521379323L. */
  val builtAtMillis: Long = 1455521379323L
  override val toString: String = {
    "version: %s, scalaVersion: %s, gitHeadCommit: %s, builtAtString: %s, builtAtMillis: %s" format (
      version, scalaVersion, gitHeadCommit, builtAtString, builtAtMillis
    )
  }
}
```