### PR TITLE
NotContains and IsDistinct constraints for HList

### DIFF
--- a/core/src/main/scala/shapeless/hlistconstraints.scala
+++ b/core/src/main/scala/shapeless/hlistconstraints.scala
@@ -152,6 +152,6 @@ object IsDistinctConstraint {
 
   implicit def hnilIsDistinct = new IsDistinctConstraint[HNil] {}
   implicit def hlistIsDistinct[H, T <: HList](implicit d: IsDistinctConstraint[T],
-                                              nc: NotContainsConstraint[T, H]): IsDistinctConstraint[H :: T] =
+                                                      nc: NotContainsConstraint[T, H]): IsDistinctConstraint[H :: T] =
     new IsDistinctConstraint[H :: T] {}
 }


### PR DESCRIPTION
There was a [conversation](https://gitter.im/milessabin/shapeless?at=56bf14a14dfe1fa71ffc852f) on gitter regarding these, but some urgent stuff weighted in short after.
So I leave it here for better times to be either merged or rejected :)

Note:
An implementation of `IsDistinctConstraint` without use of `NotContainsConstraint` can be following (with a use of ambiguous implicits trick):

```scala
trait IsDistinctConstraint[L <: HList]

object IsDistinctConstraint {
  def apply[T <: HList](implicit ev: IsDistinctConstraint[T]): IsDistinctConstraint[T] = ev

  // we have to build chain here so that ambiguous breaker works for smth like A :: B :: B :: HNil
  implicit def unique0 = new IsDistinctConstraint[HNil] {}
  implicit def unique1[H, T <: HList](implicit ev: IsDistinctConstraint[T]) = new IsDistinctConstraint[H :: T] {}

  implicit def uniqueAmb1[H <: HList, T](implicit ev: Selector[H, T]): IsDistinctConstraint[T :: H] = 
    shapeless.unexpected
  implicit def uniqueAmb2[H <: HList, T](implicit ev: Selector[H, T]): IsDistinctConstraint[T :: H] = 
    shapeless.unexpected
}
```

Maybe it's a better choice...