### PR TITLE
Add impossible method to CNil

### DIFF
--- a/core/src/main/scala/shapeless/coproduct.scala
+++ b/core/src/main/scala/shapeless/coproduct.scala
@@ -105,7 +105,9 @@ final case class Inr[+H, +T <: Coproduct](tail : T) extends :+:[H, T]
   * This makes the type `Int :+: CNil` equivalent to `Int`, because the right (`Inr`) alternative
   * of `:+:` can not be constructed properly.
   */
-sealed trait CNil extends Coproduct
+sealed trait CNil extends Coproduct {
+  def impossible: Nothing
+}
 
 object Coproduct extends Dynamic {
   import ops.coproduct.Inject


### PR DESCRIPTION
As discussed on gitter, add an `impossible` method on `CNil` to allow safer `match`/`case` expressions for `Coproduct`s.