### PR TITLE
Add generalized sub-typing evidence type class

### DIFF
--- a/core/src/main/scala/shapeless/coproduct.scala
+++ b/core/src/main/scala/shapeless/coproduct.scala
@@ -147,3 +147,52 @@ object Coproduct extends Dynamic {
    */
   def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.coproductTypeImpl
 }
+
+/**
+  * More general sub-type evidence, compatible with coproducts.
+  *
+  * Evidence that `From` can be converted to `To`. Works if `From` is a sub-type of `To`, like
+  * with `<:<` from the standard library. `From` can also possibly be a coproduct, whose elements
+  * can all be converted to `To`.
+  *
+  * This can recurse on the elements of coproducts, so that if `From` is a coproduct, this will also
+  * work if some or all its elements are coproducts that can be converted to `To`.
+  *
+  * E.g.
+  *
+  * {{{
+  *   <::<[String, AnyRef]
+  *   <::<[String :+: Seq[Int] :+: Option[Double] :+: CNil, AnyRef]
+  *   <::<[List[Double] :+: Vector[Double] :+: IndexedSeq[Double] :+: CNil, Seq[Double]]
+  * }}}
+  *
+  * @author Alexandre Archambault
+  */
+sealed abstract class <::<[From, To] extends (From => To) with Serializable
+
+object <::< {
+  def apply[From, To](implicit ev: From <::< To): From <::< To = ev
+
+  implicit def default[From, To](implicit ev: From <:< To): From <::< To =
+    new <::<[From, To] {
+      def apply(from: From) = ev(from)
+    }
+
+  implicit def cnil[A]: CNil <::< A =
+    new <::<[CNil, A] {
+      def apply(c: CNil) = c.impossible
+    }
+
+  implicit def ccons[A, H, T <: Coproduct](implicit
+    // These might possibly need to be wrapped in Lazy or Strict.
+    // The current tests seem to pass without that though.
+    headEv: H <::< A,
+    tailEv: T <::< A
+  ): (H :+: T) <::< A =
+    new <::<[H :+: T, A] {
+      def apply(c: H :+: T) = c match {
+        case Inl(h) => headEv(h)
+        case Inr(t) => tailEv(t)
+      }
+    }
+}

--- a/core/src/test/scala/shapeless/subtype.scala
+++ b/core/src/test/scala/shapeless/subtype.scala
@@ -1,0 +1,44 @@
+package shapeless
+
+import org.junit.Test
+
+import shapeless.test._
+import shapeless.union.Union
+
+import scala.collection.immutable.{ LinearSeq, Queue }
+
+class SubTypeTests {
+
+  @Test
+  def likeStandardSubType {
+    <::<[String, AnyRef]
+  }
+
+  @Test
+  def coproducts {
+    <::<[CNil, AnyRef]
+    <::<[String :+: Seq[Int] :+: Option[Double] :+: CNil, AnyRef]
+    <::<[List[Double] :+: Vector[Double] :+: IndexedSeq[Double] :+: CNil, Seq[Double]]
+    <::<[Union.`'s -> String, 'seq -> Seq[Int], 'opt -> Option[Double]`.T, AnyRef]
+    <::<[Union.`'list -> List[Double], 'vector -> Vector[Double], 'is -> IndexedSeq[Double]`.T, Seq[Double]]
+
+    <::<[(Int :+: CNil) :+: (String :+: CNil) :+: CNil, _ :+: CNil]
+    <::<[(String :+: CNil) :+: (String :+: CNil) :+: CNil, String :+: CNil]
+    <::<[(String :+: CNil) :+: (String :+: CNil) :+: CNil, String]
+  }
+
+  @Test
+  def recursive {
+    type C1 = List[Double] :+: Vector[Double] :+: IndexedSeq[Double] :+: CNil
+    type C2 = Queue[Double] :+: LinearSeq[Double] :+: Stream[Double] :+: CNil
+    type C12 = C1 :+: C2 :+: CNil
+
+    <::<[C12, Seq[Double]]
+    <::<[C1 :+: Queue[Double] :+: LinearSeq[Double] :+: Stream[Double] :+: CNil, Seq[Double]]
+    <::<[Queue[Double] :+: LinearSeq[Double] :+: C1 :+: Stream[Double] :+: CNil, Seq[Double]]
+
+    <::<[C12 :+: C1 :+: Stream[Double] :+: CNil, Seq[Double]]
+    <::<[Stream[Double] :+: C1 :+: C12 :+: CNil, Seq[Double]]
+  }
+
+}


### PR DESCRIPTION
Adds a more general sub-type evidence `<::<`, compatible with coproducts. Like with `<:<` from the standard library, usual sub-typing is fine, e.g.

``` scala
<::<[String, AnyRef]
```

but the first type can be a coproduct too, e.g.

``` scala
<::<[List[Double] :+: Vector[Double] :+: IndexedSeq[Double] :+: CNil, Seq[Double]]
```

This can also recurse on the coproducts elements, like in

``` scala
<::<[(String :+: CNil) :+: (String :+: CNil) :+: CNil, String]
```
