### PR TITLE
fix bug in hlist.{Intersection, Union}

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1251,12 +1251,10 @@ object hlist {
   trait LowPriorityUnion {
     type Aux[L <: HList, M <: HList, Out0 <: HList] = Union[L, M] { type Out = Out0 }
 
-    // let (H :: T) ∪ M  =  H :: (T ∪ M) when H ∉ M
-    implicit def hlistUnion1[H, T <: HList, M <: HList]
-      (implicit
-       u: Union[T, M],
-       f: FilterNot.Aux[M, H, M]
-      ): Aux[H :: T, M, H :: u.Out] =
+    // buggy version; let (H :: T) ∪ M  =  H :: (T ∪ M)
+    @deprecated("Incorrectly witnesses that {x} ∪ {x} = {x, x}", "2.3.1")
+    def hlistUnion1[H, T <: HList, M <: HList]
+      (implicit u: Union[T, M]): Aux[H :: T, M, H :: u.Out] =
         new Union[H :: T, M] {
           type Out = H :: u.Out
           def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
@@ -1272,6 +1270,17 @@ object hlist {
         type Out = M
         def apply(l: HNil, m: M): Out = m
       }
+
+    // let (H :: T) ∪ M  =  H :: (T ∪ M) when H ∉ M
+    implicit def hlistUnion1[H, T <: HList, M <: HList]
+      (implicit
+       u: Union[T, M],
+       f: FilterNot.Aux[M, H, M]
+      ): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
+        }
 
     // let (H :: T) ∪ M  =  H :: (T ∪ (M - H)) when H ∈ M
     implicit def hlistUnion2[H, T <: HList, M <: HList, MR <: HList]
@@ -1299,12 +1308,10 @@ object hlist {
   trait LowPriorityIntersection {
     type Aux[L <: HList, M <: HList, Out0 <: HList] = Intersection[L, M] { type Out = Out0 }
 
-    // let (H :: T) ∩ M  =  T ∩ M  when H ∉ M
-    implicit def hlistIntersection1[H, T <: HList, M <: HList]
-      (implicit
-       i: Intersection[T, M],
-       f: FilterNot.Aux[M, H, M]
-      ): Aux[H :: T, M, i.Out] =
+    // buggy version;  let (H :: T) ∩ M  =  T ∩ M
+    @deprecated("Incorrectly witnesses that {x} ∩ M = ∅", "2.3.1")
+    def hlistIntersection1[H, T <: HList, M <: HList]
+      (implicit i: Intersection[T, M]): Aux[H :: T, M, i.Out] =
         new Intersection[H :: T, M] {
           type Out = i.Out
           def apply(l: H :: T): Out = i(l.tail)
@@ -1320,6 +1327,17 @@ object hlist {
         type Out = HNil
         def apply(l: HNil): Out = HNil
       }
+
+    // let (H :: T) ∩ M  =  T ∩ M  when H ∉ M
+    implicit def hlistIntersection1[H, T <: HList, M <: HList]
+      (implicit
+       i: Intersection[T, M],
+       f: FilterNot.Aux[M, H, M]
+      ): Aux[H :: T, M, i.Out] =
+        new Intersection[H :: T, M] {
+          type Out = i.Out
+          def apply(l: H :: T): Out = i(l.tail)
+        }
 
     // let (H :: T) ∩ M  =  H :: (T ∩ (M - H)) when H ∈ M
     implicit def hlistIntersection2[H, T <: HList, M <: HList, MR <: HList]

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1251,8 +1251,12 @@ object hlist {
   trait LowPriorityUnion {
     type Aux[L <: HList, M <: HList, Out0 <: HList] = Union[L, M] { type Out = Out0 }
 
+    // let (H :: T) ∪ M  =  H :: (T ∪ M) when H ∉ M
     implicit def hlistUnion1[H, T <: HList, M <: HList]
-      (implicit u: Union[T, M]): Aux[H :: T, M, H :: u.Out] =
+      (implicit
+       u: Union[T, M],
+       f: FilterNot.Aux[M, H, M]
+      ): Aux[H :: T, M, H :: u.Out] =
         new Union[H :: T, M] {
           type Out = H :: u.Out
           def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
@@ -1262,12 +1266,14 @@ object hlist {
   object Union extends LowPriorityUnion {
     def apply[L <: HList, M <: HList](implicit union: Union[L, M]): Aux[L, M, union.Out] = union
 
+    // let ∅ ∩ M = M
     implicit def hlistUnion[M <: HList]: Aux[HNil, M, M] =
       new Union[HNil, M] {
         type Out = M
         def apply(l: HNil, m: M): Out = m
       }
 
+    // let (H :: T) ∪ M  =  H :: (T ∪ (M - H)) when H ∈ M
     implicit def hlistUnion2[H, T <: HList, M <: HList, MR <: HList]
       (implicit
         r: Remove.Aux[M, H, (H, MR)],
@@ -1293,8 +1299,12 @@ object hlist {
   trait LowPriorityIntersection {
     type Aux[L <: HList, M <: HList, Out0 <: HList] = Intersection[L, M] { type Out = Out0 }
 
+    // let (H :: T) ∩ M  =  T ∩ M  when H ∉ M
     implicit def hlistIntersection1[H, T <: HList, M <: HList]
-      (implicit i: Intersection[T, M]): Aux[H :: T, M, i.Out] =
+      (implicit
+       i: Intersection[T, M],
+       f: FilterNot.Aux[M, H, M]
+      ): Aux[H :: T, M, i.Out] =
         new Intersection[H :: T, M] {
           type Out = i.Out
           def apply(l: H :: T): Out = i(l.tail)
@@ -1304,12 +1314,14 @@ object hlist {
   object Intersection extends LowPriorityIntersection {
     def apply[L <: HList, M <: HList](implicit intersection: Intersection[L, M]): Aux[L, M, intersection.Out] = intersection
 
+    // let ∅ ∩ M = ∅
     implicit def hnilIntersection[M <: HList]: Aux[HNil, M, HNil] =
       new Intersection[HNil, M] {
         type Out = HNil
         def apply(l: HNil): Out = HNil
       }
 
+    // let (H :: T) ∩ M  =  H :: (T ∩ (M - H)) when H ∈ M
     implicit def hlistIntersection2[H, T <: HList, M <: HList, MR <: HList]
       (implicit
         r: Remove.Aux[M, H, (H, MR)],

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -1266,7 +1266,7 @@ object hlist {
   object Union extends LowPriorityUnion {
     def apply[L <: HList, M <: HList](implicit union: Union[L, M]): Aux[L, M, union.Out] = union
 
-    // let ∅ ∩ M = M
+    // let ∅ ∪ M = M
     implicit def hlistUnion[M <: HList]: Aux[HNil, M, M] =
       new Union[HNil, M] {
         type Out = M

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1892,7 +1892,7 @@ class HListTests {
     type L4 = Int :: Int :: Int :: HNil
     val l4: L4 = 4 :: 5 :: 6 :: HNil
 
-    val lnil = l1.union(HNil)
+    val lnil = l1.union[HNil](HNil)
     assertTypedEquals[L1](l1, lnil)
 
     val lself = l1.union(l1)

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1904,6 +1904,9 @@ class HListTests {
     val l21 = l2.union(l1)
     assertTypedEquals[Int :: String :: Boolean :: Long :: HNil](2 :: "bar" :: true :: 3L :: HNil, l21)
 
+
+    illTyped { """implicitly[Union.Aux[Int :: HNil, Int :: HNil, Int :: Int :: HNil]]"""}
+
     val ldup1 = (l3).union(l4)
     assertTypedEquals[Int :: Int :: Int :: HNil](1 :: 2 :: 6 :: HNil, ldup1)
 
@@ -1933,6 +1936,8 @@ class HListTests {
 
     val l21 = l2.intersect[L1]
     assertTypedEquals[Int :: String :: HNil](2 :: "bar" :: HNil, l21)
+
+    illTyped { """implicitly[Intersection.Aux[Int :: HNil, Int :: HNil, HNil]]"""}
 
     val ldup1 = (l3).intersect[Int :: HNil]
     assertTypedEquals[Int :: HNil](4 :: HNil, ldup1)


### PR DESCRIPTION
Fix bugs described in #562.

Currently `Intersection` is witnessed by three cases:
`hnilIntersection` says ∅ ∩ M = ∅, which is good.
`hlistIntersection1` says (H :: T ∩ M) = T ∩ M
`hlistIntersection2` says: if H ∈ M, (H :: T ∩ M) = H :: (T ∩ (M - R))

Unfortunately, (H :: T ∩ M) = T ∩ M is false if H ∉ M.  This patch adds the H ∉ M condition to `hlistIntersection1` using a `FilterNot.Aux[M,H,M]` witness.

The patch also fixes an equivalent bug in `Union`.

---
I had a couple additional questions:

1. Should `hlistIntersection1` and `hlistIntersection2` reside in the same trait now, eliminating the need for `LowPriorityIntersection`?
2. Why is it that `Intersection extends DepFn1` but `Union extends DepFn2`?  It seems like they should be the same, but I don't know what the right answer is.