### PR TITLE
Scope credentials to ThisBuild

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -263,7 +263,7 @@ lazy val releaseSettings = Seq(
   )
 )
 
-credentials ++= (for {
+credentials in ThisBuild ++= (for {
   username <- Option(System.getenv().get("SONATYPE_USERNAME"))
   password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
   testvar <- Option(System.getenv().get("TEST_VAR"))


### PR DESCRIPTION
Something about using .sbtrc & switching projects in validate etc is confusingly
not making credentials evaluate.

As a stop-gap, set this to ThisBuild which arguably is what it should be: the
entire project, every module, should publish with these credentials.