### PR TITLE
Bump to Scala 2.11.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
 - 2.10.6
-- 2.11.7
+- 2.11.8
 - 2.12.0-M3
 
 jdk:

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ to your settings.
 ### shapeless-2.3.0
 
 Builds are available for Scala 2.10.x, 2.11.x and for 2.12.0-M3. The main line of development for
-shapeless 2.3.0 is Scala 2.11.7 with Scala 2.10.x supported via the macro paradise compiler plugin.
+shapeless 2.3.0 is Scala 2.11.8 with Scala 2.10.x supported via the macro paradise compiler plugin.
 
 ```scala
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.3.0"
@@ -205,7 +205,7 @@ releases][olderusage] on the shapeless wiki.
 
 ## Building shapeless
 
-shapeless is built with SBT 0.13.9 or later, and its master branch is built with Scala 2.11.7 by default but also
+shapeless is built with SBT 0.13.9 or later, and its master branch is built with Scala 2.11.8 by default but also
 cross-builds for 2.10.6 and 2.12.x.
 
 [namehashing]: https://github.com/sbt/sbt/issues/1640

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ import GitKeys._
 
 lazy val buildSettings = Seq(
   organization := "com.chuusai",
-  scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M3")
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M3")
 )
 
 addCommandAlias("root", ";project root")


### PR DESCRIPTION
There's a trailing change about shapeless-2.2.5 using Scala 2.11.7, I've
purposely left that as is.