### PR TITLE
Add SYB instances for collections

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ Howard Branch <purestgreen@gmail.com> @purestgreen
 Huw Giddens <hgiddens@gmail.com>
 Jason Zaugg <jzaugg@gmail.com> @retronym
 Jean-Remi Desjardins <jeanremi.desjardins@gmail.com> @jrdesjardins
+Jisoo Park <xxxyel@gmail.com> @guersam
 Johannes Rudolph <johannes.rudolph@gmail.com> @virtualvoid
 Johnny Everson <khronnuz@gmail.com> @johnny_everson
 Joni Freeman <joni.freeman@ri.fi> @jonifreeman

--- a/core/src/main/scala/shapeless/sybclass.scala
+++ b/core/src/main/scala/shapeless/sybclass.scala
@@ -49,6 +49,8 @@ trait Data1 extends Data0 {
 }
 
 object Data extends Data1 {
+  import scala.collection.{ GenMap, GenTraversable }
+
   def apply[P, T, R](implicit dt: Lazy[Data[P, T, R]]): Data[P, T, R] = dt.value
 
   def gmapQ[F, T, R](f: F)(t: T)(implicit data: Lazy[Data[F, T, R]]) = data.value.gmapQ(t)
@@ -56,10 +58,29 @@ object Data extends Data1 {
   /**
    * Data type class instance for `List`s.
    */
-  implicit def listData[P, T, R](implicit qt: Lazy[Case1.Aux[P, T, R]]): Data[P, List[T], R] =
+  @deprecated("Superseded by genTraversableData", "2.3.1")
+  def listData[P, T, R](implicit qt: Lazy[Case1.Aux[P, T, R]]): Data[P, List[T], R] =
     new Data[P, List[T], R] {
       def gmapQ(t: List[T]) = t.map(qt.value(_))
     }
+
+  implicit def genTraversableData[P, C[X] <: GenTraversable[X], T, R]
+    (implicit qt: Lazy[Case1.Aux[P, T, R]]): Data[P, C[T], R] =
+      new Data[P, C[T], R] {
+        def gmapQ(t: C[T]) =
+          t.foldLeft(List.newBuilder[R]) { (b, el) =>
+            b += qt.value(el)
+          }.result
+      }
+
+  implicit def genMapData[P, M[X, Y], K, V, R]
+    (implicit ev: M[K, V] <:< GenMap[K, V], qv: Lazy[Case1.Aux[P, (K, V), R]]): Data[P, M[K, V], R] =
+      new Data[P, M[K, V], R] {
+        def gmapQ(t: M[K, V]) =
+          t.foldLeft(List.newBuilder[R]) { case (b, el) =>
+            b += qv.value(el)
+          }.result
+      }
 
   implicit def deriveHNil[P, R]: Data[P, HNil, R] =
     new Data[P, HNil, R] {
@@ -118,6 +139,9 @@ trait DataT1 extends DataT0 {
 }
 
 object DataT extends DataT1 {
+  import scala.collection.{ GenMap, GenTraversable }
+  import scala.collection.generic.CanBuildFrom
+
   def apply[P, T](implicit dtt: Lazy[DataT[P, T]]): DataT[P, T] = dtt.value
 
   def gmapT[F, T](f: F)(t: T)(implicit data: Lazy[DataT[F, T]]) = data.value.gmapT(t)
@@ -125,11 +149,36 @@ object DataT extends DataT1 {
   /**
    * DataT type class instance for `List`s.
    */
-  implicit def listDataT[F <:  Poly, T, U](implicit ft: Lazy[Case1.Aux[F, T, U]]): Aux[F, List[T], List[U]] =
+  @deprecated("Superseded by genTraversableDataT", "2.3.1")
+  def listDataT[F <: Poly, T, U](implicit ft: Lazy[Case1.Aux[F, T, U]]): Aux[F, List[T], List[U]] =
     new DataT[F, List[T]] {
       type Out = List[U]
       def gmapT(t: List[T]) = t.map(ft.value)
     }
+
+  implicit def genTraversableDataT[F <: Poly, CC[X] <: GenTraversable[X], T, U]
+    (implicit ft: Lazy[Case1.Aux[F, T, U]], cbf: CanBuildFrom[Nothing, U, CC[U]]): Aux[F, CC[T], CC[U]] =
+      new DataT[F, CC[T]] {
+        type Out = CC[U]
+        def gmapT(t: CC[T]) =
+          t.foldLeft(cbf()) { (b, x) =>
+            b += ft.value(x)
+          }.result
+      }
+
+  implicit def genMapDataT[F <: Poly, M[X, Y], K, V, U]
+    (implicit
+      ev: M[K, V] <:< GenMap[K, V],
+      fv: Lazy[Case1.Aux[F, V, U]],
+      cbf: CanBuildFrom[Nothing, (K, U), M[K, U]]
+    ): Aux[F, M[K, V], M[K, U]] =
+      new DataT[F, M[K, V]] {
+        type Out = M[K, U]
+        def gmapT(t: M[K, V]) =
+          t.foldLeft(cbf()) { case (b, (k, v)) =>
+            b += k -> fv.value(v)
+          }.result
+      }
 
   implicit def deriveHNil[P]: Aux[P, HNil, HNil] =
     new DataT[P, HNil] {

--- a/core/src/test/scala/shapeless/sybclass.scala
+++ b/core/src/test/scala/shapeless/sybclass.scala
@@ -152,6 +152,10 @@ class SybClassTests {
     typed[Int](e5)
     assertEquals(11, e5)
 
+    val e6 = everything(gsize)(plus)(Map("foo" -> List(1, 2, 3), "bar" -> Nil))
+    typed[Int](e6)
+    assertEquals(14, e6)
+
     val is = gsizeAll2(23)
     typed[Int](is)
     assertEquals(1, is)
@@ -172,9 +176,9 @@ class SybClassTests {
     typed[Int](lps)
     assertEquals(11, lps)
 
-    val mps = gsizeAll2(Map("foo" -> 23, "bar" -> 24))
+    val mps = gsizeAll2(Map("foo" -> List(1, 2, 3), "bar" -> Nil))
     typed[Int](mps)
-    assertEquals(11, mps)
+    assertEquals(14, mps)
   }
 
   @Test
@@ -238,6 +242,14 @@ class SybClassTests {
     val e11 = everywhere(inc)(Map("foo" -> 23))
     typed[Map[String, Int]](e11)
     assertEquals(Map("foo" -> 24), e11)
+
+    val e12 = everywhere(inc)(Map("foo" -> 1, "bar" -> 2))
+    typed[Map[String, Int]](e12)
+    assertEquals(Map("foo" -> 2, "bar" -> 3), e12)
+
+    val e13 = everywhere(inc)(List(Map("foo" -> Vector(Option(1), None, Option(2)))))
+    typed[List[Map[String, Vector[Option[Int]]]]](e13)
+    assertEquals(List(Map("foo" -> Vector(Option(2), None, Option(3)))), e13)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/sybclass.scala
+++ b/core/src/test/scala/shapeless/sybclass.scala
@@ -22,23 +22,30 @@ import org.junit.Assert._
 import test._
 
 class SybClassTests {
-  object gsizeAll extends Poly1 {
-    implicit def caseString = at[String](_.length)
+
+  trait gsizeAll0 extends Poly1 {
     implicit def default[T](implicit data: Lazy[Data[this.type, T, Int]]) = at[T](1+data.value.gmapQ(_).sum)
   }
+  object gsizeAll extends gsizeAll0 {
+    implicit def caseString = at[String](_.length)
+  }
 
-  object gsize extends Poly1 {
+  trait gsize0 extends Poly1 {
+    implicit def default[T] = at[T](_ => 1)
+  }
+  object gsize extends gsize0 {
     implicit def caseInt = at[Int](_ => 1)
     implicit def caseString = at[String](_.length)
-    implicit def default[T] = at[T](_ => 1)
   }
 
   def gsizeAll2[T](t: T)(implicit everything: Everything[gsize.type, plus.type, T]) = everything(t)
 
-  object incAll extends Poly1 {
+  trait incAll0 extends Poly1 {
+    implicit def default[T](implicit data: Lazy[DataT[this.type, T]]) = at[T](data.value.gmapT(_))
+  }
+  object incAll extends incAll0 {
     implicit def caseInt = at[Int](_+1)
     implicit def caseString = at[String](_+"*")
-    implicit def default[T](implicit data: Lazy[DataT[this.type, T]]) = at[T](data.value.gmapT(_))
   }
 
   object inc extends Poly1 {
@@ -141,6 +148,10 @@ class SybClassTests {
     typed[Int](e4)
     assertEquals(5, e4)
 
+    val e5 = everything(gsize)(plus)(Map("foo" -> 23, "bar" -> 24))
+    typed[Int](e5)
+    assertEquals(11, e5)
+
     val is = gsizeAll2(23)
     typed[Int](is)
     assertEquals(1, is)
@@ -160,6 +171,10 @@ class SybClassTests {
     val lps = gsizeAll2(List(("foo", 23), ("bar", 24)))
     typed[Int](lps)
     assertEquals(11, lps)
+
+    val mps = gsizeAll2(Map("foo" -> 23, "bar" -> 24))
+    typed[Int](mps)
+    assertEquals(11, mps)
   }
 
   @Test
@@ -211,6 +226,18 @@ class SybClassTests {
     val e8 = everywhere(inc)(List(Option(List(Option(List(Option(23)))))))
     typed[List[Option[List[Option[List[Option[Int]]]]]]](e8)
     assertEquals(List(Option(List(Option(List(Option(24)))))), e8)
+
+    val e9 = everywhere(inc)(Vector(23))
+    typed[Vector[Int]](e9)
+    assertEquals(Vector(24), e9)
+
+    val e10 = everywhere(inc)(Vector(Option(23)))
+    typed[Vector[Option[Int]]](e10)
+    assertEquals(Vector(Option(24)), e10)
+
+    val e11 = everywhere(inc)(Map("foo" -> 23))
+    typed[Map[String, Int]](e11)
+    assertEquals(Map("foo" -> 24), e11)
   }
 
   @Test


### PR DESCRIPTION
This PR makes `Data` and `DataT` traverse through arbitrary collections.
    
**NOTE**: The behaviour of `Map` instances differs between `Data` and `DataT`. The former treats a map like a sequence of key/value tuples, whereas the latter just ignores keys to avoid shrinking the result due to some duplicated keys.