### PR TITLE
Add `Reify` ops for `HList` and `Coproduct`

### DIFF
--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1769,6 +1769,16 @@ class CoproductTests {
       typed[C](Inr(Inr(Inl(true.narrow))))
     }
   }
+
+  @Test
+  def testReify {
+    assertEquals(HNil, Reify[CNil].apply)
+    assertEquals('a :: HNil, Reify[Coproduct.`'a`.T].apply)
+    assertEquals('a :: 1 :: "b" :: true :: HNil, Reify[Coproduct.`'a, 1, "b", true`.T].apply)
+
+    illTyped(""" Reify[String :+: Int :+: CNil] """)
+    illTyped(""" Reify[String :+: Coproduct.`'a, 1, "b", true`.T] """)
+  }
 }
 
 package CoproductTestAux {

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3230,4 +3230,14 @@ class HListTests {
     //different type
     assertEquals((3, 1 :: 2 :: 42.0 :: HNil), (1 :: 2 :: 3 :: HNil).updateAtWith(2)(_ => 42.0))
   }
+
+  @Test
+  def testReify {
+    assertEquals(HNil, Reify[HNil].apply)
+    assertEquals('a :: HNil, Reify[HList.`'a`.T].apply)
+    assertEquals('a :: 1 :: "b" :: true :: HNil, Reify[HList.`'a, 1, "b", true`.T].apply)
+
+    illTyped(""" Reify[String :: Int :: HNil] """)
+    illTyped(""" Reify[String :: HList.`'a, 1, "b", true`.T] """)
+  }
 }


### PR DESCRIPTION
This does something similar to `Keys`, but does not require the argument to be a record or a union.