### PR TITLE
Add `UnzipFields` ops for Records and Unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ cross-builds for 2.10.6 and 2.12.x.
 + Huw Giddens <hgiddens@gmail.com>
 + Jason Zaugg <jzaugg@gmail.com> [@retronym](https://twitter.com/retronym)
 + Jean-Remi Desjardins <jeanremi.desjardins@gmail.com> [@jrdesjardins](https://twitter.com/jrdesjardins)
++ Jisoo Park <xxxyel@gmail.com> [@guersam](https://twitter.com/guersam)
 + Johannes Rudolph <johannes.rudolph@gmail.com> [@virtualvoid](https://twitter.com/virtualvoid)
 + Johnny Everson <khronnuz@gmail.com> [@johnny_everson](https://twitter.com/johnny_everson)
 + Joni Freeman <joni.freeman@ri.fi> [@jonifreeman](https://twitter.com/jonifreeman)

--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -476,6 +476,46 @@ package record {
   }
 
   /**
+   * Type class combining `Keys` and `Values` for convenience and compilation speed.
+   * It's similar to `Fields`, but produces distinct `HList`s instead of a zipped one.
+   *
+   * @author Jisoo Park
+   */
+  trait UnzipFields[L <: HList] extends Serializable {
+    type Keys <: HList
+    type Values <: HList
+
+    def keys(): Keys
+    def values(l: L): Values
+  }
+
+  object UnzipFields {
+    def apply[L <: HList](implicit uf: UnzipFields[L]): Aux[L, uf.Keys, uf.Values] = uf
+
+    type Aux[L <: HList, K <: HList, V <: HList] = UnzipFields[L] { type Keys = K; type Values = V }
+
+    implicit def hnilUnzipFields[L <: HNil]: Aux[L, HNil, L] =
+      new UnzipFields[L] {
+        type Keys = HNil
+        type Values = L
+        def keys() = HNil
+        def values(l: L): L = l
+      }
+
+    implicit def hconsUnzipFields[K, V, T <: HList](implicit
+      key: Witness.Aux[K],
+      tailUF: UnzipFields[T]
+    ): Aux[FieldType[K, V] :: T, K :: tailUF.Keys, V :: tailUF.Values] =
+      new UnzipFields[FieldType[K, V] :: T] {
+        type Keys = K :: tailUF.Keys
+        type Values = V :: tailUF.Values
+
+        def keys() = key.value :: tailUF.keys()
+        def values(l: FieldType[K, V] :: T) = l.head :: tailUF.values(l.tail)
+      }
+  }
+
+  /**
    * Type class supporting converting this record to a `Map` whose keys and values
    * are typed as the Lub of the keys and values of this record.
    *

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -25,6 +25,9 @@ import syntax.singleton._
 import test._
 import testutil._
 
+// making it method local causes weird compile error in Scala 2.10
+import ops.union.UnzipFields
+
 class UnionTests {
 
   val wI = Witness('i)
@@ -244,6 +247,41 @@ class UnionTests {
       assertTypedEquals(Coproduct[USF]("first".narrow -> Option(2)), f1)
       assertTypedEquals(Coproduct[USF]("second".narrow -> Option(true)), f2)
       assertTypedEquals(Coproduct[USF]("third".narrow -> Option.empty[String]), f3)
+    }
+  }
+
+  @Test
+  def testUnzipFields {
+
+    val u1 = Union[U](i = 23)
+    val u2 = Union[U](s = "foo")
+    val u3 = Union[U](b = true)
+
+    {
+      val uf = UnzipFields[U]
+
+      type UV = Coproduct.`Int, String, Boolean`.T
+
+      assertTypedEquals('i.narrow :: 's.narrow :: 'b.narrow :: HNil, uf.keys)
+      assertTypedEquals(Coproduct[UV](23), uf.values(u1))
+      assertTypedEquals(Coproduct[UV]("foo"), uf.values(u2))
+      assertTypedEquals(Coproduct[UV](true), uf.values(u3))
+    }
+
+    type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
+    val us1 = Coproduct[US]("first" ->> Option(2))
+    val us2 = Coproduct[US]("second" ->> Option(true))
+    val us3 = Coproduct[US]("third" ->> Option.empty[String])
+
+    {
+      val uf = UnzipFields[US]
+
+      type USV = Coproduct.`Option[Int], Option[Boolean], Option[String]`.T
+
+      assertTypedEquals("first".narrow :: "second".narrow :: "third".narrow :: HNil, uf.keys)
+      assertTypedEquals(Coproduct[USV](Option(2)), uf.values(us1))
+      assertTypedEquals(Coproduct[USV](Option(true)), uf.values(us2))
+      assertTypedEquals(Coproduct[USV](Option.empty[String]), uf.values(us3))
     }
   }
 


### PR DESCRIPTION
It combines `Keys` and `Values` for convenience and compile speed.

They extend none of `DepFn0` or `DepFn1` due to conflicting `type Out`. Instead, I gave explicit type member and method for each output.