### PR TITLE
Improve tests for `Reify` and `UnzipFields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ cross-builds for 2.10.6 and 2.12.x.
 + Huw Giddens <hgiddens@gmail.com>
 + Jason Zaugg <jzaugg@gmail.com> [@retronym](https://twitter.com/retronym)
 + Jean-Remi Desjardins <jeanremi.desjardins@gmail.com> [@jrdesjardins](https://twitter.com/jrdesjardins)
++ Jisoo Park <xxxyel@gmail.com> [@guersam](https://twitter.com/guersam)
 + Johannes Rudolph <johannes.rudolph@gmail.com> [@virtualvoid](https://twitter.com/virtualvoid)
 + Johnny Everson <khronnuz@gmail.com> [@johnny_everson](https://twitter.com/johnny_everson)
 + Joni Freeman <joni.freeman@ri.fi> [@jonifreeman](https://twitter.com/jonifreeman)

--- a/core/jvm/src/test/scala/shapeless/serialization.scala
+++ b/core/jvm/src/test/scala/shapeless/serialization.scala
@@ -316,7 +316,8 @@ class SerializationTests {
     type LT = (Int, String) :: (Boolean, Double) :: (Char, Float) :: HNil
     type AL = (Int => Double) :: (String => Char) :: (Boolean => Float) :: HNil
     type I3 = Int :: Int :: Int :: HNil
-    type S = HList.`'a, "boo", 23, true`.T
+    val s = HList.`'a, "boo", 23, true`
+    type S = s.T
 
     assertSerializable(IsHCons[L])
 
@@ -566,7 +567,8 @@ class SerializationTests {
     type L = Int :+: String :+: Boolean :+: CNil
     type LP = String :+: Boolean :+: Int :+: CNil
     type BS = Boolean :+: String :+: CNil
-    type S = Coproduct.`'a, "boo", 23, true`.T
+    val s = Coproduct.`'a, "boo", 23, true`
+    type S = s.T
 
     assertSerializable(Inject[L, Int])
     assertSerializable(Inject[L, String])

--- a/core/jvm/src/test/scala/shapeless/serialization.scala
+++ b/core/jvm/src/test/scala/shapeless/serialization.scala
@@ -316,6 +316,7 @@ class SerializationTests {
     type LT = (Int, String) :: (Boolean, Double) :: (Char, Float) :: HNil
     type AL = (Int => Double) :: (String => Char) :: (Boolean => Float) :: HNil
     type I3 = Int :: Int :: Int :: HNil
+    type S = HList.`'a, "boo", 23, true`.T
 
     assertSerializable(IsHCons[L])
 
@@ -503,6 +504,9 @@ class SerializationTests {
     assertSerializable(Fill[_3, Int])
 
     assertSerializable(Patcher[_0, _1, L, IS])
+
+    assertSerializable(Reify[HNil])
+    assertSerializable(Reify[S])
   }
 
   @Test
@@ -545,6 +549,9 @@ class SerializationTests {
     assertSerializable(Values[HNil])
     assertSerializable(Values[R])
 
+    assertSerializable(UnzipFields[HNil])
+    assertSerializable(UnzipFields[R])
+
     assertSerializable(ToMap[HNil])
     assertSerializable(ToMap[R])
 
@@ -559,6 +566,7 @@ class SerializationTests {
     type L = Int :+: String :+: Boolean :+: CNil
     type LP = String :+: Boolean :+: Int :+: CNil
     type BS = Boolean :+: String :+: CNil
+    type S = Coproduct.`'a, "boo", 23, true`.T
 
     assertSerializable(Inject[L, Int])
     assertSerializable(Inject[L, String])
@@ -660,6 +668,9 @@ class SerializationTests {
 
     assertSerializable(Basis[L, CNil])
     assertSerializable(Basis[L, BS])
+
+    assertSerializable(Reify[CNil])
+    assertSerializable(Reify[S])
   }
 
   @Test
@@ -674,6 +685,9 @@ class SerializationTests {
 
     assertSerializable(Values[CNil])
     assertSerializable(Values[U])
+
+    assertSerializable(UnzipFields[CNil])
+    assertSerializable(UnzipFields[U])
 
     assertSerializable(ToMap[CNil])
     assertSerializable(ToMap[U])

--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -476,6 +476,46 @@ package record {
   }
 
   /**
+   * Type class combining `Keys` and `Values` for convenience and compilation speed.
+   * It's similar to `Fields`, but produces distinct `HList`s instead of a zipped one.
+   *
+   * @author Jisoo Park
+   */
+  trait UnzipFields[L <: HList] extends Serializable {
+    type Keys <: HList
+    type Values <: HList
+
+    def keys(): Keys
+    def values(l: L): Values
+  }
+
+  object UnzipFields {
+    def apply[L <: HList](implicit uf: UnzipFields[L]): Aux[L, uf.Keys, uf.Values] = uf
+
+    type Aux[L <: HList, K <: HList, V <: HList] = UnzipFields[L] { type Keys = K; type Values = V }
+
+    implicit def hnilUnzipFields[L <: HNil]: Aux[L, HNil, L] =
+      new UnzipFields[L] {
+        type Keys = HNil
+        type Values = L
+        def keys() = HNil
+        def values(l: L): L = l
+      }
+
+    implicit def hconsUnzipFields[K, V, T <: HList](implicit
+      key: Witness.Aux[K],
+      tailUF: UnzipFields[T]
+    ): Aux[FieldType[K, V] :: T, K :: tailUF.Keys, V :: tailUF.Values] =
+      new UnzipFields[FieldType[K, V] :: T] {
+        type Keys = K :: tailUF.Keys
+        type Values = V :: tailUF.Values
+
+        def keys() = key.value :: tailUF.keys()
+        def values(l: FieldType[K, V] :: T) = l.head :: tailUF.values(l.tail)
+      }
+  }
+
+  /**
    * Type class supporting converting this record to a `Map` whose keys and values
    * are typed as the Lub of the keys and values of this record.
    *

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1772,9 +1772,14 @@ class CoproductTests {
 
   @Test
   def testReify {
-    assertEquals(HNil, Reify[CNil].apply)
-    assertEquals('a :: HNil, Reify[Coproduct.`'a`.T].apply)
-    assertEquals('a :: 1 :: "b" :: true :: HNil, Reify[Coproduct.`'a, 1, "b", true`.T].apply)
+    import syntax.singleton._
+
+    assertTypedEquals(HNil, Reify[CNil].apply)
+    assertTypedEquals('a.narrow :: HNil, Reify[Coproduct.`'a`.T].apply)
+    assertEquals(
+      'a.narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil,
+      Reify[Coproduct.`'a, 1, "b", true`.T].apply
+    )
 
     illTyped(""" Reify[String :+: Int :+: CNil] """)
     illTyped(""" Reify[String :+: Coproduct.`'a, 1, "b", true`.T] """)

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1775,11 +1775,12 @@ class CoproductTests {
     import syntax.singleton._
 
     assertTypedEquals(HNil, Reify[CNil].apply)
-    assertTypedEquals('a.narrow :: HNil, Reify[Coproduct.`'a`.T].apply)
-    assertEquals(
-      'a.narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil,
-      Reify[Coproduct.`'a, 1, "b", true`.T].apply
-    )
+
+    val s1 = Coproduct.`'a`
+    assertTypedEquals('a.narrow :: HNil, Reify[s1.T].apply)
+
+    val s2 = Coproduct.`'a, 1, "b", true`
+    assertEquals('a.narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil, Reify[s2.T].apply)
 
     illTyped(""" Reify[String :+: Int :+: CNil] """)
     illTyped(""" Reify[String :+: Coproduct.`'a, 1, "b", true`.T] """)

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3236,11 +3236,12 @@ class HListTests {
     import syntax.singleton._
 
     assertTypedEquals(HNil, Reify[HNil].apply)
-    assertTypedEquals('a.narrow :: HNil, Reify[HList.`'a`.T].apply)
-    assertTypedEquals(
-      'a.narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil,
-      Reify[HList.`'a, 1, "b", true`.T].apply
-    )
+
+    val s1 = HList.`'a`
+    assertTypedEquals('a.narrow :: HNil, Reify[s1.T].apply)
+
+    val s2 = HList.`'a, 1, "b", true`
+    assertTypedEquals('a.narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil, Reify[s2.T].apply)
 
     illTyped(""" Reify[String :: Int :: HNil] """)
     illTyped(""" Reify[String :: HList.`'a, 1, "b", true`.T] """)

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3233,9 +3233,14 @@ class HListTests {
 
   @Test
   def testReify {
-    assertEquals(HNil, Reify[HNil].apply)
-    assertEquals('a :: HNil, Reify[HList.`'a`.T].apply)
-    assertEquals('a :: 1 :: "b" :: true :: HNil, Reify[HList.`'a, 1, "b", true`.T].apply)
+    import syntax.singleton._
+
+    assertTypedEquals(HNil, Reify[HNil].apply)
+    assertTypedEquals('a.narrow :: HNil, Reify[HList.`'a`.T].apply)
+    assertTypedEquals(
+      'a.narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil,
+      Reify[HList.`'a, 1, "b", true`.T].apply
+    )
 
     illTyped(""" Reify[String :: Int :: HNil] """)
     illTyped(""" Reify[String :: HList.`'a, 1, "b", true`.T] """)

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -25,6 +25,9 @@ import syntax.singleton._
 import test._
 import testutil._
 
+// making it method local causes weird compile error in Scala 2.10
+import ops.union.UnzipFields
+
 class UnionTests {
 
   val wI = Witness('i)
@@ -244,6 +247,41 @@ class UnionTests {
       assertTypedEquals(Coproduct[USF]("first".narrow -> Option(2)), f1)
       assertTypedEquals(Coproduct[USF]("second".narrow -> Option(true)), f2)
       assertTypedEquals(Coproduct[USF]("third".narrow -> Option.empty[String]), f3)
+    }
+  }
+
+  @Test
+  def testUnzipFields {
+
+    val u1 = Union[U](i = 23)
+    val u2 = Union[U](s = "foo")
+    val u3 = Union[U](b = true)
+
+    {
+      val uf = UnzipFields[U]
+
+      type UV = Coproduct.`Int, String, Boolean`.T
+
+      assertTypedEquals('i.narrow :: 's.narrow :: 'b.narrow :: HNil, uf.keys)
+      assertTypedEquals(Coproduct[UV](23), uf.values(u1))
+      assertTypedEquals(Coproduct[UV]("foo"), uf.values(u2))
+      assertTypedEquals(Coproduct[UV](true), uf.values(u3))
+    }
+
+    type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
+    val us1 = Coproduct[US]("first" ->> Option(2))
+    val us2 = Coproduct[US]("second" ->> Option(true))
+    val us3 = Coproduct[US]("third" ->> Option.empty[String])
+
+    {
+      val uf = UnzipFields[US]
+
+      type USV = Coproduct.`Option[Int], Option[Boolean], Option[String]`.T
+
+      assertTypedEquals("first".narrow :: "second".narrow :: "third".narrow :: HNil, uf.keys)
+      assertTypedEquals(Coproduct[USV](Option(2)), uf.values(us1))
+      assertTypedEquals(Coproduct[USV](Option(true)), uf.values(us2))
+      assertTypedEquals(Coproduct[USV](Option.empty[String]), uf.values(us3))
     }
   }
 


### PR DESCRIPTION
It depends on #570, so please review this one after that.

Added missing serialization tests for `Reify` and `UnzipFields` and modified `Reify` tests to use `assertTypedEquals` to ensure the reified values' singleton-ness.