### PR TITLE
Flexible Ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ cross-builds for 2.10.6 and 2.12.x.
 + Huw Giddens <hgiddens@gmail.com>
 + Jason Zaugg <jzaugg@gmail.com> [@retronym](https://twitter.com/retronym)
 + Jean-Remi Desjardins <jeanremi.desjardins@gmail.com> [@jrdesjardins](https://twitter.com/jrdesjardins)
++ Jeff Wilde <jeff@robo.ai>
 + Jisoo Park <xxxyel@gmail.com> [@guersam](https://twitter.com/guersam)
 + Johannes Rudolph <johannes.rudolph@gmail.com> [@virtualvoid](https://twitter.com/virtualvoid)
 + Johnny Everson <khronnuz@gmail.com> [@johnny_everson](https://twitter.com/johnny_everson)

--- a/core/src/main/scala/shapeless/ops/nat.scala
+++ b/core/src/main/scala/shapeless/ops/nat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Miles Sabin 
+ * Copyright (c) 2011-16 Miles Sabin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ object nat {
   }
 
   /**
-   * Type class witnessing that `Out` is range `A` to `B`.
+   * Type class witnessing that `Out` is range `A` to `B`, inclusive of `A` and exclusive of `B`.
    *
    * @author Andreas Koestler
    */
@@ -327,6 +327,258 @@ object nat {
       ): Aux[A, B, div.Out] = new LCM[A, B] {
       type Out = div.Out
     }
+  }
+
+  /**
+    * Type class witnessing that `Out` is an HList of `Nat` numbers ranging from
+    * `A` to `B`.
+    *
+    * This differs from the `Range` type class in that it accepts another
+    * type class, `Bound`, at both the start and end of the range (instead of
+    * bare `Nat` types). This allows the flexibility to specify inclusive or
+    * exclusive range boundaries for either end of the range.
+    *
+    * Reversed ranges are also possible (i.e. starting the range with a larger
+    * number than it ends with), and results in an HList that counts from the
+    * beginning of the range _down to_ the end of the range.
+    *
+    * @author Jeff Wilde
+    */
+  trait BoundedRange[A <: BoundedRange.Bound, B <: BoundedRange.Bound] extends DepFn0 with Serializable {
+    type Out <: HList
+  }
+
+  object BoundedRange {
+
+    def apply[A <: BoundedRange.Bound, B <: BoundedRange.Bound](implicit range: BoundedRange[A,B])
+    : AuxF[A, B, range.Out]  = range
+
+    trait Bound extends DepFn0 with Serializable {
+      type Out <: Nat
+    }
+
+    /**
+      * Type class witnessing that the `Nat` `A` is the inclusive bound of
+      * a range, i.e. the beginning or end of a range that includes `A`.
+      *
+      * @author Jeff Wilde
+      */
+    trait Inclusive[A] extends Bound
+
+    trait SoftInclusive[A] extends Bound
+
+    /**
+      * Type class witnessing that the `Nat` `A` is the exclusive bound of
+      * a range, i.e. the beginning or end of a range that does not include `A`.
+      *
+      * @author Jeff Wilde
+      */
+    trait Exclusive[A] extends Bound
+
+
+    import shapeless.ops.hlist._
+
+    type AuxF[A <: BoundedRange.Bound, B <: BoundedRange.Bound, Out0 <: HList] =
+      BoundedRange[A, B] {type Out = Out0}
+
+    //
+    // nil ranges (both nil starting and recursive terminators)
+
+    implicit def nilClosed[A <: Nat]
+    (implicit w: Witness.Aux[A])
+    : AuxF[Inclusive[A], Inclusive[A], A :: HNil] =
+      new BoundedRange[Inclusive[A], Inclusive[A]] {
+        type Out = A :: HNil
+
+        def apply(): Out = w.value :: HNil
+      }
+
+    implicit def nilOpen[A <: Nat]
+    (implicit w: Witness.Aux[A])
+    : AuxF[Exclusive[A], Exclusive[A], HNil] =
+      new BoundedRange[Exclusive[A], Exclusive[A]] {
+        type Out = HNil
+
+        def apply(): Out = HNil
+      }
+
+    implicit def nilLeftOpenRightClosed[A <: Nat]
+    (implicit w: Witness.Aux[A])
+    : AuxF[Exclusive[A], Inclusive[A], A :: HNil] =
+      new BoundedRange[Exclusive[A], Inclusive[A]] {
+        type Out = A :: HNil
+
+        def apply(): Out = w.value :: HNil
+      }
+
+    implicit def nilLeftClosedRightOpen[A <: Nat]
+    (implicit w: Witness.Aux[A])
+    : AuxF[Inclusive[A], Exclusive[A], A :: HNil] =
+      new BoundedRange[Inclusive[A], Exclusive[A]] {
+        type Out = A :: HNil
+
+        def apply(): Out = w.value :: HNil
+      }
+
+    //
+    // nil ranges (recursive terminators only)
+
+    implicit def nilLeftOpenRightSoft[A <: Nat]
+    : AuxF[Exclusive[A], SoftInclusive[A], HNil] =
+      new BoundedRange[Exclusive[A], SoftInclusive[A]] {
+        type Out = HNil
+
+        def apply(): Out = HNil
+      }
+
+    implicit def nilLeftClosedRightSoft[A <: Nat]
+    (implicit w: Witness.Aux[A])
+    : AuxF[Inclusive[A], SoftInclusive[A], A :: HNil] =
+      new BoundedRange[Inclusive[A], SoftInclusive[A]] {
+        type Out = A :: HNil
+
+        def apply(): Out = w.value :: HNil
+      }
+
+    //
+    // intermediate recursive ranges
+
+    implicit def leftOpenRightSoft[A <: Nat, B <: Nat, Sub <: HList]
+    (implicit
+      w: Witness.Aux[Succ[B]],
+      subRange: AuxF[Exclusive[A], SoftInclusive[B], Sub])
+    : AuxF[Exclusive[A], SoftInclusive[Succ[B]], Succ[B] :: Sub] =
+      new BoundedRange[Exclusive[A], SoftInclusive[Succ[B]]] {
+        type Out = Succ[B] :: Sub
+
+        def apply(): Out = w.value :: subRange()
+      }
+
+    implicit def leftClosedRightSoft[A <: Nat, B <: Nat, Sub <: HList]
+    (implicit
+      w: Witness.Aux[Succ[B]],
+      subRange: AuxF[Inclusive[A], SoftInclusive[B], Sub])
+    : AuxF[Inclusive[A], SoftInclusive[Succ[B]], Succ[B] :: Sub] =
+      new BoundedRange[Inclusive[A], SoftInclusive[Succ[B]]] {
+        type Out =  Succ[B] :: Sub
+
+        def apply(): Out = w.value :: subRange()
+      }
+
+    //
+    // public starting ranges
+
+    implicit def closed[A <: Nat, B <: Nat, Sub <: HList, Rev <: HList]
+    (implicit
+      w: Witness.Aux[Succ[B]],
+      subRange: AuxF[Inclusive[A], SoftInclusive[B], Sub],
+      reverse: ReversePrepend.Aux[Sub, Succ[B] :: HNil, Rev])
+    : AuxF[Inclusive[A], Inclusive[Succ[B]], Rev] =
+      new BoundedRange[Inclusive[A], Inclusive[Succ[B]]] {
+        type Out = Rev
+
+        def apply(): Out = reverse(subRange(), w.value :: HNil)
+      }
+
+    implicit def open[A <: Nat, B <: Nat, Sub <: HList, Rev <: HList]
+    (implicit
+      subRange: AuxF[Exclusive[A], SoftInclusive[B], Sub],
+      reverse: Reverse.Aux[Sub, Rev])
+    : AuxF[Exclusive[A], Exclusive[Succ[B]], Rev] =
+      new BoundedRange[Exclusive[A], Exclusive[Succ[B]]] {
+        type Out = Rev
+
+        def apply(): Out = reverse(subRange())
+      }
+
+    implicit def leftOpenRightClosed[A <: Nat, B <: Nat, Sub <: HList, Rev <: HList]
+    (implicit
+      w: Witness.Aux[Succ[B]],
+      subRange: AuxF[Exclusive[A], SoftInclusive[B], Sub],
+      reverse: ReversePrepend.Aux[Sub, Succ[B] :: HNil, Rev])
+    : AuxF[Exclusive[A], Inclusive[Succ[B]], Rev] =
+      new BoundedRange[Exclusive[A], Inclusive[Succ[B]]] {
+        type Out = Rev
+
+        def apply(): Out = reverse(subRange(), w.value :: HNil)
+      }
+
+    implicit def leftClosedRightOpen[A <: Nat, B <: Nat, Sub <: HList, Rev <: HList]
+    (implicit
+      subRange: AuxF[Inclusive[A], SoftInclusive[B], Sub],
+      reverse: Reverse.Aux[Sub, Rev])
+    : AuxF[Inclusive[A], Exclusive[Succ[B]], Rev] =
+      new BoundedRange[Inclusive[A], Exclusive[Succ[B]]] {
+        type Out =  Rev
+
+        def apply(): Out = reverse(subRange())
+      }
+
+    //
+    // reversed starting ranges
+
+    implicit def openReverse[A <: Nat, B <: Nat, Sub <: HList]
+    (implicit subRange: AuxF[Exclusive[B], SoftInclusive[A], Sub])
+    : AuxF[Exclusive[Succ[A]], Exclusive[B], Sub] =
+      new BoundedRange[Exclusive[Succ[A]], Exclusive[B]] {
+        type Out = Sub
+
+        def apply(): Out = subRange()
+      }
+
+    implicit def leftClosedRightOpenReverse[A <: Nat, B <: Nat, Sub <: HList]
+    (implicit
+      wA: Witness.Aux[Succ[A]],
+      subRange: AuxF[Exclusive[B], SoftInclusive[A], Sub])
+    : AuxF[Inclusive[Succ[A]], Exclusive[B], Succ[A] :: Sub] =
+      new BoundedRange[Inclusive[Succ[A]], Exclusive[B]] {
+        type Out =  Succ[A] :: Sub
+
+        def apply(): Out = wA.value :: subRange()
+      }
+
+    implicit def leftOpenRightClosedReverse[A <: Nat, B <: Nat, Sub <: HList]
+    (implicit subRange: AuxF[Inclusive[B], SoftInclusive[A], Sub])
+    : AuxF[Exclusive[Succ[A]], Inclusive[B], Sub] =
+      new BoundedRange[Exclusive[Succ[A]], Inclusive[B]] {
+        type Out =  Sub
+
+        def apply(): Out = subRange()
+      }
+
+    implicit def closedReverse[A <: Nat, B <: Nat, Sub <: HList]
+    (implicit
+      wA: Witness.Aux[Succ[A]],
+      subRange: AuxF[Inclusive[B], SoftInclusive[A], Sub])
+    : AuxF[Inclusive[Succ[A]], Inclusive[B], Succ[A] :: Sub] =
+      new BoundedRange[Inclusive[Succ[A]], Inclusive[B]] {
+        type Out =  Succ[A] :: Sub
+
+        def apply(): Out = wA.value :: subRange()
+      }
+
+    object Bound {
+
+      implicit def inclusive[A <: Nat]
+      (implicit w: Witness.Aux[A])
+      : Inclusive[A] =
+        new Inclusive[A] {
+          type Out = A
+
+          def apply(): Out = w.value
+        }
+
+      implicit def exclusive[A <: Nat]
+      (implicit w: Witness.Aux[A])
+      : Exclusive[A] =
+        new Exclusive[A] {
+          type Out = A
+
+          def apply(): Out = w.value
+        }
+
+    }
+
   }
 
   /**

--- a/core/src/main/scala/shapeless/syntax/nat.scala
+++ b/core/src/main/scala/shapeless/syntax/nat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-15 Dale Wijnand
+ * Copyright (c) 2011-16 Dale Wijnand
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,21 @@
 
 package shapeless
 package syntax
+
+object nat {
+
+  import ops.nat.BoundedRange
+  import BoundedRange.{Exclusive, Inclusive}
+
+  type *--*[A,B] = BoundedRange[Inclusive[A], Inclusive[B]]
+
+  type :--:[A,B] = BoundedRange[Exclusive[A], Exclusive[B]]
+
+  type :--*[A,B] = BoundedRange[Exclusive[A], Inclusive[B]]
+
+  type *--:[A,B] = BoundedRange[Inclusive[A], Exclusive[B]]
+
+}
 
 /**
  * Carrier for `Nat` operations.

--- a/core/src/test/scala/shapeless/natranges.scala
+++ b/core/src/test/scala/shapeless/natranges.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Assert._
+import org.junit.Test
+
+class natranges {
+
+  import nat._
+  import shapeless.testutil._
+
+  //
+  // Nil ranges: "X to same X"
+
+  @Test
+  def smallest_closed_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _1 :: HNil
+    ](
+      _1 :: HNil,
+      the[_1 *--* _1].apply()
+    )
+  }
+
+  @Test
+  def smallest_closed_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _1 :: HNil
+    ](
+      _1 :: HNil,
+      the[BoundedRange[Inclusive[_1], Inclusive[_1]]].apply()
+    )
+  }
+
+  @Test
+  def smallest_open_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      HNil
+    ](
+      HNil,
+      the[_1 :--: _1].apply()
+    )
+  }
+
+    @Test
+  def smallest_open_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      HNil
+    ](
+      HNil,
+      the[BoundedRange[Exclusive[_1], Exclusive[_1]]].apply()
+    )
+  }
+
+  @Test
+  def smallest_leftOpenRightClosed_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _1 :: HNil
+    ](
+      _1 :: HNil,
+      the[_1 :--* _1].apply()
+    )
+  }
+
+  @Test
+  def smallest_leftOpenRightClosed_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _1 :: HNil
+    ](
+      _1 :: HNil,
+      the[BoundedRange[Exclusive[_1], Inclusive[_1]]].apply()
+    )
+  }
+
+  @Test
+  def smallest_leftClosedRightOpen_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _1 :: HNil
+    ](
+      _1 :: HNil,
+      the[_1 *--: _1].apply()
+    )
+  }
+
+  @Test
+  def smallest_leftClosedRightOpen_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _1 :: HNil
+    ](
+      _1 :: HNil,
+      the[BoundedRange[Inclusive[_1], Exclusive[_1]]].apply()
+    )
+  }
+
+  //
+  // regular ranges: "X to Y"
+
+  @Test
+  def larger_closed_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _1 :: _2 :: _3 :: _4 :: HNil
+    ](
+      _1 :: _2 :: _3 :: _4 :: HNil,
+      the[_1 *--* _4].apply()
+    )
+  }
+
+  @Test
+  def larger_closed_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _1 :: _2 :: _3 :: _4 :: HNil
+    ](
+      _1 :: _2 :: _3 :: _4 :: HNil,
+      the[BoundedRange[Inclusive[_1], Inclusive[_4]]].apply()
+    )
+  }
+
+  @Test
+  def larger_open_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _2 :: _3 :: HNil
+    ](
+      _2 :: _3 :: HNil,
+      the[_1 :--: _4].apply()
+    )
+  }
+
+  @Test
+  def larger_open_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _2 :: _3 :: HNil
+    ](
+      _2 :: _3 :: HNil,
+      the[BoundedRange[Exclusive[_1], Exclusive[_4]]].apply()
+    )
+  }
+
+  @Test
+  def larger_leftClosedRightOpen_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _1 :: _2 :: _3 :: HNil
+    ](
+      _1 :: _2 :: _3 :: HNil,
+      the[_1 *--: _4].apply()
+    )
+  }
+
+  @Test
+  def larger_leftClosedRightOpen_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _1 :: _2 :: _3 :: HNil
+    ](
+      _1 :: _2 :: _3 :: HNil,
+      the[BoundedRange[Inclusive[_1], Exclusive[_4]]].apply()
+    )
+  }
+
+  @Test
+  def larger_leftOpenRightClosed_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _2 :: _3 :: _4 :: HNil
+    ](
+      _2 :: _3 :: _4 :: HNil,
+      the[_1 :--* _4].apply()
+    )
+  }
+
+  @Test
+  def larger_leftOpenRightClosed_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _2 :: _3 :: _4 :: HNil
+    ](
+      _2 :: _3 :: _4 :: HNil,
+      the[BoundedRange[Exclusive[_1], Inclusive[_4]]].apply()
+    )
+  }
+
+  //
+  // Reversed ranges: "X down to Y"
+
+  @Test
+  def reversed_closed_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _4 :: _3 :: _2 :: _1 :: HNil
+    ](
+      _4 :: _3 :: _2 :: _1 :: HNil,
+      the[_4 *--* _1].apply()
+    )
+  }
+
+  @Test
+  def reversed_closed_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _4 :: _3 :: _2 :: _1 :: HNil
+    ](
+      _4 :: _3 :: _2 :: _1 :: HNil,
+      the[BoundedRange[Inclusive[_4], Inclusive[_1]]].apply()
+    )
+  }
+
+  @Test
+  def reversed_open_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _3 :: _2 :: HNil
+    ](
+      _3 :: _2 :: HNil,
+      the[_4 :--: _1].apply()
+    )
+  }
+
+  @Test
+  def reversed_open_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _3 :: _2 :: HNil
+    ](
+      _3 :: _2 :: HNil,
+      the[BoundedRange[Exclusive[_4], Exclusive[_1]]].apply()
+    )
+  }
+
+  @Test
+  def reversed_leftClosedRightOpen_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _4 :: _3 :: _2 :: HNil
+    ](
+      _4 :: _3 :: _2 :: HNil,
+      the[_4 *--: _1].apply()
+    )
+  }
+
+  @Test
+  def reversed_leftClosedRightOpen_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _4 :: _3 :: _2 :: HNil
+    ](
+      _4 :: _3 :: _2 :: HNil,
+      the[BoundedRange[Inclusive[_4], Exclusive[_1]]].apply()
+    )
+  }
+
+  @Test
+  def reversed_leftOpenRightClosed_range_symbolic_syntax = {
+    import syntax.nat._
+    assertTypedEquals[
+      _3 :: _2 :: _1 :: HNil
+    ](
+      _3 :: _2 :: _1 :: HNil,
+      the[_4 :--* _1].apply()
+    )
+  }
+
+  @Test
+  def reversed_leftOpenRightClosed_range_word_syntax = {
+    import ops.nat.BoundedRange
+    import BoundedRange.{Inclusive, Exclusive}
+    assertTypedEquals[
+      _3 :: _2 :: _1 :: HNil
+    ](
+      _3 :: _2 :: _1 :: HNil,
+      the[BoundedRange[Exclusive[_4], Inclusive[_1]]].apply()
+    )
+  }
+
+}


### PR DESCRIPTION
I came across the need in one of my projects to create a range of nats that included the ending nat, and also a reversed range (counting down instead of up). Dealing with the extra syntax and type classes for this was a bit awkward, so I created my own type class that handled those two cases. 

I figured that might be useful to others, so I took the opportunity to extend the generality of of my new typeclass, add some fancy syntax, and provide it here if there is interest in integrating it back into shapeless.

The new type class, `FRange` accepts the `Bound` type class for the beginning and ending of the range (instead of bare `Nat`s), which allows the user to specify that the bound is either inclusive or exclusive. Along with some type aliases, this allows syntax like the following to create ranges:

```scala
scala> import nat._; import syntax.nat.range._
...
scala> the[_1 *--* _4].apply() == _1 :: _2 :: _3 :: _4 :: HNil
res1:  Boolean = true

scala> the[_1 :--* _4].apply() == _2 :: _3 :: _4 :: HNil
res2:  Boolean = true

scala> the[_1 :--: _4].apply() == _2 :: _3 :: HNil
res3:  Boolean = true
```
There's also fancy unicode aliases included:
```scala
scala> the[_1 ●--● _4].apply() == _1 :: _2 :: _3 :: _4 :: HNil
res4:  Boolean = true

scala> the[_1 ○--● _4].apply() == _2 :: _3 :: _4 :: HNil
res5:  Boolean = true

scala> the[_1 ○--○ _4].apply() == _2 :: _3 :: HNil
res6:  Boolean = true
```
Counting down also works with all variations:
```scala
scala> the[_4 ●--● _1].apply() == _4 :: _3 :: _2 :: _1 :: HNil
res8:  Boolean = true
```
The behaviour of the original `Range` type class can be duplicated with fancier syntax:
```scala
scala> the[_1 ●--○ _4].apply() == _1 :: _2 :: _3 :: HNil
res8:  Boolean = true
```

If anything doesn't match up with project standards I'm happy to change the syntax aliasing, shuffle around the package naming, change the line-breaks, or rip out the unicode support.

I also have a few outstanding bits that I wasn't able to find any way to work-into the change request. Any suggestions are welcome:
- [ ] The `FRange.SoftInclusive` trait and associated intermediate recursive implicits should actually be marked private, but it didn't seem possible with the way implicit resolution works.
- [ ] Ideally, I would have liked to alter the original `Range` class to accept the `Bound` type class (as well as the original `Nat`) instead of creating a whole new `FRange` type class. I couldn't figure a way to maintain binary compatibility with the existing Range trait, though. 
- [ ] I was going to add an `@implicitNotFound` annotation for `FRange`, but I couldn't think of a case in which this would be usefully displayed.