### PR TITLE
Add an unwrapped instance for shapeless tags

### DIFF
--- a/core/src/main/scala/shapeless/unwrapped.scala
+++ b/core/src/main/scala/shapeless/unwrapped.scala
@@ -60,6 +60,10 @@ trait UnwrappedInstances extends LowPriorityUnwrappedInstances {
     chain: Strict[Unwrapped.Aux[UI, UF]]
   ) = chain.value.asInstanceOf[Unwrapped.Aux[Newtype[UI, Ops], UF]]
 
+  implicit def tagUnwrapped[T[UI, TT] <: tag.@@[UI, TT], UI, TT, UF](implicit
+    chain: Strict[Unwrapped.Aux[UI, UF]]
+  ) = chain.value.asInstanceOf[Unwrapped.Aux[T[UI, TT], UF]]
+
 }
 
 trait LowPriorityUnwrappedInstances {

--- a/core/src/test/scala/shapeless/unwrapped.scala
+++ b/core/src/test/scala/shapeless/unwrapped.scala
@@ -79,6 +79,23 @@ class UnwrappedTests {
   }
 
   @Test
+  def testShapelessTagged: Unit = {
+
+    import tag._
+
+    val pass = the[Pass[String @@ TestTag]]
+    the[pass.U =:= String]
+    val tagged = tag[TestTag]("testing")
+    val actual = pass.actual(tagged)
+    val wrapped = pass.wrapped(tagged: String)
+    val unwrapped = pass.unwrapped(tagged)
+    assert((actual: String @@ TestTag) == tagged)
+    assert((wrapped: String @@ TestTag) == tagged)
+    assert((unwrapped: String) == (tagged: String))
+    test.illTyped("unwrapped: String @@ TestTag")
+  }
+
+  @Test
   def testScalazTagged: Unit = {
 
     type Tagged[A, T] = { type Tag = T; type Self = A }


### PR DESCRIPTION
By triggering unification, we can get the compiler to be less-good about computing tightest bounds. This allows us to strip off shapeless tags without writing a special-purpose macro.

Supersedes #538 