### PR TITLE
improve `illTyped`

### DIFF
--- a/core/src/main/scala/shapeless/test/typechecking.scala
+++ b/core/src/main/scala/shapeless/test/typechecking.scala
@@ -20,7 +20,7 @@ import scala.language.experimental.macros
 
 import java.util.regex.Pattern
 
-import scala.reflect.macros.{ whitebox, TypecheckException }
+import scala.reflect.macros.{ whitebox, ParseException, TypecheckException }
 
 /**
  * A utility which ensures that a code fragment does not typecheck.
@@ -50,12 +50,14 @@ class IllTypedMacros(val c: whitebox.Context) {
       val dummy0 = TermName(c.freshName)
       val dummy1 = TermName(c.freshName)
       c.typecheck(c.parse(s"object $dummy0 { val $dummy1 = { $codeStr } }"))
-      c.abort(c.enclosingPosition, "Type-checking succeeded unexpectedly.\n"+expMsg)
+      c.error(c.enclosingPosition, "Type-checking succeeded unexpectedly.\n"+expMsg)
     } catch {
       case e: TypecheckException =>
         val msg = e.getMessage
         if((expected ne null) && !(expPat.matcher(msg)).matches)
-          c.abort(c.enclosingPosition, "Type-checking failed in an unexpected way.\n"+expMsg+"\nActual error: "+msg)
+          c.error(c.enclosingPosition, "Type-checking failed in an unexpected way.\n"+expMsg+"\nActual error: "+msg)
+      case e: ParseException =>
+        c.error(c.enclosingPosition, s"Parsing failed.\n${e.getMessage}")
     }
 
     q"()"


### PR DESCRIPTION
* catch parse errors (to distinguish them from type errors)
* blackbox context suffices
* don't abort macro expansion, just report an error