### PR TITLE
Configure external links in ScalaDoc

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,12 @@
 scalacOptions += "-deprecation"
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.15"
 
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"       % "0.1.8")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-osgi"              % "0.6.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"         % "0.6.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-git"               % "0.8.5")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"           % "0.6.9")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"           % "1.0.0")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"               % "1.0.0")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"          % "1.1")
+addSbtPlugin("com.typesafe"                      % "sbt-mima-plugin"       % "0.1.8")
+addSbtPlugin("com.typesafe.sbt"                  % "sbt-osgi"              % "0.6.0")
+addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"         % "0.6.0")
+addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"               % "0.8.5")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"           % "0.6.9")
+addSbtPlugin("com.github.gseitz"                 % "sbt-release"           % "1.0.0")
+addSbtPlugin("com.jsuereth"                      % "sbt-pgp"               % "1.0.0")
+addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"          % "1.1")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "0.2.2")


### PR DESCRIPTION
I found that Shapeless's [Scaladoc](https://oss.sonatype.org/service/local/repositories/releases/archive/com/chuusai/shapeless_2.11/2.3.1/shapeless_2.11-2.3.1-javadoc.jar/!/index.html) does not link to Scala standard library and other dependencies. This patch fixes the problem.