### PR TITLE
RecordArg, inverse of RecordArgs trait

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Arya Irani <arya.irani@gmail.com> @aryairani
 Ben Hutchison <brhutchison@gmail.com> @ben_hutchison
 Ben James <ben.james@guardian.co.uk> @bmjames
 Brian McKenna <brian@brianmckenna.org> @puffnfresh
+Brian Zeligson <brian.zeligson@gmail.com> @beezee
 Bryn Keller <xoltar@xoltar.org> @brynkeller
 Chris Hodapp <clhodapp1@gmail.com> @clhodapp
 Cody Allen <ceedubs@gmail.com> @fourierstrick

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ cross-builds for 2.10.6 and 2.12.x.
 + Ben Hutchison <brhutchison@gmail.com> [@ben_hutchison](https://twitter.com/ben_hutchison)
 + Ben James <ben.james@guardian.co.uk> [@bmjames](https://twitter.com/bmjames)
 + Brian McKenna <brian@brianmckenna.org> [@puffnfresh](https://twitter.com/puffnfresh)
++ Brian Zeligson <brian.zeligson@gmail.com> [@beezee](https://twitter.com/bzeg)
 + Bryn Keller <xoltar@xoltar.org> [@brynkeller](https://twitter.com/brynkeller)
 + Chris Hodapp <clhodapp1@gmail.com> [@clhodapp](https://twitter.com/clhodapp)
 + Cody Allen <ceedubs@gmail.com> [@fourierstrick](https://twitter.com/fourierstrick)

--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -88,22 +88,47 @@ trait RecordArgs extends Dynamic {
   def applyDynamicNamed(method: String)(rec: Any*): Any = macro RecordMacros.forwardNamedImpl
 }
 
+/**
+ * Trait supporting mapping record arguments to named argument lists, inverse of RecordArgs.
+ *
+ * Mixing in this trait enables method applications of the form,
+ *
+ * {{{
+ * lhs.methodRecord('x ->> 23 :: 'y ->> "foo" :: 'z ->> true :: HNil)
+ * }}}
+ *
+ * to be rewritten as,
+ *
+ * {{{
+ * lhs.method(x = 23, y = "foo", z = true)
+ * }}}
+ *
+ * ie. the record argument is used to look up arguments for a target method
+ * (the called method named minus the "Record" suffix) by name and type and the application
+ * is rewritten to an application of the target method
+ */
+trait RecordArg extends Dynamic {
+  def applyDynamic[L <: HList](method: String)(rec: L): Any = macro RecordMacros.forwardFromRecordImpl[L]
+}
+
 @macrocompat.bundle
 class RecordMacros(val c: whitebox.Context) {
   import c.universe._
   import internal.constantType
   import labelled.FieldType
+  import ops.hlist.Selector
 
   val hconsValueTree = reify {  ::  }.tree
   val hnilValueTree  = reify { HNil: HNil }.tree
   val fieldTypeTpe = typeOf[FieldType[_, _]].typeConstructor
   val SymTpe = typeOf[scala.Symbol]
   val atatTpe = typeOf[tag.@@[_,_]].typeConstructor
+  val selectorTpe = typeOf[Selector[_, _]].typeConstructor
 
   def mkRecordEmptyImpl(method: Tree)(rec: Tree*): Tree = {
     if(rec.nonEmpty)
       c.abort(c.enclosingPosition, "this method must be called with named arguments")
-    
+
     q"_root_.shapeless.HNil"
   }
 
@@ -132,13 +157,31 @@ class RecordMacros(val c: whitebox.Context) {
     q""" $lhs.$methodName($recTree) """
   }
 
+  def forwardFromRecordImpl[L <: HList](method: Tree)(rec: Expr[L]): Tree = {
+    val lhs = c.prefix.tree
+    val lhsTpe = lhs.tpe
+
+    val q"${methodString: String}" = method
+
+    if (!methodString.matches(".*Record$"))
+      c.abort(c.enclosingPosition, s"missing method '$methodString'")
+
+    val methodName = TermName(methodString.replaceAll("Record$", ""))
+
+    if(!lhsTpe.member(methodName).isMethod)
+      c.abort(c.enclosingPosition, s"missing method '$methodName'")
+
+    val params = mkParamsImpl(lhsTpe.member(methodName).asMethod, rec)
+    q""" $lhs.$methodName(..$params) """
+  }
+
+  def mkSingletonSymbolType(c: Constant): Type =
+    appliedType(atatTpe, List(SymTpe, constantType(c)))
+
+  def mkFieldTpe(keyTpe: Type, valueTpe: Type): Type =
+    appliedType(fieldTypeTpe, List(keyTpe, valueTpe.widen))
+
   def mkRecordImpl(rec: Tree*): Tree = {
-    def mkSingletonSymbolType(c: Constant): Type =
-      appliedType(atatTpe, List(SymTpe, constantType(c)))
-
-    def mkFieldTpe(keyTpe: Type, valueTpe: Type): Type =
-      appliedType(fieldTypeTpe, List(keyTpe, valueTpe.widen))
-
     def mkElem(keyTpe: Type, value: Tree): Tree =
       q"$value.asInstanceOf[${mkFieldTpe(keyTpe, value.tpe)}]"
 
@@ -151,5 +194,18 @@ class RecordMacros(val c: whitebox.Context) {
     rec.foldRight(hnilValueTree) {
       case(elem, acc) => q""" $hconsValueTree(${promoteElem(elem)}, $acc) """
     }
+  }
+
+  def mkParamsImpl[L <: HList](method: MethodSymbol, rec: Expr[L]): List[Tree] = {
+    def mkElem(keyTpe: Type, value: Tree): Tree =
+      q"implicitly[shapeless.ops.hlist.Selector[${rec.actualType}, ${mkFieldTpe(keyTpe, value.tpe)}]].apply($rec)"
+
+    if (method.paramLists.length != 1)
+      c.abort(c.enclosingPosition, s"${method} must have exactly one parameter list for record application")
+
+    method.paramLists.headOption.toList.flatMap(_.map { x =>
+      mkElem(mkSingletonSymbolType(Constant(x.name.decodedName.toString)), q"${x.typeSignature}")
+    })
+
   }
 }

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -812,6 +812,23 @@ class RecordTests {
     """)
   }
 
+  object Bar extends RecordArg {
+    def sum(i1: Int, i2: Int) = i1 + i2
+  }
+
+  @Test
+  def testRecordArg {
+    val r = ('i1 ->> 1) :: ('i2 ->> 3) :: HNil
+
+    val v1 = Bar.sumRecord(r)
+    typed[Int](v1)
+    assertEquals(4, v1)
+
+    illTyped("""
+      Bar.sumRecord(('i1 ->> 1) :: ('i3 ->> 3) :: HNil)
+    """)
+  }
+
   @Test
   def testFields {
     {


### PR DESCRIPTION
This adds a RecordArg trait, which is essentially the inverse of the RecordArgs trait. Specifically, instead of allowing forward from "method" to "methodRecord" where method can be passed named parameters that will be rolled into a record for the forwarded call, this allows forwarding from "methodRecord" to "method", where the signature of method is used to access required parameters from a record passed to the original call.

This allows a more typesafe application of functions that may take a series of similarly typed parameters, so that parameter order cannot be mistaken in such a way as to produce errors or incorrect behavior at runtime.

EG - https://gist.github.com/beezee/fe604473c557564f9a6c1be06bc0960d