### PR TITLE
RecordArg, inverse of RecordArgs trait

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Arya Irani <arya.irani@gmail.com> @aryairani
 Ben Hutchison <brhutchison@gmail.com> @ben_hutchison
 Ben James <ben.james@guardian.co.uk> @bmjames
 Brian McKenna <brian@brianmckenna.org> @puffnfresh
+Brian Zeligson <brian.zeligson@gmail.com> @beezee
 Bryn Keller <xoltar@xoltar.org> @brynkeller
 Chris Hodapp <clhodapp1@gmail.com> @clhodapp
 Cody Allen <ceedubs@gmail.com> @fourierstrick

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ cross-builds for 2.10.6 and 2.12.x.
 + Ben Hutchison <brhutchison@gmail.com> [@ben_hutchison](https://twitter.com/ben_hutchison)
 + Ben James <ben.james@guardian.co.uk> [@bmjames](https://twitter.com/bmjames)
 + Brian McKenna <brian@brianmckenna.org> [@puffnfresh](https://twitter.com/puffnfresh)
++ Brian Zeligson <brian.zeligson@gmail.com> [@beezee](https://twitter.com/bzeg)
 + Bryn Keller <xoltar@xoltar.org> [@brynkeller](https://twitter.com/brynkeller)
 + Chris Hodapp <clhodapp1@gmail.com> [@clhodapp](https://twitter.com/clhodapp)
 + Cody Allen <ceedubs@gmail.com> [@fourierstrick](https://twitter.com/fourierstrick)

--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -196,7 +196,7 @@ class RecordMacros(val c: whitebox.Context) {
 
   def mkParamsImpl[L <: HList](method: MethodSymbol, rec: Expr[L]): List[Tree] = {
     def mkElem(keyTpe: Type, value: Tree): Tree =
-      q"implicitly[shapeless.ops.hlist.Selector[${rec.actualType}, ${mkFieldTpe(keyTpe, value.tpe)}]].apply($rec)"
+      q"_root_.scala.Predef.implicitly[_root_.shapeless.ops.hlist.Selector[${rec.actualType}, ${mkFieldTpe(keyTpe, value.tpe)}]].apply($rec)"
 
     if (method.paramLists.length != 1)
       c.abort(c.enclosingPosition, s"${method} must have exactly one parameter list for record application")

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3021,6 +3021,43 @@ class HListTests {
     assertEquals((23, true), ib)
   }
 
+  object Bar extends FromProductArgs {
+    def sumLabel(k: String, i1: Int, i2: Int) = (k, i1 + i2)
+    def sumImplicitLabel(k: String, i1: Int)(implicit i2: Int) = (k, i1 + i2)
+    def sumMultipleParamListLabel(k: String, i1: Int)(i2: Int) = (k, i1 + i2)
+  }
+
+  @Test
+  def testFromProductArgs {
+    val p = "foo" :: 1 :: 3 :: HNil
+
+    val v1 = Bar.sumLabelProduct(p)
+    typed[(String, Int)](v1)
+    assertEquals(("foo", 4), v1)
+
+    val p2 = "bar" :: 1 :: 2 :: HNil
+    val v2 = Bar.sumMultipleParamListLabelProduct(p2)
+    typed[(String, Int)](v2)
+    assertEquals(("bar", 3), v2)
+
+    illTyped("""
+      Bar.sumImplicitLabelProduct("foo" :: 1 :: 3 :: HNil)
+    """)
+
+    implicit val i2 = 7
+    val v3 = Bar.sumImplicitLabelProduct("foo" :: 1 :: HNil)
+    typed[(String, Int)](v3)
+    assertEquals(("foo", 8), v3)
+
+    illTyped("""
+      Bar.sumLabelProduct("foo" :: "bar" :: 1 :: 2 :: HNil)
+    """)
+
+    illTyped("""
+      Bar.sumMultipleParamListLabelProduct("foo" :: "1" :: 2 :: 3 :: HNil)
+    """)
+  }
+
   @Test
   def selectAllTest: Unit ={
     import shapeless._, record._ , ops.hlist.SelectAll

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -826,7 +826,8 @@ class RecordTests {
     typed[Int](v1)
     assertEquals(4, v1)
 
-    val v2 = Bar.sumMultipleParamListRecord(r.merge(('i2 ->> 2) :: HNil))
+    val r2 = r.merge(('i2 ->> 2) :: HNil)
+    val v2 = Bar.sumMultipleParamListRecord(r2)
     typed[Int](v2)
     assertEquals(3, v2)
 

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -812,20 +812,39 @@ class RecordTests {
     """)
   }
 
-  object Bar extends RecordArg {
+  object Bar extends FromRecordArgs {
     def sum(i1: Int, i2: Int) = i1 + i2
+    def sumImplicit(i1: Int)(implicit i2: Int) = i1 + i2
+    def sumMultipleParamList(i1: Int)(i2: Int) = i1 + i2
   }
 
   @Test
-  def testRecordArg {
+  def testFromRecordArgs {
     val r = ('i1 ->> 1) :: ('i2 ->> 3) :: HNil
 
     val v1 = Bar.sumRecord(r)
     typed[Int](v1)
     assertEquals(4, v1)
 
+    val v2 = Bar.sumMultipleParamListRecord(r.merge(('i2 ->> 2) :: HNil))
+    typed[Int](v2)
+    assertEquals(3, v2)
+
+    illTyped("""
+      Bar.sumImplicitRecord(('i1 ->> 1) :: ('i2 ->> 3) :: HNil)
+    """)
+
+    implicit val i2 = 7
+    val v3 = Bar.sumImplicitRecord(r)
+    typed[Int](v2)
+    assertEquals(8, v3)
+
     illTyped("""
       Bar.sumRecord(('i1 ->> 1) :: ('i3 ->> 3) :: HNil)
+    """)
+
+    illTyped("""
+      Bar.sumMultipleParamListRecord(('i1 ->> 1) :: ('i3 ->> 3) :: HNil)
     """)
   }
 

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -812,6 +812,23 @@ class RecordTests {
     """)
   }
 
+  object Bar extends RecordArg {
+    def sum(i1: Int, i2: Int) = i1 + i2
+  }
+
+  @Test
+  def testRecordArg {
+    val r = ('i1 ->> 1) :: ('i2 ->> 3) :: HNil
+
+    val v1 = Bar.sumRecord(r)
+    typed[Int](v1)
+    assertEquals(4, v1)
+
+    illTyped("""
+      Bar.sumRecord(('i1 ->> 1) :: ('i3 ->> 3) :: HNil)
+    """)
+  }
+
   @Test
   def testFields {
     {


### PR DESCRIPTION
This adds a RecordArg trait, which is essentially the inverse of the RecordArgs trait. Specifically, instead of allowing forward from "method" to "methodRecord" where method can be passed named parameters that will be rolled into a record for the forwarded call, this allows forwarding from "methodRecord" to "method", where the signature of method is used to access required parameters from a record passed to the original call.

This allows a more typesafe application of functions that may take a series of similarly typed parameters, so that parameter order cannot be mistaken in such a way as to produce errors or incorrect behavior at runtime.

EG - https://gist.github.com/beezee/fe604473c557564f9a6c1be06bc0960d

Re-open of #602 after correcting commit history and cleaning up a stray import and definition.