### PR TITLE
ZipOne instance for HNil

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -2089,7 +2089,21 @@ object hlist {
    */
   trait ZipOne[H <: HList, T <: HList] extends DepFn2[H, T] with Serializable { type Out <: HList }
 
-  object ZipOne {
+  object ZipOne extends LowPriorityZipOne {
+    implicit def zipOne0: Aux[HNil, HNil, HNil] =
+      new ZipOne[HNil, HNil] {
+        type Out = HNil
+        def apply(h : HNil, t : HNil): Out = HNil
+      }
+
+    implicit def zipOne3[H, T <: HList]: Aux[H :: HNil, T :: HNil, (H :: T) :: HNil] =
+      new ZipOne[H :: HNil, T :: HNil] {
+        type Out = (H :: T) :: HNil
+        def apply(h : H :: HNil, t : T :: HNil): Out = (h.head :: t.head) :: HNil
+      }
+  }
+
+  trait LowPriorityZipOne {
     def apply[H <: HList, T <: HList](implicit zip: ZipOne[H, T]): Aux[H, T, zip.Out] = zip
 
     type Aux[H <: HList, T <: HList, Out0 <: HList] = ZipOne[H, T] { type Out = Out0 }
@@ -2104,12 +2118,6 @@ object hlist {
       new ZipOne[HNil, T] {
         type Out = HNil
         def apply(h : HNil, t : T): Out = HNil
-      }
-
-    implicit def zipOne3[H, T <: HList]: Aux[H :: HNil, T :: HNil, (H :: T) :: HNil] =
-      new ZipOne[H :: HNil, T :: HNil] {
-        type Out = (H :: T) :: HNil
-        def apply(h : H :: HNil, t : T :: HNil): Out = (h.head :: t.head) :: HNil
       }
 
     implicit def zipOne4[HH, HT <: HList, TH <: HList, TT <: HList, ZotOut <: HList]

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1734,6 +1734,9 @@ class HListTests {
 
     val r11 = (HNil :: HNil :: HNil : HNil :: HNil :: HNil).transpose
     assertTypedEquals[HNil](HNil, r11)
+
+    val r12 = (1 :: HNil) zipOne ((2 :: HNil) :: HNil)
+    assertTypedEquals[(Int :: Int :: HNil) :: HNil]((1 :: 2 :: HNil) :: HNil, r12)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1723,6 +1723,17 @@ class HListTests {
 
     val r8 = t3.transpose
     assertTypedEquals[ISD :: ISD :: ISD :: HNil](z2, r8)
+
+    val nil: HNil = HNil
+
+    val r9 = nil zipOne nil
+    assertTypedEquals[HNil](HNil, r9)
+
+    val r10 = nil.transpose
+    assertTypedEquals[HNil](HNil, r10)
+
+    val r11 = (HNil :: HNil :: HNil : HNil :: HNil :: HNil).transpose
+    assertTypedEquals[HNil](HNil, r11)
   }
 
   @Test
@@ -1747,6 +1758,10 @@ class HListTests {
     val z3 = (l1 :: l2 :: HNil).zip
     assertTypedEquals[(Int, Int) :: (String, String) :: (Double, Double) :: HNil](
       (1, 2) :: ("a", "b") :: (1.0, 2.0) :: HNil, z3)
+
+    val nil : HNil = HNil
+    val z4 = (nil :: nil :: HNil).zip
+    assertTypedEquals[HNil](nil, z4)
 
     val t2 = z1.map(productElements).transpose
     val u1 = t2.tupled


### PR DESCRIPTION
``` scala
implicitly[ZipOne[HNil, HNil]]
```

caused an ambiguous implicit resiolution. This commit fixes it, allowing us to zip two `HNil`s together.
