### PR TITLE
improve singleton macro error message

### DIFF
--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -326,7 +326,7 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils wi
       case (SymTpe, LiteralSymbol(s)) =>
         mkResult(SingletonSymbolType(s), mkSingletonSymbol(s))
 
-      case (tpe, tree) if tree.symbol.isTerm && tree.symbol.asTerm.isStable && !isValueClass(tree.symbol) =>
+      case (tpe, tree) if (tree.symbol ne null) && tree.symbol.isTerm && tree.symbol.asTerm.isStable && !isValueClass(tree.symbol) =>
         val sym = tree.symbol.asTerm
         val pre = if(sym.owner.isClass) c.internal.thisType(sym.owner) else NoPrefix
         val symTpe = c.internal.singleType(pre, sym)


### PR DESCRIPTION
before

```
scala> import shapeless._, syntax.singleton._
import shapeless._
import syntax.singleton._

scala> (true: Boolean).narrow
<console>:20: error: exception during macro expansion:
java.lang.NullPointerException
    at shapeless.SingletonTypeMacros.extractResult(singletons.scala:318)
    at shapeless.SingletonTypeMacros.mkSingletonOps(singletons.scala:393)

       (true: Boolean).narrow
            ^
<console>:20: error: value narrow is not a member of Boolean
       (true: Boolean).narrow
                       ^
```

after

```
scala> import shapeless._, syntax.singleton._
import shapeless._
import syntax.singleton._

scala> (true: Boolean).narrow
<console>:23: error: Expression (true: Boolean) does not evaluate to a constant or a stable reference value
       (true: Boolean).narrow
            ^
<console>:23: error: value narrow is not a member of Boolean
       (true: Boolean).narrow
                       ^
```
