### PR TITLE
Add HasNoGeneric

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -264,6 +264,12 @@ object HasCoproductGeneric {
   implicit def apply[T]: HasCoproductGeneric[T] = macro GenericMacros.mkHasCoproductGeneric[T]
 }
 
+class HasNoGeneric[T] extends Serializable
+
+object HasNoGeneric {
+  implicit def apply[T]: HasNoGeneric[T] = macro GenericMacros.mkHasNoGeneric[T]
+}
+
 @macrocompat.bundle
 trait ReprTypes {
   val c: blackbox.Context
@@ -1078,5 +1084,13 @@ class GenericMacros(val c: whitebox.Context) extends CaseClassMacros {
       abort(s"Unable to materialize HasCoproductGeneric for $tTpe")
 
     q"""new _root_.shapeless.HasCoproductGeneric[$tTpe]: _root_.shapeless.HasCoproductGeneric[$tTpe]"""
+  }
+
+  def mkHasNoGeneric[T: WeakTypeTag]: Tree = {
+    val tTpe = weakTypeOf[T]
+    if (isProduct(tTpe) || isCoproduct(tTpe))
+      abort(s"Unable to materialize HasNoGeneric for $tTpe")
+
+    q"""new _root_.shapeless.HasNoGeneric[$tTpe]: _root_.shapeless.HasNoGeneric[$tTpe]"""
   }
 }

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -599,6 +599,14 @@ class GenericTests {
     illTyped(" Generic[Union.`'i -> Int, 's -> String`.T] ")
   }
 
+  @Test
+  def testHasNoGeneric {
+    HasNoGeneric[Array[Int]]
+    HasNoGeneric[String]
+    illTyped(" HasNoGeneric[Fruit] ")
+    illTyped(" HasNoGeneric[(Int, String)] ")
+  }
+
   sealed trait Color
   case object Green extends Color
   object Color {


### PR DESCRIPTION
This PR adds a `HasNoGeneric[T]` type class to witness that `T` has no `Generic` instance. With this addition, it becomes possible to implement a `trait GenericRep[T] { type Repr }` which fully "unrolls" all the `Generic` macros to have the full generic representation of a type. [Example gist](https://gist.github.com/OlivierBlanvillain/4163a3b4cd615a37f62a5006fe7dc34b).