### PR TITLE
`Builder` and `build` method to build an HList from a type and a Poly

### DIFF
--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -89,6 +89,8 @@ object HList extends Dynamic {
     */
   def fillWith[L <: HList] = new FillWithOps[L]
 
+  def build[H <: HList](f: Poly)(implicit builder: Builder[f.type, H]): H = builder()
+
   implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
 
   /**

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -317,6 +317,24 @@ object hlist {
         }
   }
 
+  trait Builder[HF, H <: HList] extends Serializable {
+    def apply():H
+  }
+
+  object Builder {
+
+    implicit def hnilBuilder1[HF]: Builder[HF, HNil] = new Builder[HF, HNil] {
+      def apply() = HNil
+    }
+
+    implicit def hlistBuilder1[HF <: Poly, H, T <: HList]
+      (implicit hc : Case.Aux[HF, HNil, H], bt : Builder[HF, T]): Builder[HF, H :: T] =
+      new Builder[HF, H ::T] {
+        def apply() = hc(HNil) :: bt()
+      }
+
+  }
+
   /**
    * Type class supporting flatmapping a higher ranked function over this `HList`.
    *

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3342,4 +3342,18 @@ class HListTests {
     val r5 = (1 :: "2" :: 3 :: 4 :: HNil).combinations(0)
     assertTypedEquals[HNil :: HNil](HNil :: HNil, r5)
   }
+
+  @Test
+  def testBuild {
+    type H = Int :: String :: HNil
+
+    object builder extends Poly0 {
+      implicit val atInt = at[Int](42)
+      implicit val atString = at[String]("foo")
+    }
+
+    val r = HList.build[H](builder)
+
+    assertTypedEquals[Int :: String :: HNil](42 :: "foo" :: HNil, r)
+  }
 }


### PR DESCRIPTION
This seems like a reasonable utility method; it makes doing a couple things a lot cleaner. I don't know if the `build`/`Builder` names are what we want.

If people think this should be in Shapeless core, I'm happy to add docs and make any changes.