### PR TITLE
Fix type loss issue with `LiftAll`

### DIFF
--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -2829,10 +2829,10 @@ object hlist {
       def instances = HNil
     }
 
-    implicit def hcons[F[_], H, T <: HList]
-      (implicit headInstance: F[H], tailInstances: LiftAll[F, T]): Aux[F, H :: T, F[H] :: tailInstances.Out] =
+    implicit def hcons[F[_], H, T <: HList, TI <: HList]
+      (implicit headInstance: F[H], tailInstances: Aux[F, T, TI]): Aux[F, H :: T, F[H] :: TI] =
         new LiftAll[F, H :: T] {
-          type Out = F[H] :: tailInstances.Out
+          type Out = F[H] :: TI
           def instances = headInstance :: tailInstances.instances
     }
   }


### PR DESCRIPTION
I did this because `LiftAll.Aux` can't always resolve correctly with the current implementation.  Because the type `tailInstances.Out` is not a type argument to `hcons`, scalac has trouble resolving implicit `LiftAll.Aux[F, L, I]` if `I` is to be inferred.  With this small change, `I` can always be inferred (assuming all elements of `L` have instances for `F`)