### PR TITLE
Minimal conditions for automatic type class derivation

### DIFF
--- a/core/src/main/scala/shapeless/labelledtypeclasscompanions.scala
+++ b/core/src/main/scala/shapeless/labelledtypeclasscompanions.scala
@@ -1,0 +1,114 @@
+package shapeless
+
+/**
+  * A type class that is isomorphic to the kind it abstracts over.
+  * Refines TypeClassIsomorphism with the addition of runtime `String` labels
+  * corresponding to the names of the product elements.
+  * A type class inheriting this behavior can automatically abstract over the `product`
+  * operation. See LabelledProductTypeClassIsomorphismCompanion.
+  */
+trait LabelledTypeClassIsomorphism[C[_]] extends Serializable { // an isomorphism between T and C[T]
+  def point[T](t: T): C[T]
+  def unwrap[T](ct: C[T]): T
+  def unwrap[T](name: String, ct: C[T]): T
+}
+
+trait LabelledProductTypeClassIsomorphismCompanion[C[_]] extends Serializable with LabelledProductTypeClassCompanion[C] with LabelledTypeClassIsomorphism[C] {
+  trait typeClassTrait extends Serializable with LabelledProductTypeClass[C] {
+    def product[H, T <: HList](name: String, ch: C[H], ct: C[T]): C[H :: T] = point(unwrap(name, ch) :: unwrap(ct))
+    def emptyProduct: C[HNil] = point(HNil)
+    def project[F, G](instance: => C[G], to: (F) => G, from: (G) => F): C[F] = point(from(unwrap(instance)))
+  }
+
+  object typeClass extends typeClassTrait
+}
+
+/**
+  * A type class that can be created from a single function `T => T` for any type `T`.
+  * Given an instance of the type class and a value of type `T`, the type class can be applied
+  * on the value to return a type `T`
+  * Refines TypeClassApplyInstance with the addition of runtime `String` labels
+  * corresponding to the names of the product elements.
+  * A type class inheriting this behavior can automatically abstract over the `product`
+  * operation. See LabelledProductTypeClassApplyInstanceCompanion.
+  */
+trait LabelledTypeClassApplyInstance[C[_]] {
+  def point[T](f: T => T): C[T]
+  def applyInstance[T](instance: => C[T], t: T): T
+  def applyInstance[T](name: String, instance: => C[T], t: T): T
+}
+
+trait LabelledProductTypeClassApplyInstanceCompanion[C[_]] extends Serializable with LabelledProductTypeClassCompanion[C] with LabelledTypeClassApplyInstance[C] {
+  trait typeClassTrait extends Serializable with LabelledProductTypeClass[C] {
+    def product[H, T <: HList](name: String, ch: C[H], ct: C[T]): C[H :: T] = point(hl => applyInstance(name, ch, hl.head) :: applyInstance(ct, hl.tail))
+    def emptyProduct: C[HNil] = point(identity)
+    def project[F, G](instance: => C[G], to: (F) => G, from: (G) => F): C[F] = point(f => from(applyInstance(instance, to(f))))
+  }
+
+  object typeClass extends typeClassTrait
+}
+
+/**
+  * A type class that can be created from a single function `T => G` for any types `T` and `G`.
+  * Given an instance of the type class and a value of type `T`, the type class can be applied
+  * on the value to return a type `G`
+  * Refines CoproductTypeClassApplyInstance with the addition of runtime `String` labels
+  * corresponding to the names of the product elements.
+  * A type class inheriting this behavior can automatically abstract over the `coproduct`
+  * operation. See LabelledCoproductTypeClassApplyInstanceCompanion.
+  */
+trait LabelledCoproductTypeClassApplyInstance[C[_], G] extends Serializable {
+  def point[T](f: T => G): C[T]
+  def applyInstance[T](instance: => C[T], t: T): G
+  def applyInstance[T](name: String, instance: => C[T], t: T): G
+}
+
+trait LabelledCoproductTypeClassApplyInstanceCompanion[C[_], G] extends Serializable with LabelledCoproductTypeClassCompanion[C] with LabelledCoproductTypeClassApplyInstance[C, G] {
+  trait typeClassTrait extends Serializable with LabelledCoproductTypeClass[C] {
+    def coproduct[L, R <: Coproduct](name: String, cl: => C[L], cr: => C[R]): C[L :+: R] = point {
+      case Inl(l) => applyInstance(name, cl, l)
+      case Inr(r) => applyInstance(cr, r)
+    }
+    def emptyCoproduct: C[CNil] = point(_ => ???)
+  }
+
+  object typeClass extends typeClassTrait
+}
+
+/**
+  * A type class that can be created from a single function `T => G` for any types `T` and `G`,
+  * where G is also a Monoid.
+  * Given an instance of the type class and a value of type `T`, the type class can be applied
+  * on the value to return a type `G`
+  * Refines Companion1 with the addition of runtime `String` labels
+  * corresponding to the names of the product elements.
+  * A type class inheriting this behavior can automatically abstract over the `product` and `coproduct`
+  * operations. See LabelledTypeClassCompanion1.
+  */
+trait LabelledCompanion1[C[_], G] extends Serializable {
+  def point[T](f: T => G): C[T]
+  def applyInstance[T](instance: => C[T], t: T): G
+  def applyInstanceProduct[T](name: String, instance: => C[T], t: T): G
+  def applyInstanceCoproduct[T](name: String, instance: => C[T], t: T): G
+  def zero: G
+  def append(left: G, right: G): G
+  implicit class GOps(left: G) {
+    def |+|(right: G) = append(left, right)
+  }
+}
+
+trait LabelledTypeClassCompanion1[C[_], G] extends Serializable with LabelledTypeClassCompanion[C] with LabelledCompanion1[C, G] {
+  trait typeClassTrait extends Serializable with LabelledTypeClass[C] {
+    def emptyCoproduct: C[CNil] = point(_ => zero)
+    def coproduct[L, R <: Coproduct](name: String, cl: => C[L], cr: => C[R]): C[L :+: R] = point {
+      case Inl(l) => applyInstanceCoproduct(name, cl, l)
+      case Inr(r) => applyInstance(cr, r)
+    }
+    def product[H, T <: HList](name: String, ch: C[H], ct: C[T]): C[H :: T] =
+      point(hlist => applyInstanceProduct(name, ch, hlist.head) |+| applyInstance(ct, hlist.tail))
+    def emptyProduct: C[HNil] = point(_ => zero)
+    def project[F, G](instance: => C[G], to: F => G, from: G => F): C[F] = point((t: F) => applyInstance(instance, to(t)))
+  }
+
+  object typeClass extends typeClassTrait
+}

--- a/core/src/main/scala/shapeless/typeclasscompanions.scala
+++ b/core/src/main/scala/shapeless/typeclasscompanions.scala
@@ -1,0 +1,101 @@
+package shapeless
+
+/**
+  * A type class that is isomorphic to the kind it abstracts over for every kind `*`.
+  * A type class inheriting this behavior can automatically abstract over the `product`
+  * operation. See ProductTypeClassIsomorphismCompanion.
+  */
+trait TypeClassIsomorphism[C[_]] extends Serializable { // an isomorphism between T and C[T]
+  def point[T](t: T): C[T]
+  def unwrap[T](ct: C[T]): T
+}
+
+trait ProductTypeClassIsomorphismCompanion[C[_]] extends Serializable with ProductTypeClassCompanion[C] with TypeClassIsomorphism[C] {
+  trait typeClassTrait extends Serializable with ProductTypeClass[C] {
+    def product[H, T <: HList](ch: C[H], ct: C[T]): C[H :: T] = point(unwrap(ch) :: unwrap(ct))
+    def emptyProduct: C[HNil] = point(HNil)
+    def project[F, G](instance: => C[G], to: (F) => G, from: (G) => F): C[F] = point(from(unwrap(instance)))
+  }
+
+  object typeClass extends typeClassTrait
+}
+
+/**
+  * A type class that can be created from a single function `T => T` for any type `T`.
+  * Given an instance of the type class and a value of type `T`, the type class can be applied
+  * on the value to return a type `T`
+  * A type class inheriting this behavior can automatically abstract over the `product`
+  * operation. See ProductTypeClassApplyInstanceCompanion.
+  */
+trait TypeClassApplyInstance[C[_]] extends Serializable {
+  def point[T](f: T => T): C[T]
+  def applyInstance[T](instance: => C[T], t: T): T
+}
+
+trait ProductTypeClassApplyInstanceCompanion[C[_]] extends Serializable with ProductTypeClassCompanion[C] with TypeClassApplyInstance[C] {
+  trait typeClassTrait extends Serializable with ProductTypeClass[C] {
+    def product[H, T <: HList](ch: C[H], ct: C[T]): C[H :: T] = point(hl => applyInstance(ch, hl.head) :: applyInstance(ct, hl.tail))
+    def emptyProduct: C[HNil] = point(identity)
+    def project[F, G](instance: => C[G], to: (F) => G, from: (G) => F): C[F] = point(f => from(applyInstance(instance, to(f))))
+  }
+
+  object typeClass extends typeClassTrait
+}
+
+/**
+  * A type class that can be created from a single function `T => G` for any types `T` and `G`.
+  * Given an instance of the type class and a value of type `T`, the type class can be applied
+  * on the value to return a type `G`
+  * A type class inheriting this behavior can automatically abstract over the `coproduct`
+  * operation. See CoproductTypeClassApplyInstanceCompanion.
+  */
+trait CoproductTypeClassApplyInstance[C[_], G] extends Serializable {
+  def point[T](f: T => G): C[T]
+  def applyInstance[T](instance: => C[T], t: T): G
+}
+
+trait CoproductTypeClassApplyInstanceCompanion[C[_], G] extends Serializable with CoproductTypeClassCompanion[C] with CoproductTypeClassApplyInstance[C, G] {
+  trait typeClassTrait extends Serializable with CoproductTypeClass[C] {
+    def coproduct[L, R <: Coproduct](cl: => C[L], cr: => C[R]): C[L :+: R] = point {
+      case Inl(l) => applyInstance(cl, l)
+      case Inr(r) => applyInstance(cr, r)
+    }
+    def emptyCoproduct: C[CNil] = point(_ => ???)
+  }
+
+  object typeClass extends typeClassTrait
+}
+
+/**
+  * A type class that can be created from a single function `T => G` for any types `T` and `G`,
+  * where G is also a Monoid.
+  * Given an instance of the type class and a value of type `T`, the type class can be applied
+  * on the value to return a type `G`
+  * A type class inheriting this behavior can automatically abstract over the `product` and `coproduct`
+  * operations. See TypeClassCompanion1.
+  */
+trait Companion1[C[_], G] extends Serializable {
+  def point[T](f: T => G): C[T]
+  def applyInstance[T](instance: => C[T], t: T): G
+  def zero: G
+  def append(left: G, right: G): G
+  implicit class GOps(left: G) {
+    def |+|(right: G) = append(left, right)
+  }
+}
+
+trait TypeClassCompanion1[C[_], G] extends Serializable with TypeClassCompanion[C] with Companion1[C, G] {
+  trait typeClassTrait extends Serializable with TypeClass[C] {
+    def emptyCoproduct: C[CNil] = point(_ => zero)
+    def coproduct[L, R <: Coproduct](cl: => C[L], cr: => C[R]): C[L :+: R] = point {
+      case Inl(l) => applyInstance(cl, l)
+      case Inr(r) => applyInstance(cr, r)
+    }
+    def product[H, T <: HList](ch: C[H], ct: C[T]): C[H :: T] =
+      point(hlist => applyInstance(ch, hlist.head) |+| applyInstance(ct, hlist.tail))
+    def emptyProduct: C[HNil] = point(_ => zero)
+    def project[F, G](instance: => C[G], to: F => G, from: G => F): C[F] = point((t: F) => applyInstance(instance, to(t)))
+  }
+
+  object typeClass extends typeClassTrait
+}

--- a/examples/src/main/scala/shapeless/examples/increment.scala
+++ b/examples/src/main/scala/shapeless/examples/increment.scala
@@ -1,0 +1,35 @@
+package shapeless
+package examples
+
+trait Increment[T] {
+  def increment(t: T): T
+}
+
+object Increment extends ProductTypeClassApplyInstanceCompanion[Increment] {
+  override def point[T](f: (T) => T): Increment[T] = new Increment[T] {
+    override def increment(t: T): T = f(t)
+  }
+  override def applyInstance[T](instance: => Increment[T], t: T): T = instance.increment(t)
+
+  implicit val int: Increment[Int] = point(_ + 1)
+  implicit val double: Increment[Double] = point(_ + 1.0)
+  implicit val boolean: Increment[Boolean] = point(_ || true)
+}
+
+trait IncrementSyntax[T] {
+  def increment: T
+}
+
+object IncrementSyntax {
+  implicit def ToIncrementSyntax[T](t: T)(implicit ev: Increment[T]) = new IncrementSyntax[T] {
+    def increment: T = ev.increment(t)
+  }
+}
+
+object IncrementExample extends App {
+  import IncrementSyntax._
+  case class Foo(i: Int, d: Double, b: Boolean)
+  val foo = Foo(12, 100.32, false)
+  val foo2 = Foo(13, 101.32, true)
+  assert(foo.increment == foo2)
+}

--- a/examples/src/main/scala/shapeless/examples/name.scala
+++ b/examples/src/main/scala/shapeless/examples/name.scala
@@ -1,0 +1,44 @@
+package shapeless
+package examples
+
+case class Name(override val toString: String) extends AnyVal
+
+trait HasName[T] {
+  def name(t: T): Name
+}
+
+object HasName extends CoproductTypeClassApplyInstanceCompanion[HasName, Name] {
+  def point[T](f: (T) => Name): HasName[T] = new HasName[T] {
+    def name(t: T): Name = f(t)
+  }
+  def applyInstance[T](instance: => HasName[T], t: T): Name = instance.name(t)
+
+  implicit val int: HasName[Int] = point(_ => Name("Int"))
+  implicit val double: HasName[Double] = point(_ => Name("Double"))
+  implicit val boolean: HasName[Boolean] = point(_ => Name("Boolean"))
+  implicit val string: HasName[String] = point(_ => Name("String"))
+}
+
+trait HasNameSyntax {
+  def getName: Name
+}
+
+object HasNameSyntax {
+  implicit def toHasNameSyntax[T](t: T)(implicit ev: HasName[T]) = new HasNameSyntax {
+    def getName: Name = ev.name(t)
+  }
+}
+
+object NameExample extends App {
+  import HasNameSyntax._
+  type A = Int :+: Boolean :+: Double :+: String :+: CNil
+  val i = Coproduct[A](12)
+  val d = Coproduct[A](101.12)
+  val b = Coproduct[A](true)
+  val s = Coproduct[A]("abcd")
+
+  assert(i.getName == Name("Int"))
+  assert(d.getName == Name("Double"))
+  assert(b.getName == Name("Boolean"))
+  assert(s.getName == Name("String"))
+}

--- a/examples/src/main/scala/shapeless/examples/width.scala
+++ b/examples/src/main/scala/shapeless/examples/width.scala
@@ -1,0 +1,37 @@
+package shapeless
+package examples
+
+trait Width[T] {
+  def width(t: T): Int
+}
+
+object Width extends TypeClassCompanion1[Width, Int] {
+  def point[T](f: (T) => Int): Width[T] = new Width[T] {
+    def width(t: T): Int = f(t)
+  }
+  def applyInstance[T](instance: => Width[T], t: T): Int = instance.width(t)
+  val zero: Int = 0
+  def append(left: Int, right: Int): Int = left + right
+
+  implicit val int: Width[Int] = point(_ => 1)
+  implicit val boolean: Width[Boolean] = point(_ => 1)
+  implicit val double: Width[Double] = point(_ => 1)
+  implicit val string: Width[String] = point(_.length)
+}
+
+trait WidthSyntax {
+  def width: Int
+}
+
+object WidthSyntax {
+  implicit def ToWidthSyntax[T](t: T)(implicit ev: Width[T]) = new WidthSyntax {
+    def width = ev.width(t)
+  }
+}
+
+object WidthExample extends App {
+  import WidthSyntax._
+  case class Foo(i: Int, d: Double, b: Boolean, s: String)
+  val foo = Foo(12, 13.0, false, "hello")
+  assert(foo.width == 8)
+}

--- a/examples/src/main/scala/shapeless/examples/zero.scala
+++ b/examples/src/main/scala/shapeless/examples/zero.scala
@@ -1,0 +1,25 @@
+package shapeless
+package examples
+
+trait Zero[T] {
+  def zero: T
+}
+
+object Zero extends ProductTypeClassIsomorphismCompanion[Zero] {
+  def point[T](t: T): Zero[T] = new Zero[T] {
+    def zero: T = t
+  }
+  def unwrap[T](ct: Zero[T]): T = ct.zero
+
+  implicit val int: Zero[Int] = point(0)
+  implicit val double: Zero[Double] = point(0.0)
+  implicit val boolean: Zero[Boolean] = point(false)
+  implicit val string: Zero[String] = point("")
+}
+
+object ZeroExample extends App {
+  case class Foo(i: Int, b: Boolean, s: String)
+  case class Bar(d: Double, f: Foo)
+  val bar = Bar(0.0, Foo(0, false, ""))
+  assert(Zero[Bar].zero == bar)
+}


### PR DESCRIPTION
The current set up for automatic type class derivation leaves much to be desired. Its biggest problem is that it induces boilerplate code.

This PR tries to find the minimal conditions required on a type class in order to be able to automatically derive the product and coproduct operations. I've focused here only on the case of a type class that is parameterized on a single type parameter, `T`, and has only one method associated with it. I have found three instances where this can arise:

1. The method of interest takes no arguments and returns type `T` (see examples/zero.scala)
2. The method of interest takes a single argument of type `T` and returns type `T` (see examples/increment.scala)
3. 
    * The method of interest takes a single argument of type `T` and returns concrete type `G` (see examples/name.scala)
    * Same as above but there exists a Monoid on `G` (see examples/width.scala and examples/shows.scala)

I've also separated out a `CoproductTypeClass` because I have personally encountered the case where I only want to abstract over `Coproducts` and not `Products`. This change will induce a bincompat failure but I'm fairly confident it is backwards compatible.

The extension to type classes with more than one method is fairly straightforward as it will simple be combinations of the three (.5) cases I've highlighted above. I also think the extension to type classes that are parameterized over more than one type parameter should be fairly straight forward too. However, both extensions will need a better naming convention than I've come up with so far.