### PR TITLE
Add type logic gates

### DIFF
--- a/core/src/main/scala/shapeless/package.scala
+++ b/core/src/main/scala/shapeless/package.scala
@@ -106,8 +106,7 @@ package object shapeless {
     val b = Some(evb)
   }
 
-  implicit def abXorAmbigTpe0[A, B](implicit eva: A, evb: B): A ^^ B = unexpected
-  implicit def abXorAmbigTpe1[A, B](implicit eva: A, evb: B): A ^^ B = unexpected
+  implicit def abXorAmbigTpe[A, B](implicit eva: A, evb: B): A ^^ B = unexpected
 
   trait !![A] extends Serializable
 

--- a/core/src/main/scala/shapeless/package.scala
+++ b/core/src/main/scala/shapeless/package.scala
@@ -59,6 +59,61 @@ package object shapeless {
   type ∃[P[_]] = P[T] forSome { type T }
   type ∀[P[_]] = ¬[∃[({ type λ[X] = ¬[P[X]]})#λ]]
 
+  //Type logic-gates
+  trait ||[A, B] extends Serializable {
+    def a: Option[A]
+    def b: Option[B]
+  }
+
+  object || {
+    implicit def aOrTpe[A, B](implicit eva: A): A || B = new ||[A, B] {
+      val a = Some(eva)
+      val b = None
+    }
+    implicit def bOrTpe[A, B](implicit evb: B): A || B = new ||[A, B] {
+      val a = None
+      val b = Some(evb)
+    }
+  }
+
+  implicit def abOrTpe[A, B](implicit eva: A, evb: B): A || B = new ||[A, B] {
+    val a = Some(eva)
+    val b = Some(evb)
+  }
+
+  trait &&[A, B] extends Serializable {
+    def a: A
+    def b: B
+  }
+
+  implicit def abAndTpe[A, B](implicit eva: A, evb: B): A && B = new &&[A, B] {
+    val a = eva
+    val b = evb
+  }
+
+  trait ^^[A, B] extends Serializable {
+    def a: Option[A]
+    def b: Option[B]
+  }
+
+  implicit def aXorTpe[A, B](implicit eva: A): A ^^ B = new ^^[A, B] {
+    val a = Some(eva)
+    val b = None
+  }
+
+  implicit def bXorTpe[A, B](implicit evb: B): A ^^ B = new ^^[A, B] {
+    val a = None
+    val b = Some(evb)
+  }
+
+  implicit def abXorAmbigTpe0[A, B](implicit eva: A, evb: B): A ^^ B = unexpected
+  implicit def abXorAmbigTpe1[A, B](implicit eva: A, evb: B): A ^^ B = unexpected
+
+  trait !![A] extends Serializable
+
+  implicit def nNotTpe[A](implicit eva: A): !![A] = unexpected
+  implicit def notTpe[A]: !![A] = new !![A] {}
+
   /** `Optic` definitions */
   val optic = OpticDefns
   val lens = OpticDefns

--- a/core/src/test/scala/shapeless/typeLogicGates.scala
+++ b/core/src/test/scala/shapeless/typeLogicGates.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import org.junit.Test
+
+import test._
+import ops.nat.LT._
+import nat._
+
+import shapeless.test.illTyped
+
+class TypeLogicGatesTests {
+  @Test
+  def testOr {
+    val ev1 = implicitly[(_1 < _2) || (_3 < _5)]
+    assert(ev1.a.isDefined && ev1.b.isDefined)
+    val ev2 = implicitly[(_1 < _3) || (_2 < _1)]
+    assert(ev2.a.isDefined && ev2.b.isEmpty)
+    val ev3 = implicitly[(_3 < _1) || (_2 < _3)]
+    assert(ev3.a.isEmpty && ev3.b.isDefined)
+    illTyped("""
+      implicitly[(_3 < _1) || (_4 < _2)]
+    """)
+  }
+
+  @Test
+  def testAnd {
+    implicitly[(_3 < _4) && (_4 < _5)]
+    illTyped("""
+      implicitly[(_1 < _2) && (_3 < _2)]
+    """)
+  }
+
+  @Test
+  def testXor {
+    val ev1 = implicitly[(_2 < _4) ^^ (_3 < _1)]
+    assert(ev1.a.isDefined && ev1.b.isEmpty)
+    val ev2 = implicitly[(_3 < _2) ^^ (_1 < _2)]
+    assert(ev2.a.isEmpty && ev2.b.isDefined)
+    illTyped("""
+      implicitly[(_1 < _2) ^^ (_1 < _3)]
+    """)
+  }
+ 
+  @Test
+  def testNot {
+    implicitly[!![_4 < _2]]
+    illTyped("""
+      implicitly[!![_1 < _2]]
+    """)
+  }
+}


### PR DESCRIPTION
Within our code base I've found it useful to sometimes have the ability to do OR, AND, NOT, XOR on a typelevel for evidences. AND is usually fine as you simply need 2 parameters, but OR, XOR and NOT can sometimes cause a few issues.

I'm unsure whether these belong in shapeless at all and this is merely a speculative PR.