### PR TITLE
Added orElse to Poly

### DIFF
--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -81,6 +81,28 @@ object PolyDefns extends Cases {
   }
 
   /**
+    * Represents the composition of two polymorphic function values by falling back
+    * to the second function where the first is not defined.
+    *
+    * @author Denis Rosca
+    */
+  class OrElse[F,G](f: F, g: G) extends Poly
+
+  object OrElse {
+    implicit def caseF[C, F <: Poly, G <: Poly, T, U]
+      (implicit unpack: Unpack2[C, OrElse, F, G], cF : Case1.Aux[F, T, U]) = new Case[C, T :: HNil] {
+      type Result = U
+      val value = (t : T :: HNil) => cF(t)
+    }
+
+    implicit def caseG[C, F <: Poly, G <: Poly, T, V]
+      (implicit unpack: Unpack2[C, OrElse, F, G], cG : Case1.Aux[G, T, V]) = new Case[C, T :: HNil] {
+      type Result = V
+      val value = (t : T :: HNil) => cG(t)
+    }
+  }
+
+  /**
    * Represents rotating a polymorphic function by N places to the left
    *
    * @author Stacy Curl
@@ -191,6 +213,8 @@ trait Poly extends PolyApply with Serializable {
   def compose(f: Poly) = new Compose[this.type, f.type](this, f)
 
   def andThen(f: Poly) = new Compose[f.type, this.type](f, this)
+
+  def orElse(f: Poly) = new OrElse[this.type, f.type](this, f)
 
   def rotateLeft[N <: Nat] = new RotateLeft[this.type, N](this)
 

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -247,16 +247,24 @@ class PolyTests {
     object stringPlusOne extends Poly1 {
       implicit def caseString = at[String](_ + 1)
     }
+    object doublePlusOne extends Poly1 {
+      implicit def caseDouble = at[Double](_ + 1)
+    }
 
-    val orElse = intPlusOne orElse stringPlusOne
+    val partialFp = intPlusOne orElse stringPlusOne
+    val fp = partialFp orElse doublePlusOne
 
-    val two = orElse(1)
+    val two = fp(1)
     typed[Int](two)
     assertEquals(2, two)
 
-    val one1 = orElse("one")
+    val one1 = fp("one")
     typed[String](one1)
     assertEquals("one1", one1)
+
+    val tmp = fp(3.45)
+    typed[Double](tmp)
+    assertEquals(4.45, tmp, 0.0001)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -240,6 +240,26 @@ class PolyTests {
   }
 
   @Test
+  def testOrElse {
+    object intPlusOne extends Poly1 {
+      implicit def caseInt = at[Int](_ + 1)
+    }
+    object stringPlusOne extends Poly1 {
+      implicit def caseString = at[String](_ + 1)
+    }
+
+    val orElse = intPlusOne orElse stringPlusOne
+
+    val two = orElse(1)
+    typed[Int](two)
+    assertEquals(2, two)
+
+    val one1 = orElse("one")
+    typed[String](one1)
+    assertEquals("one1", one1)
+  }
+
+  @Test
   def testPolyVal {
     val i1 = zero[Int]
     typed[Int](i1)


### PR DESCRIPTION
Allow composition of two polymorphic functions by specifying
a fallback to be applied where the first function is not
defined.
