### PR TITLE
More idiomatic <+= replacement

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,7 @@ lazy val core = crossProject.crossType(CrossTypeMixed)
   .configureCross(buildInfoSetup)
   .settings(osgiSettings:_*)
   .settings(
-    sourceGenerators in Compile += Def.task(Boilerplate.gen((sourceManaged in Compile).value)).taskValue
+    sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue
   )
   .settings(mimaSettings:_*)
   .jsSettings(commonJsSettings:_*)


### PR DESCRIPTION
This is just a minor matter of syntax, but I know I'm not the only person who's cargo-culted their whole boilerplate setup from here, so we might as well be as idiomatic as possible.

(Thanks to @eed3si9n for pointing out that I could do without the `Def.task` in circe.)