### PR TITLE
Rough cuts of Interface and LabelledInterface

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(
     sources in (Compile,doc) := Seq.empty
   )
 
-val macroCompatUri = uri("https://github.com/clhodapp/macro-compat.git#2f774fc")
+val macroCompatUri = uri("https://github.com/milessabin/macro-compat.git#5b4fccdbfaf6bd730725f1cde0cbbd50bf4c3e78")
 lazy val coreJVM = core.jvm.dependsOn(
   ProjectRef(
     macroCompatUri,
@@ -154,7 +154,12 @@ lazy val coreJS = core.js.dependsOn(
   )
 )
 
-lazy val coreNative = core.native
+lazy val coreNative = core.native.dependsOn(
+  ProjectRef(
+    macroCompatUri,
+    "coreJVM"
+  )
+)
 
 lazy val scratch = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(CrossType.Pure)
   .configureCross(configureJUnit)

--- a/build.sbt
+++ b/build.sbt
@@ -139,8 +139,21 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(
     sources in (Compile,doc) := Seq.empty
   )
 
-lazy val coreJVM = core.jvm
-lazy val coreJS = core.js
+val macroCompatUri = uri("https://github.com/clhodapp/macro-compat.git#2f774fc")
+lazy val coreJVM = core.jvm.dependsOn(
+  ProjectRef(
+    macroCompatUri,
+    "coreJVM"
+  )
+)
+
+lazy val coreJS = core.js.dependsOn(
+  ProjectRef(
+    macroCompatUri,
+    "coreJS"
+  )
+)
+
 lazy val coreNative = core.native
 
 lazy val scratch = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(CrossType.Pure)
@@ -227,7 +240,7 @@ lazy val nativeTest = project
 
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "macro-compat" % "1.1.1",
+    // "org.typelevel" %% "macro-compat" % "1.1.1",
     scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided",
     scalaOrganization.value % "scala-compiler" % scalaVersion.value % "provided",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)

--- a/core/src/main/scala/shapeless/interface.scala
+++ b/core/src/main/scala/shapeless/interface.scala
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import shapeless.ops.adjoin._
+
+import scala.language.experimental.macros
+
+import scala.reflect.macros.whitebox
+
+trait NestedInterface[T] extends Serializable {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+object NestedInterface {
+  type Aux[T, Repr0] = NestedInterface[T] { type Repr = Repr0 }
+  def apply[T](implicit iface: NestedInterface[T]): Aux[T, iface.Repr] = iface
+  implicit def materialize[T, Repr]: NestedInterface.Aux[T, Repr] =
+    macro InterfaceMacros.materializeUnlabelledNestedInterface[T, Repr]
+}
+
+trait FlatInterface[T] extends Serializable {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+object FlatInterface {
+  type Aux[T, Repr0] = FlatInterface[T] { type Repr = Repr0 }
+  def apply[T](implicit iface: FlatInterface[T]): Aux[T, iface.Repr] = iface
+  implicit def materialize[T, Repr]: FlatInterface.Aux[T, Repr] =
+    macro InterfaceMacros.materializeUnlabelledFlatInterface[T, Repr]
+}
+
+@macrocompat.bundle
+class InterfaceMacros(val c: whitebox.Context) extends SingletonTypeUtils {
+
+  import c.universe._
+  import compat._
+
+  case class InterfaceInfo(members: List[MemberInfo])
+  case class MemberInfo(
+    name: TermName,
+    paramLists: List[List[ParamInfo]],
+    returnType: Tree
+  )
+  case class ParamInfo(
+    name: TermName,
+    paramType: Tree
+  )
+
+  sealed trait ExtractionError
+  case class NotTrait(tpe: Type) extends ExtractionError
+  case class ConcreteMember(symbol: Symbol) extends ExtractionError
+  case class GenericMember(symbol: Symbol) extends ExtractionError
+  case class ByNameParameter(param: Symbol) extends ExtractionError
+
+  def traverse[T](
+    items: List[Either[ExtractionError, T]]
+  ): Either[ExtractionError, List[T]] = {
+    items.foldRight[Either[ExtractionError, List[T]]](Right(Nil)) {
+      case (Right(added), Right(current)) => Right(added :: current)
+      case (Right(ignored), Left(existingErr)) => Left(existingErr)
+      case (Left(newErr), dropped) => Left(newErr)
+    }
+  }
+
+  val defaultBaseTypeSymbols = {
+    Set[Symbol](
+      symbolOf[Any],
+      symbolOf[AnyRef],
+      symbolOf[AnyVal],
+      symbolOf[Object]
+    )
+  }
+
+  implicit class BiasEither[T](e: Either[ExtractionError, T]) {
+    def map[U](
+      f: T => U
+    ): Either[ExtractionError, U] = {
+      e.right.map(f)
+    }
+    def flatMap[U](
+      f: T => Either[ExtractionError, U]
+    ): Either[ExtractionError, U] = {
+      e.right.flatMap(f)
+    }
+  }
+
+  def extractInterfaceInfo(
+    tpe: Type
+  ): Either[ExtractionError, InterfaceInfo] = {
+    for {
+      memberSymbols <- {
+        if (tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isTrait) Right {
+          tpe
+            .members
+            .flatMap { member =>
+              if (member.isTerm) {
+                member.asTerm.alternatives.toList
+              } else List(member)
+            }.filterNot(member => defaultBaseTypeSymbols contains member.owner)
+            .toList
+        } else Left(NotTrait(tpe))
+      }
+      members <- traverse {
+        memberSymbols.map(extractMemberInfo(tpe))
+      }
+    } yield InterfaceInfo(members = members)
+  }
+
+  def extractMemberInfo(
+    containingType: Type
+  )(
+    memberSymbol: Symbol
+  ): Either[ExtractionError, MemberInfo] = {
+    for {
+      signature <- {
+          val signature = memberSymbol.typeSignatureIn(containingType)
+          if (!memberSymbol.isAbstract) Left(ConcreteMember(memberSymbol))
+          else if (signature.typeParams.nonEmpty) Left(GenericMember(memberSymbol))
+          else Right(signature)
+      }
+      name <- Right(memberSymbol.name.toTermName)
+      returnType <- Right(TypeTree(signature.finalResultType))
+      paramLists <- traverse {
+        signature.paramLists.map { paramList =>
+          traverse {
+            paramList.map(extractParamInfo(signature))
+          }
+        }
+      }
+    } yield MemberInfo(name = name, returnType = returnType, paramLists = paramLists)
+  }
+
+  def extractParamInfo(
+    methodSignature: Type
+  )(
+    paramSymbol: Symbol
+  ): Either[ExtractionError, ParamInfo] = {
+    for {
+      paramType <- {
+        if (paramSymbol.asTerm.isByNameParam) Left(ByNameParameter(paramSymbol))
+        else Right(TypeTree(paramSymbol.typeSignatureIn(methodSignature)))
+      }
+      name <- Right(paramSymbol.name.toTermName)
+    } yield ParamInfo(name = name, paramType = paramType)
+  }
+
+  def tpeHCons(a: Tree, b: Tree): Tree = tq"_root_.shapeless.::[$a, $b]"
+  val tpeHNil: Tree = tq"_root_.shapeless.HNil"
+
+  def valueHCons(a: Tree, b: Tree): Tree = q"_root_.shapeless.::($a, $b)"
+  val valueHNil: Tree = q"_root_.shapeless.HNil"
+
+  def selectByIndex(l: Tree, n: Int): Tree = {
+    if (n == 0) q"$l.head"
+    else selectByIndex(q"$l.tail", n - 1)
+  }
+
+  def materializeInterface[T: WeakTypeTag, Repr: WeakTypeTag](
+    typeclassName: String,
+    paramRepr: ParamInfo => Tree,
+    listRepr: (List[List[Tree]], List[Tree] => Tree) => Tree,
+    functionRepr: TermName => Tree => Tree,
+    concreteArg: (Tree, List[List[ParamInfo]]) => List[List[Tree]]
+  ): Tree = {
+
+    extractInterfaceInfo(weakTypeOf[T]) match {
+      case Left(NotTrait(nonTrait)) =>
+        if (c.compilerSettings contains "-Xlog-implicits") {
+          c.error(
+            nonTrait.typeSymbol.pos,
+            "Note: unsupported non-trait defined here"
+          )
+        } else ()
+        c.abort(
+          c.enclosingPosition,
+          "Unsupported Type: Interface-type generic represenation converters can only be generated for traits"
+        )
+      case Left(ByNameParameter(byNameParam)) =>
+        if (c.compilerSettings contains "-Xlog-implicits") {
+          c.error(
+            byNameParam.pos,
+            "Note: unsupported by-name parameter defined here"
+          )
+        } else ()
+        c.abort(
+          c.enclosingPosition,
+          "Unsupported Type: Interface-type generic represenation converters can only be generated for interfaces when none of their member methods have by-name parameters"
+        )
+      case Left(GenericMember(genericMember)) =>
+        if (c.compilerSettings contains "-Xlog-implicits") {
+          c.error(
+            genericMember.pos,
+            "Note: unsupported generic member defined here"
+          )
+        } else ()
+        c.abort(
+          c.enclosingPosition,
+          "Unsupported Type: Interface-type generic represenation converters can only be generated for traits with no generic members"
+        )
+      case Left(ConcreteMember(concreteMember)) =>
+        if (c.compilerSettings contains "-Xlog-implicits") {
+          c.error(
+            concreteMember.pos,
+            "Note: unsupported concrete member defined here"
+          )
+        } else ()
+        c.abort(
+          c.enclosingPosition,
+          "Unsupported Type: Interface-type generic represenation converters can only be generated for traits with no concrete members"
+        )
+      case Right(interfaceInfo) =>
+        val reprTypeTree = {
+          interfaceInfo.members.map {
+            case MemberInfo(name, paramLists, returnType) =>
+              val unifiedParamLists = listRepr(paramLists.map(_.map(paramRepr)), _.foldRight(tpeHNil)(tpeHCons))
+              functionRepr(name)(tq"$unifiedParamLists => $returnType")
+          }.foldRight(tpeHNil)(tpeHCons)
+        }
+        val toGeneric = {
+          val target = TermName(c.freshName("target"))
+            val body = interfaceInfo.members.map {
+              case MemberInfo(name, paramLists, returnType) =>
+                val param = Ident(TermName(c.freshName("param")))
+                val arguments = concreteArg(param, paramLists)
+                val paramType = listRepr(paramLists.map(_.map(paramRepr)), _.foldRight(tpeHNil)(tpeHCons))
+                val application = q"${target}.${name}(...${arguments})"
+                val functionType = functionRepr(name)(tq"$paramType => $returnType")
+                q"{ ($param: $paramType) => $application }.asInstanceOf[$functionType]"
+            }.foldRight(valueHNil)(valueHCons)
+            q"""
+              val $target = t
+              $body
+            """
+        }
+        val toConcrete = {
+          val target = TermName(c.freshName("target"))
+          val members = interfaceInfo.members.zipWithIndex.map {
+            case (MemberInfo(name, paramLists, returnType), idx) =>
+              val body = {
+                val arg = {
+                  val unifiedArgLists = {
+                    paramLists
+                      .map { paramList =>
+                        paramList.map { param =>
+                          val paramReprTpe = paramRepr(param)
+                          q"${param.name}.asInstanceOf[${paramReprTpe}]"
+                        }
+                      }
+                  }
+                  listRepr(unifiedArgLists, _.foldRight(valueHNil)(valueHCons))
+                }
+                q"${selectByIndex(q"$target", idx)}.apply($arg)"
+              }
+              val parameters = paramLists.map { paramList =>
+                paramList.map { param =>
+                  q"${param.name}: ${param.paramType}"
+                }
+              }
+              q"""def $name(...$parameters) = $body"""
+          }
+          if (members.nonEmpty) {
+            q"""
+              val $target = r
+              new ${weakTypeOf[T]} {
+                ..$members
+              }
+            """
+          } else {
+            q"""
+              val $target = r
+              new ${weakTypeOf[T]} {}
+            """
+          }
+        }
+        val tpeNme = TypeName(typeclassName)
+        val clsName = TypeName(c.freshName("anon$"))
+        q"""
+          class $clsName extends _root_.shapeless.$tpeNme[${weakTypeOf[T]}] {
+            type Repr = ${reprTypeTree}
+            def to(t: ${weakTypeOf[T]}): ${reprTypeTree} = $toGeneric
+            def from(r: ${reprTypeTree}): ${weakTypeOf[T]} = $toConcrete
+          }
+          new $clsName(): _root_.shapeless.${tpeNme.toTermName}.Aux[${weakTypeOf[T]}, $reprTypeTree]
+        """
+    }
+
+  }
+
+  def unlabelledParam(paramInfo: ParamInfo): Tree = paramInfo.paramType
+  def labelledParam(paramInfo: ParamInfo): Tree = {
+    val paramType = paramInfo.paramType
+    val paramNameTree = SingletonSymbolType(paramInfo.name.decodedName.toString)
+    tq"_root_.shapeless.labelled.FieldType[$paramNameTree, $paramType]"
+  }
+
+  def unlabelledFunction(name: TermName): Tree => Tree = identity
+  def labelledFunction(functionName: TermName): Tree => Tree = { functionTree =>
+    val functionNameTree = SingletonSymbolType(functionName.decodedName.toString)
+    tq"_root_.shapeless.labelled.FieldType[$functionNameTree, $functionTree]"
+  }
+
+  def nestedParamListRepr(paramReprs: List[List[Tree]], reduce: List[Tree] => Tree): Tree = {
+    reduce(paramReprs.map(reduce))
+  }
+
+  def flatParamListRepr(paramReprs: List[List[Tree]], reduce: List[Tree] => Tree): Tree = {
+    reduce(paramReprs.flatten)
+  }
+
+  def nestedConcreteArgRepr(target: Tree, paramLists: List[List[ParamInfo]]): List[List[Tree]] = {
+    paramLists.zipWithIndex.map { case (paramList, listIndex) =>
+      paramList.zipWithIndex.map { case (name, paramIndex) =>
+        selectByIndex(selectByIndex(q"$target", listIndex), paramIndex)
+      }
+    }
+  }
+
+  def flatConcreteArgRepr(target: Tree, paramLists: List[List[ParamInfo]]): List[List[Tree]] = {
+    val listSizes = paramLists.scanLeft(0)((offset, paramList) => paramList.size)
+    (paramLists zip listSizes).map { case (paramList, offset) =>
+      paramList.zipWithIndex.map { case (name, paramIndex) =>
+        selectByIndex(q"$target", paramIndex+offset)
+      }
+    }
+  }
+
+  def materializeUnlabelledNestedInterface[T: WeakTypeTag, Repr: WeakTypeTag]: Tree = {
+    materializeInterface[T, Repr](
+      typeclassName = "NestedInterface",
+      paramRepr = unlabelledParam,
+      listRepr = nestedParamListRepr,
+      functionRepr = unlabelledFunction,
+      concreteArg = nestedConcreteArgRepr
+    )
+  }
+
+  def materializeUnlabelledFlatInterface[T: WeakTypeTag, Repr: WeakTypeTag]: Tree = {
+    materializeInterface[T, Repr](
+      typeclassName = "FlatInterface",
+      paramRepr = unlabelledParam,
+      listRepr = flatParamListRepr,
+      functionRepr = unlabelledFunction,
+      concreteArg = flatConcreteArgRepr
+    )
+  }
+
+  def materializeLabelledNestedInterface[T: WeakTypeTag, Repr: WeakTypeTag]: Tree = {
+    materializeInterface[T, Repr](
+      typeclassName = "LabelledNestedInterface",
+      paramRepr = labelledParam,
+      listRepr = nestedParamListRepr,
+      functionRepr = labelledFunction,
+      concreteArg = nestedConcreteArgRepr
+    )
+  }
+
+  def materializeLabelledFlatInterface[T: WeakTypeTag, Repr: WeakTypeTag]: Tree = {
+    materializeInterface[T, Repr](
+      typeclassName = "LabelledFlatInterface",
+      paramRepr = labelledParam,
+      listRepr = flatParamListRepr,
+      functionRepr = labelledFunction,
+      concreteArg = flatConcreteArgRepr
+    )
+  }
+
+}
+
+trait LabelledNestedInterface[T] extends Serializable {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+object LabelledNestedInterface {
+  type Aux[T, Repr0] = LabelledNestedInterface[T] { type Repr = Repr0 }
+  def apply[T](implicit iface: LabelledNestedInterface[T]): Aux[T, iface.Repr] = {
+    iface
+  }
+  implicit def materialize[T, Repr]: LabelledNestedInterface.Aux[T, Repr] =
+    macro InterfaceMacros.materializeLabelledNestedInterface[T, Repr]
+}
+
+trait LabelledFlatInterface[T] extends Serializable {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+object LabelledFlatInterface {
+  type Aux[T, Repr0] = LabelledFlatInterface[T] { type Repr = Repr0 }
+  def apply[T](implicit iface: LabelledFlatInterface[T]): Aux[T, iface.Repr] = {
+    iface
+  }
+  implicit def materialize[T, Repr]: LabelledFlatInterface.Aux[T, Repr] =
+    macro InterfaceMacros.materializeLabelledFlatInterface[T, Repr]
+}

--- a/core/src/test/scala/shapeless/iface.scala
+++ b/core/src/test/scala/shapeless/iface.scala
@@ -1,0 +1,3 @@
+
+package shapeless
+

--- a/core/src/test/scala/shapeless/interface.scala
+++ b/core/src/test/scala/shapeless/interface.scala
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2013-15 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+import syntax.typeable._
+
+import reflect.ClassTag
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.nio.ByteBuffer
+
+package rpcService {
+
+  trait Iface {
+    def add(a: Int, b: Int): Int
+    def concat(s1: String, s2: String): String
+  }
+
+  object Impl extends Iface {
+    def add(a: Int, b: Int): Int = a + b
+    def concat(s1: String, s2: String): String = s1 ++ s2
+  }
+
+}
+
+package rpcFramework {
+
+  trait Endpoint {
+    def call(rpcRequest: RpcRequest): Either[String, RpcResponse]
+  }
+  object Endpoint {
+    object ops {
+      implicit class ToEndpointOp[T](val t: T) extends AnyVal {
+        def toEndpoint[U >: T](implicit tet: ToEndpoint[U]): Endpoint = {
+          tet.apply(t)
+        }
+      }
+      implicit class ToClientOp(val ep: Endpoint) extends AnyVal {
+        def toClient[T](implicit tc: ToClient[T]): T = tc(ep)
+      }
+    }
+  }
+
+  trait ToClient[T] {
+    def apply(endpoint: Endpoint): T
+  }
+  object ToClient {
+    implicit def instance[T, Repr <: HList, F <: HList](implicit
+      iface: FlatInterface.Aux[T, Repr],
+      sf: SynthesizeFuncs[Repr]
+    ): ToClient[T] = {
+      new ToClient[T] {
+        def apply(ep: Endpoint): T = {
+          val funcs = sf.synthesizeFuncs(ep).funcs
+          iface.from(funcs)
+        }
+      }
+    }
+  }
+
+  trait SynthesizeFunc[Func] {
+    def synthesizeFunc(af: Args => Either[String, RpcResponse]): Func
+  }
+  object SynthesizeFunc {
+    implicit def synthesizeFunc[
+      A <: HList,
+      R
+    ](implicit
+      ac: ArgsCodec[A],
+      rc: ResponseCodec[R]
+    ): SynthesizeFunc[A => R] = {
+      new SynthesizeFunc[A => R] {
+        def synthesizeFunc(af: Args => Either[String, RpcResponse]): A => R = { a =>
+          af(ac.toWire(a)).right.flatMap(rc.fromWire) match {
+            case Right(res) => res
+            case Left(err) => throw new Exception(s"RPC Error: $err")
+          }
+        }
+      }
+    }
+  }
+
+  trait Funcs[F <: HList] {
+    def funcs: F
+    def index: Int
+  }
+
+  trait SynthesizeFuncs[F <: HList] {
+    def synthesizeFuncs(ep: Endpoint): Funcs[F]
+  }
+  object SynthesizeFuncs {
+    implicit val synthesizeHNil: SynthesizeFuncs[HNil] = new SynthesizeFuncs[HNil] {
+      def synthesizeFuncs(ep: Endpoint): Funcs[HNil] = new Funcs[HNil] {
+        def funcs = HNil
+        def index = -1
+      }
+    }
+    implicit def synthesizeHCons[
+      H,
+      T <: HList
+    ](implicit
+      sh: SynthesizeFunc[H],
+      st: SynthesizeFuncs[T]
+    ): SynthesizeFuncs[H :: T] = {
+      new SynthesizeFuncs[H :: T] {
+        def synthesizeFuncs(ep: Endpoint): Funcs[H :: T] = {
+          new Funcs[H :: T] {
+            val t = st.synthesizeFuncs(ep)
+            def index = t.index + 1
+            def funcs = sh.synthesizeFunc(args => ep.call(RpcRequest(index, args))) :: t.funcs
+          }
+        }
+      }
+    }
+  }
+
+  trait ToHandler[T] {
+    def toHandler(t: T): Args => Either[String, RpcResponse]
+  }
+  object ToHandler {
+    implicit def fromFunction[A <: HList, R](implicit
+      ac: ArgsCodec[A],
+      rc: ResponseCodec[R]
+    ): ToHandler[A => R] = new ToHandler[A => R] {
+      def toHandler(af: A => R) = { args =>
+        ac.fromWire(args).right.map(a => rc.toWire(af(a)))
+      }
+    }
+  }
+
+  trait ToHandlers[T] {
+    def toHandlers(t: T): List[Args => Either[String, RpcResponse]]
+  }
+  object ToHandlers {
+    implicit val hnilToHandlers: ToHandlers[HNil] = new ToHandlers[HNil] {
+      def toHandlers(hnil: HNil): List[Args => Either[String, RpcResponse]] = Nil
+    }
+    implicit def hconsToHandlers[H, T <: HList](implicit
+      hToHandler: ToHandler[H],
+      tToHandlers: ToHandlers[T]
+    ): ToHandlers[H :: T] = new ToHandlers[H :: T] {
+      def toHandlers(hcons: H :: T): List[Args => Either[String, RpcResponse]] = {
+        hToHandler.toHandler(hcons.head) :: tToHandlers.toHandlers(hcons.tail)
+      }
+    }
+  }
+
+  trait ToEndpoint[T] {
+    def apply(t: T): Endpoint
+  }
+  object ToEndpoint {
+    def apply[T](implicit tet: ToEndpoint[T]) = tet
+
+    implicit def instance[T, Repr <: HList, F <: HList](implicit
+      iface: FlatInterface.Aux[T, Repr],
+      th: ToHandlers[Repr]
+    ): ToEndpoint[T] = {
+      new ToEndpoint[T] {
+        def apply(t: T) = new Endpoint {
+          val repr = iface.to(t)
+          val handlers = th.toHandlers(repr).toVector.reverse
+          def call(request: RpcRequest) = {
+            if (request.op <= handlers.size) handlers(request.op)(request.args)
+            else Left("No handler for method")
+          }
+        }
+      }
+    }
+  }
+
+  trait ArgsCodec[T] {
+    def toWire(t: T): Args
+    def fromWire(args: Args): Either[String, T]
+  }
+  object ArgsCodec {
+    implicit val hnilArgsCodec: ArgsCodec[HNil] = new ArgsCodec[HNil] {
+      def toWire(hn: HNil): Args = Args(hn)
+      def fromWire(args: Args): Either[String, HNil] =
+        args.raw match {
+          case HNil => Right(HNil)
+          case other => Left("Invalid args")
+        }
+    }
+    implicit def hconsArgsCodec[H: Typeable, T <: HList: ArgsCodec: Typeable]: ArgsCodec[H :: T] =
+      new ArgsCodec[H :: T] {
+        def toWire(hl: H :: T): Args = Args(hl)
+        def fromWire(args: Args): Either[String, H :: T] = {
+          args.raw.cast[H :: T] match {
+            case Some(h :: t) => {
+              implicitly[ArgsCodec[T]]
+                .fromWire(Args(t))
+                .right.map(t => h :: t)
+            }
+            case None => Left("Invalid args")
+          }
+        }
+      }
+  }
+
+  trait ResponseCodec[T] {
+    def toWire(t: T): RpcResponse
+    def fromWire(response: RpcResponse): Either[String, T]
+  }
+  object ResponseCodec {
+    implicit def rpcResponseCodec[T: Typeable]: ResponseCodec[T] = {
+      new ResponseCodec[T] {
+        def toWire(t: T): RpcResponse = RpcResponse(t)
+        def fromWire(response: RpcResponse): Either[String, T] = {
+          response.raw.cast[T] match {
+            case Some(t) => Right(t)
+            case None => Left("Invalid response")
+          }
+        }
+      }
+    }
+  }
+
+  case class RpcRequest(op: Int, args: Args)
+  case class Args(raw: Any)
+  case class RpcResponse(raw: Any)
+
+}
+
+package generationFramework {
+
+  trait Gen[T] {
+    def generate: T
+  }
+  object Gen {
+    def apply[T](implicit instance: Gen[T]): Gen[T] = instance
+    implicit val genInt: Gen[Int] = new Gen[Int] {
+      def generate: Int = util.Random.nextInt
+    }
+    implicit val genString: Gen[String] = new Gen[String] {
+      def generate: String = util.Random.nextInt.toString
+    }
+    implicit def genFunction[A, R](implicit
+      genR: Gen[R]
+    ): Gen[A => R] = new Gen[A => R] {
+      def generate: (A => R) = {
+        val res: R = genR.generate
+        _ => res
+      }
+    }
+    implicit val genHNil: Gen[HNil] = new Gen[HNil] {
+      def generate: HNil = HNil
+    }
+    implicit def genHCons[H, T <: HList](implicit
+      gh: Gen[H],
+      gt: Gen[T]
+    ): Gen[H :: T] = new Gen[H :: T] {
+      def generate: H :: T = gh.generate :: gt.generate
+    }
+    implicit def genInstance[T, Repr](implicit
+      iface: FlatInterface.Aux[T, Repr],
+      genRepr: Gen[Repr]
+    ): Gen[T] = new Gen[T] {
+      def generate = iface.from(genRepr.generate)
+    }
+  }
+
+}
+
+package tracingFramework {
+  import labelled._
+  import collection.mutable.ListBuffer
+  trait Show[T] {
+    def show(t: T): String
+  }
+  object Show {
+    def apply[T](implicit instance: Show[T]): Show[T] = instance
+    implicit val showString: Show[String] = new Show[String] {
+      def show(str: String) = "\""++str++"\""
+    }
+    implicit val showInt: Show[Int] = new Show[Int] {
+      def show(i: Int) = i.toString
+    }
+  }
+
+  trait ShowArg[T] {
+    def showArg(t: T): String
+  }
+  object ShowArg {
+    implicit def instance[K <: Symbol, T](implicit
+      kw: Witness.Aux[K],
+      st: Show[T],
+      tt: Typeable[T]
+    ): ShowArg[FieldType[K, T]] = new ShowArg[FieldType[K, T]] {
+      def showArg(t: FieldType[K, T]): String = {
+        s"${kw.value.name} = ${st.show(t)}: ${tt.describe}"
+      }
+    }
+  }
+
+  trait ShowArgList[T <: HList] {
+    def showArgList(t: T): List[String]
+  }
+  object ShowArgList {
+    implicit val showHNil: ShowArgList[HNil] = new ShowArgList[HNil] {
+      def showArgList(hnil: HNil): List[String] = Nil
+    }
+    implicit def showHCons[H, T <: HList](implicit
+      sh: ShowArg[H],
+      st: ShowArgList[T]
+    ): ShowArgList[H :: T] = new ShowArgList[H :: T] {
+      def showArgList(hc: H :: T): List[String] = sh.showArg(hc.head) :: st.showArgList(hc.tail)
+    }
+  }
+
+  trait ShowArgLists[T <: HList] {
+    def showArgLists(t: T): List[List[String]]
+  }
+  object ShowArgLists {
+    implicit val showHNil: ShowArgLists[HNil] = new ShowArgLists[HNil] {
+      def showArgLists(hnil: HNil): List[List[String]] = Nil
+    }
+    implicit def showHCons[H <: HList, T <: HList](implicit
+      sh: ShowArgList[H],
+      st: ShowArgLists[T]
+    ): ShowArgLists[H :: T] = new ShowArgLists[H :: T] {
+      def showArgLists(hc: H :: T): List[List[String]] = sh.showArgList(hc.head) :: st.showArgLists(hc.tail)
+    }
+  }
+
+  trait Tracer[T] {
+    def traced(t: T, buff: ListBuffer[String]): T
+  }
+  object Tracer {
+    def apply[T](implicit instance: Tracer[T]): Tracer[T] = instance
+
+    implicit val traceHNil: Tracer[HNil] = new Tracer[HNil] {
+      def traced(hnil: HNil, buff: ListBuffer[String]): HNil = hnil
+    }
+
+    implicit def traceHCons[H, T <: HList](implicit
+      ht: Tracer[H],
+      tt: Tracer[T]
+    ): Tracer[H :: T] = new Tracer[H :: T] {
+      def traced(hc: H :: T, buff: ListBuffer[String]): H :: T = {
+        ht.traced(hc.head, buff) :: tt.traced(hc.tail, buff)
+      }
+    }
+
+    implicit def traceFunction[K <: Symbol, A <: HList, R](implicit
+      k: Witness.Aux[K],
+      sa: ShowArgLists[A],
+      sr: Show[R],
+      tr: Typeable[R]
+    ): Tracer[FieldType[K, A => R]] = new Tracer[FieldType[K, A => R]] {
+      def traced(f: FieldType[K, A => R], buff: ListBuffer[String]): FieldType[K, A => R] = field[K] { a: A =>
+        val args = sa.showArgLists(a).map(_.mkString("(", ", ", ")")).mkString
+        val callString = k.value.name++args
+        val res = f(a)
+        val resString = sr.show(res) ++ ": " ++ tr.describe
+        buff += s"$callString => $resString"
+        res
+      }
+    }
+    implicit def traceInterface[T, Repr](implicit
+      iface: LabelledNestedInterface.Aux[T, Repr],
+      tr: Tracer[Repr]
+    ): Tracer[T] = new Tracer[T] {
+      def traced(t: T, buff: ListBuffer[String]): T = iface.from(tr.traced(iface.to(t), buff))
+    }
+  }
+}
+
+
+class InterfaceTests {
+
+  @Test
+  def testSynthesizeRpc {
+
+    import rpcFramework._
+    import rpcService._
+    import Endpoint.ops._
+
+    val ep: Endpoint = Impl.toEndpoint[Iface]
+
+    val client = ep.toClient[Iface]
+
+    assert(client.add(3,4) == 7)
+    assert(client.concat("x", "y") == "xy")
+  }
+
+  @Test
+  def testSynthesizeInstance {
+    import generationFramework._
+    import rpcService._
+    val instance = Gen[Iface].generate
+    val res: Int = instance.add(3, 4)
+  }
+
+  @Test
+  def testTracer {
+    import tracingFramework._
+    import rpcService._
+    import collection.mutable.ListBuffer
+    val log = ListBuffer[String]()
+    val traced = Tracer[Iface].traced(Impl, log)
+    traced.add(4,5)
+    traced.concat("a", "b")
+    val expected = List(
+      """add(a = 4: Int, b = 5: Int) => 9: Int""",
+      """concat(s1 = "a": String, s2 = "b": String) => "ab": String"""
+    )
+    assert(log.toList == expected)
+  }
+}


### PR DESCRIPTION
This is the PR I promised. It still needs a good deal of polish, but it should be sufficient to completely clarify what I was talking about (at least for this phase 😉). The core idea is to allow two-way conversions between interfaces (purely abstract traits) and HLists of HList-taking functions. This is the sort of thing that should have a tremendous number of use-cases, but the three I've written tests for are:
  * Autogenerating RPC clients/servers a la Autowire: https://github.com/lihaoyi/autowire
  * Autogenerating instances of interfaces (potentially useful in Scalacheck)
  * Defining AOP-like transformations without runtime reflection or client-project-side macros

Open Questions:
  * Should these be their own typeclasses or should the macros just produce instances of `Generic` and `LabelledGeneric`?
  * Currently, the ending of e.g. a method with shape `(Int)(Int) => Int` (two param lists) is `(Int :: HNil) :: (Int :: HNil) :: HNil => Int`, with there being typeclass instances for conversion to a flattened-param-list version (`Int :: Int :: HNil => Int`). The question is whether we care about keeping the param lists separate or whether the initial encoding should just be flat in the first place

