### PR TITLE
Add elegant syntax for creating polys from functions

### DIFF
--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -119,11 +119,11 @@ object PolyDefns extends Cases {
    *
    * @author Aristotelis Dossas
    */
-  trait Poly1Builder[L <: HList] extends Poly1 { self =>
+  trait Poly1Builder[L <: HList] { self =>
 
    val functions: L
 
-   class CaseOfAux[In] {
+   class AtAux[In] {
      def apply[Out](λ: In => Out) = {
        new Poly1Builder[(In => Out) :: L] {
          val functions = λ :: self.functions
@@ -131,17 +131,18 @@ object PolyDefns extends Cases {
      }
    }
 
-   def caseOf[In] = new CaseOfAux[In]
+   def at[In] = new AtAux[In]
 
-   implicit def allCases[In, Out](implicit tL: FunctionTypeAt[In, Out, L]) = {
-     val func: In => Out = tL(functions)
-     at(func)
+   def build = new Poly1 {
+     val functions = self.functions
+
+     implicit def allCases[In, Out](implicit tL: FunctionTypeAt[In, Out, L]) = {
+       val func: In => Out = tL(functions)
+       at(func)
+     }
    }
   }
 
-  object newPoly extends Poly1Builder[HNil] {
-   val functions = HNil
-  }
   /* For internal use of Poly1Builder */
   trait FunctionTypeAt[U, V, L <: HList] {
    def apply(l: L): U => V
@@ -291,7 +292,9 @@ trait Poly extends PolyApply with Serializable {
  *
  * @author Miles Sabin
  */
-object Poly extends PolyInst {
+object Poly extends PolyInst with PolyDefns.Poly1Builder[HNil] {
+  val functions = HNil
+
   implicit def inst0(p: Poly)(implicit cse : p.ProductCase[HNil]) : cse.Result = cse()
 }
 

--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -115,54 +115,6 @@ object PolyDefns extends Cases {
   }
 
   /**
-   * Provides elegant syntax for creating polys from functions
-   *
-   * @author Aristotelis Dossas
-   */
-  trait Poly1Builder[L <: HList] { self =>
-
-   val functions: L
-
-   class AtAux[In] {
-     def apply[Out](λ: In => Out) = {
-       new Poly1Builder[(In => Out) :: L] {
-         val functions = λ :: self.functions
-       }
-     }
-   }
-
-   def at[In] = new AtAux[In]
-
-   def build = new Poly1 {
-     val functions = self.functions
-
-     implicit def allCases[In, Out](implicit tL: FunctionTypeAt[In, Out, L]) = {
-       val func: In => Out = tL(functions)
-       at(func)
-     }
-   }
-  }
-
-  /* For internal use of Poly1Builder */
-  trait FunctionTypeAt[U, V, L <: HList] {
-   def apply(l: L): U => V
-  }
-
-  object FunctionTypeAt {
-   implicit def at0[U,V,T <: HList] = new FunctionTypeAt[U, V, (U => V)::T] {
-     def apply(l: (U => V)::T): U => V = {
-       l.head
-     }
-   }
-
-   implicit def atOther[U, V, T<: HList, H](implicit tprev: FunctionTypeAt[U, V, T]) = new FunctionTypeAt[U, V, H::T] {
-     def apply(l: H::T): U => V = {
-       tprev(l.tail)
-     }
-   }
-  }
-
-  /**
    * Base class for lifting a `Function1` to a `Poly1`
    */
   class ->[T, R](f : T => R) extends Poly1 {
@@ -292,9 +244,7 @@ trait Poly extends PolyApply with Serializable {
  *
  * @author Miles Sabin
  */
-object Poly extends PolyInst with PolyDefns.Poly1Builder[HNil] {
-  val functions = HNil
-
+object Poly extends PolyInst {
   implicit def inst0(p: Poly)(implicit cse : p.ProductCase[HNil]) : cse.Result = cse()
 }
 

--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -136,7 +136,7 @@ object PolyDefns extends Cases {
 
     def caseOf[In] = new CaseOfAux[In]
 
-    implicit def allCases[In,Out]: Case.Aux[In,Out] = macro PolyMacros.allCasesImpl[In]
+    implicit def allCases[In](implicit selector: hl.Selector[L,Func[In]]): Case.Aux[In,Func[In]#Out] = at(functions.select[Func[In]].λ)
   }
 
   object newPoly extends PolyBuilder[HNil] {
@@ -315,14 +315,5 @@ class PolyMacros(val c: whitebox.Context) {
     }
 
     q""" $value.caseUniv[$tTpe] """
-  }
-
-  def allCasesImpl[In : c.WeakTypeTag]: Tree = {
-    val q"$prefix.${_}[..${_}]" = c.macroApplication
-    val temp = c.freshName(TermName("temp"))
-    q"""
-        val $temp = $prefix
-        $temp.at($temp.functions.select[Func[${weakTypeOf[In]}]].λ)
-    """
   }
 }

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -373,7 +373,7 @@ class PolyTests {
 
   @Test
   def testPoly1Builder {
-    val myPoly = Poly.at[Int]( x => x).at[String](_.length).at[Boolean](if(_) 1 else 0).build
+    val myPoly = Poly1.at[Int]( x => x).at[String](_.length).at[Boolean](if(_) 1 else 0).build
     import myPoly._
 
     val r1 = myPoly(10)
@@ -384,5 +384,23 @@ class PolyTests {
 
     val r3 = myPoly(true)
     assertTypedEquals[Int](1, r3)
+  }
+
+  @Test
+  def testPoly2Builder {
+    val myPoly = Poly2.at[Int, Int]((acc, x) => acc + x).
+                       at[Int, String]((acc, s) => acc + s.length).
+                       at[Int, Boolean]((acc, b) => acc + (if(b) 1 else 0)).
+                       build
+    import myPoly._
+
+    val r1 = myPoly(5, 10)
+    assertTypedEquals[Int](15, r1)
+
+    val r2 = myPoly(5, "hello")
+    assertTypedEquals[Int](10, r2)
+
+    val r3 = myPoly(5, true)
+    assertTypedEquals[Int](6, r3)
   }
 }

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -370,4 +370,19 @@ class PolyTests {
     val r6 = dcis(2.0, 'a', 1, "foo")
     assertTypedEquals[String](s"i: 1, s: foo, d: ${2.0}, c: a", r6)
   }
+
+  @Test
+  def testPolyBuilder {
+    val myPoly = newPoly.caseOf[Int]( x => x).caseOf[String](_.length).caseOf[Boolean](if(_) 1 else 0)
+    import myPoly._
+
+    val r1 = myPoly(10)
+    assertTypedEquals[Int](10, r1)
+
+    val r2 = myPoly("hello")
+    assertTypedEquals[Int](5, r2)
+
+    val r3 = myPoly(true)
+    assertTypedEquals[Int](1, r3)
+  }
 }

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -372,8 +372,8 @@ class PolyTests {
   }
 
   @Test
-  def testPolyBuilder {
-    val myPoly = newPoly.caseOf[Int]( x => x).caseOf[String](_.length).caseOf[Boolean](if(_) 1 else 0)
+  def testPoly1Builder {
+    val myPoly = Poly.at[Int]( x => x).at[String](_.length).at[Boolean](if(_) 1 else 0).build
     import myPoly._
 
     val r1 = myPoly(10)


### PR DESCRIPTION
Adds syntax for creating polys like this:
```scala
import poly._

val myPoly = newPoly caseOf[Int]( x => x) caseOf[String](_.length) caseOf[Boolean](if(_) 1 else 0)

import myPoly._

(10 :: "hello" :: true :: HNil).map(myPoly) //  10 :: 5 :: 1 :: HNil
```
Names open to debate off course.

It works for scala 2.12.1 and 2.11.8 and 2.10.6 (for 2.10.6 you have to replace the spaces between the methods with the dot (.) operator).

I will add tests if there is interest in merging this.