### PR TITLE
HListOption

### DIFF
--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1888,6 +1888,22 @@ class CoproductTests {
     assertEquals(Inl(23), isCCons.cons(Left(23)))
     assertEquals(Inr(Inl("bar")), isCCons.cons(Right(Inl("bar"))))
   }
+
+  @Test
+  def testHListOption = {
+    type ISB = Int :+: String :+: Boolean :+: CNil
+    val isb1 = Coproduct[ISB](12)
+    val isb2 = Coproduct[ISB]("abc")
+    val isb3 = Coproduct[ISB](true)
+
+    val ho1 = HListOption[ISB].apply(isb1)
+    val ho2 = HListOption[ISB].apply(isb2)
+    val ho3 = HListOption[ISB].apply(isb3)
+
+    assertEquals(ho1, Some(12) :: None :: None :: HNil)
+    assertEquals(ho2, None :: Some("abc") :: None :: HNil)
+    assertEquals(ho3, None :: None :: Some(true) :: HNil)
+  }
 }
 
 package CoproductTestAux {


### PR DESCRIPTION
Question posed by @AlecZorab in the shapeless gitter channel:

"does anyone have a neat solution for doing something like this"
```Scala
type co = Int :+: String :+: CNil
val i = Coproduct[co](1)
val s = Coproduct[co]("s")
val io : Option[Int] :: Option[String] :: HNil = f(i) //Some(i) :: None :: Nil
val so : Option[Int] :: Option[String] :: HNil = f(i) //None :: Some("s") :: Nil
```

This is my solution to his question and thought it may be useful to others! A simple type class that accepts a coproduct and returns an hlist with all values in the hlist being `None` except for the value inside the coproduct which is wrapped in `Some`