### PR TITLE
Adds `TypedRecordArgs`

### DIFF
--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -89,6 +89,17 @@ trait RecordArgs extends Dynamic {
 }
 
 /**
+  * Similar to [[RecordArgs]], but allows the specification of the return type of the
+  * methods.
+  *
+  * @tparam T The return type for all record-accepting methods
+  */
+trait TypedRecordArgs[T] extends Dynamic {
+  def applyDynamic(method: String)(): T = macro RecordMacros.forwardImpl
+  def applyDynamicNamed(method: String)(rec: Any*): T = macro RecordMacros.forwardNamedImpl
+}
+
+/**
  * Trait supporting mapping record arguments to named argument lists, inverse of RecordArgs.
  *
  * Mixing in this trait enables method applications of the form,

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -18,6 +18,7 @@ package shapeless
 
 import org.junit.Test
 import org.junit.Assert._
+import shapeless.ops.hlist.Selector
 
 class RecordTests {
   import labelled._
@@ -809,6 +810,28 @@ class RecordTests {
 
     illTyped("""
       r.get('foo)
+    """)
+  }
+
+  object FooT extends TypedRecordArgs[String] {
+    def applyRecord[R <: HList](rec: R)(implicit selector: Selector[R, FieldType[Witness.`'foo`.T, String]]): String =
+      selector(rec)
+  }
+
+  @Test
+  def testTypedRecordArgs = {
+    val s = FooT(a = 22, foo = "foo", bar = true)
+    assertEquals(s, "foo")
+
+    val s2 = FooT(z = "foo", bar = "foo", foo = "foo2")
+    assertEquals(s2, "foo2")
+
+    illTyped("""
+      fooT(z = "foo")
+    """)
+
+    illTyped("""
+      fooT(z = "foo", foo = 22)
     """)
   }
 


### PR DESCRIPTION
`TypedRecordArgs` is just like `RecordArgs`, but allows you to specify the return type of the dynamic methods.

The primary use case is that IDEs like IntelliJ have trouble inferring types that are refined by macro expansion. If the result of `applyDynamicNamed` has a fixed upper bound on its return type before macro expansion, then it can be inferred more easily by using `TypedRecordArgs`.