### PR TITLE
Optimise hlist

### DIFF
--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -36,8 +36,8 @@ sealed trait HList extends Product with Serializable
  */
 final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
   override def toString = head match {
-    case _: ::[_, _] => "("+head+") :: "+tail.toString
-    case _ => head+" :: "+tail.toString
+    case _: ::[_, _] => s"(${head}) :: ${tail}"
+    case _           => s"${head} :: ${tail}"
   }
 
   // the default case class equals / hashCode is very inefficient

--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -39,6 +39,13 @@ final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
     case _: ::[_, _] => "("+head+") :: "+tail.toString
     case _ => head+" :: "+tail.toString
   }
+
+  // the default case class equals / hashCode is very inefficient
+  override def equals(other: Any): Boolean = other match {
+    case that: ::[_, _] => head == that.head && tail == that.tail
+    case _              => false
+  }
+  override def hashCode: Int = head.hashCode + 13 * tail.hashCode
 }
 
 /**
@@ -56,7 +63,14 @@ sealed trait HNil extends HList {
  * 
  * @author Miles Sabin
  */
-case object HNil extends HNil
+case object HNil extends HNil {
+  // the default case object equals / hashCode is very inefficient
+  override def equals(other: Any): Boolean = other match {
+    case that: HNil => true
+    case _          => false
+  }
+  override def hashCode: Int = 0
+}
 
 object HList extends Dynamic {
   import ops.hlist._

--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -42,7 +42,7 @@ final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
 
   // the default case class equals / hashCode is very inefficient
   override def equals(other: Any): Boolean = other match {
-    case that: ::[_, _] => head == that.head && tail == that.tail
+    case that: ::[_, _] => (this eq that) || (head == that.head && tail == that.tail)
     case _              => false
   }
   override def hashCode: Int = head.hashCode + 13 * tail.hashCode

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3399,4 +3399,10 @@ class HListTests {
     assertFalse(h3.hashCode == h4.hashCode)
   }
 
+  @Test
+  def testToString = {
+    assertTrue(("foo" :: 1 :: HNil).toString == "foo :: 1 :: HNil")
+    assertTrue(("foo" :: (1 :: HNil) :: HNil).toString == "foo :: (1 :: HNil) :: HNil")
+  }
+
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3375,4 +3375,28 @@ class HListTests {
 
   @Test
   def testIsHCons = assertTypedEquals[Int :: HNil](23 :: HNil, IsHCons[Int :: HNil].cons(23, HNil))
+
+  @Test
+  def testHashCode = {
+    val h1 = "foo" :: 1 :: HNil
+    val h2 = "foo" :: 1 :: HNil
+    val h3 = "foo" :: 2 :: HNil
+    val h4 = "bar" :: 1 :: HNil
+
+    assertTrue(h1 == h1)
+    assertTrue(h1.hashCode == h1.hashCode)
+
+    assertTrue(h1 == h2)
+    assertTrue(h1.hashCode == h2.hashCode)
+
+    assertFalse(h1 == h3)
+    assertFalse(h1.hashCode == h3.hashCode)
+
+    assertFalse(h1 == h4)
+    assertFalse(h1.hashCode == h4.hashCode)
+
+    assertFalse(h3 == h4)
+    assertFalse(h3.hashCode == h4.hashCode)
+  }
+
 }


### PR DESCRIPTION
this will break downstream users who are depending on the exact hashCode values that are currently produced. It is hard to say if that requires a minor bump or not. IMHO it is not a change of the API or binary interface, but people can get touchy about this sort of thing.