### PR TITLE
HList.IndexOf / Coproduct.IndexOf type operation

### DIFF
--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -1248,6 +1248,32 @@ object coproduct {
   }
 
   /**
+   * Typeclass witnessing a specific type is the ''i''th element of an [[Coproduct]].
+   * @author ctongfei (Tongfei Chen)
+   */
+  trait IndexOf[X, C <: Coproduct] extends DepFn0 with Serializable { type Out <: Nat }
+
+  object IndexOf {
+
+    def apply[X, C <: Coproduct](implicit indexOf: IndexOf[X, C]): Aux[X, C, indexOf.Out] = indexOf
+
+    type Aux[X, C <: Coproduct, Out0] = IndexOf[X, C] { type Out = Out0 }
+
+    implicit def indexOfHead[X, T <: Coproduct]: Aux[X, X :+: T, _0] =
+      new IndexOf[X, X :+: T] {
+        type Out = _0
+        def apply() = Nat._0
+      }
+
+    implicit def indexOfOthers[X, H, T <: Coproduct, I <: Nat]
+    (implicit indexOf: IndexOf.Aux[X, T, I]): Aux[X, H :+: T, Succ[I]] =
+      new IndexOf[X, H :+: T] {
+        type Out = Succ[I]
+        def apply() = Succ[I]
+      }
+  }
+
+  /**
     * Type class supporting reifying a `Coproduct` of singleton types.
     *
     * @author Jisoo Park

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -2927,10 +2927,9 @@ object hlist {
    * Typeclass witnessing a specific type is the ''i''th element of an [[HList]].
    * @author ctongfei (Tongfei Chen)
    */
-  trait IndexOf[X, L <: HList] extends /* DepFn1[L] with */ Serializable { type Out <: Nat }
+  trait IndexOf[X, L <: HList] extends DepFn0 with Serializable { type Out <: Nat }
 
   object IndexOf {
-    import ops.nat._
 
     def apply[X, L <: HList](implicit indexOf: IndexOf[X, L]): Aux[X, L, indexOf.Out] = indexOf
 
@@ -2939,13 +2938,14 @@ object hlist {
     implicit def indexOfHead[X, T <: HList]: Aux[X, X :: T, _0] =
       new IndexOf[X, X :: T] {
         type Out = _0
-        def apply(t: X :: T) = Nat._0
+        def apply() = Nat._0
       }
 
-    implicit def indexOfOthers[X, H, T <: HList, I <: Nat, J <: Nat]
+    implicit def indexOfOthers[X, H, T <: HList, I <: Nat]
     (implicit indexOf: IndexOf.Aux[X, T, I]): Aux[X, H :: T, Succ[I]] =
       new IndexOf[X, H :: T] {
         type Out = Succ[I]
+        def apply() = Succ[I]
       }
   }
 

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -2924,6 +2924,32 @@ object hlist {
   }
 
   /**
+   * Typeclass witnessing a specific type is the ''i''th element of an [[HList]].
+   * @author ctongfei (Tongfei Chen)
+   */
+  trait IndexOf[X, L <: HList] extends /* DepFn1[L] with */ Serializable { type Out <: Nat }
+
+  object IndexOf {
+    import ops.nat._
+
+    def apply[X, L <: HList](implicit indexOf: IndexOf[X, L]): Aux[X, L, indexOf.Out] = indexOf
+
+    type Aux[X, L <: HList, Out0] = IndexOf[X, L] { type Out = Out0 }
+
+    implicit def indexOfHead[X, T <: HList]: Aux[X, X :: T, _0] =
+      new IndexOf[X, X :: T] {
+        type Out = _0
+        def apply(t: X :: T) = Nat._0
+      }
+
+    implicit def indexOfOthers[X, H, T <: HList, I <: Nat, J <: Nat]
+    (implicit indexOf: IndexOf.Aux[X, T, I]): Aux[X, H :: T, Succ[I]] =
+      new IndexOf[X, H :: T] {
+        type Out = Succ[I]
+      }
+  }
+
+  /**
     * Type class supporting reifying an `HList` of singleton types.
     *
     * @author Jisoo Park

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1853,6 +1853,17 @@ class CoproductTests {
   }
 
   @Test
+  def testIndexOf {
+    import ops.coproduct._
+    import nat._
+    type IDSB = Int :+: Double :+: String :+: Boolean :+: CNil
+    assertEquals(toInt(implicitly[IndexOf.Aux[Int, IDSB, _0]].apply()), 0)
+    assertEquals(toInt(implicitly[IndexOf.Aux[Double, IDSB, _1]].apply()), 1)
+    assertEquals(toInt(implicitly[IndexOf.Aux[String, IDSB, _2]].apply()), 2)
+    assertEquals(toInt(implicitly[IndexOf.Aux[Boolean, IDSB, _3]].apply()), 3)
+  }
+
+  @Test
   def testReify {
     import syntax.singleton._
 

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3297,10 +3297,10 @@ class HListTests {
   def testIndexOf: Unit = {
     import shapeless.nat._
     type IDSB = Int :: Double :: String :: Boolean :: HNil
-    implicitly[IndexOf.Aux[Int, IDSB, _0]]
-    implicitly[IndexOf.Aux[Double, IDSB, _1]]
-    implicitly[IndexOf.Aux[String, IDSB, _2]]
-    implicitly[IndexOf.Aux[Boolean, IDSB, _3]]
+    assertEquals(toInt(implicitly[IndexOf.Aux[Int, IDSB, _0]].apply()), 0)
+    assertEquals(toInt(implicitly[IndexOf.Aux[Double, IDSB, _1]].apply()), 1)
+    assertEquals(toInt(implicitly[IndexOf.Aux[String, IDSB, _2]].apply()), 2)
+    assertEquals(toInt(implicitly[IndexOf.Aux[Boolean, IDSB, _3]].apply()), 3)
   }
 
   @Test

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3295,12 +3295,12 @@ class HListTests {
 
   @Test
   def testIndexOf: Unit = {
-    import shapeless.Nat._
+    import shapeless.nat._
     type IDSB = Int :: Double :: String :: Boolean :: HNil
     implicitly[IndexOf.Aux[Int, IDSB, _0]]
-    implicitly[IndexOf.Aux[Double, IDSB, Succ[_0]]]
-    implicitly[IndexOf.Aux[String, IDSB, Succ[Succ[_0]]]]
-    implicitly[IndexOf.Aux[Boolean, IDSB, Succ[Succ[Succ[_0]]]]]
+    implicitly[IndexOf.Aux[Double, IDSB, _1]]
+    implicitly[IndexOf.Aux[String, IDSB, _2]]
+    implicitly[IndexOf.Aux[Boolean, IDSB, _3]]
   }
 
   @Test

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3294,6 +3294,16 @@ class HListTests {
   }
 
   @Test
+  def testIndexOf: Unit = {
+    import shapeless.Nat._
+    type IDSB = Int :: Double :: String :: Boolean :: HNil
+    implicitly[IndexOf.Aux[Int, IDSB, _0]]
+    implicitly[IndexOf.Aux[Double, IDSB, Succ[_0]]]
+    implicitly[IndexOf.Aux[String, IDSB, Succ[Succ[_0]]]]
+    implicitly[IndexOf.Aux[Boolean, IDSB, Succ[Succ[Succ[_0]]]]]
+  }
+
+  @Test
   def testToSizedHList {
     val ns = List(1,2,3,4)
     assertTypedEquals[Option[III]](None, ns.toSizedHList(3))


### PR DESCRIPTION
Implements HList.IndexOf[L, X], which returns a Nat that is the index of the first occurrence of X in HList L.