### PR TITLE
Removed unsound cases in appliedTypTree1

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@ Eugene Burmako <xeno.by@gmail.com> @xeno_by
 Filipe Nepomuceno <filinep@gmail.com
 Frank S. Thomas <frank@timepit.eu> @fst9000
 George Leontiev <folone@gmail.com> @folone
+Georgi Krastev <joro.kr.21@gmail.com> @Joro_Kr
 Hamish Dickenson <hamish.dickson@gmail.com> @hamishdickson
 Howard Branch <purestgreen@gmail.com> @purestgreen
 Huw Giddens <hgiddens@gmail.com>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ of shapeless. It then drops you immediately into a REPL session,
 Loading...
 Welcome to the Ammonite Repl 0.8.2
 (Scala 2.11.8 Java 1.8.0_102)
-@ 23 :: "foo" :: true :: HNil 
+@ 23 :: "foo" :: true :: HNil
 res0: Int :: String :: Boolean :: HNil = 23 :: foo :: true :: HNil
 @ Bye!
 %
@@ -248,6 +248,7 @@ cross-builds for 2.10.6 and 2.11.8.
 + Filipe Nepomuceno <filinep@gmail.com>
 + Frank S. Thomas <frank@timepit.eu> [@fst9000](https://twitter.com/fst9000)
 + George Leontiev <folone@gmail.com> [@folone](https://twitter.com/folone)
++ Georgi Krastev <joro.kr.21@gmail.com> [@Joro_Kr](https://twitter.com/joro_kr)
 + Hamish Dickenson <hamish.dickson@gmail.com> [@hamishdickson](https://twitter.com/hamishdickson)
 + Howard Branch <purestgreen@gmail.com> [@purestgreen](https://twitter.com/purestgreen)
 + Huw Giddens <hgiddens@gmail.com>

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -552,17 +552,11 @@ trait CaseClassMacros extends ReprTypes {
         Ident(arg)
       case PolyType(params, body) if params.head.asType.toType =:= param =>
         appliedTypTree1(body, param, arg)
-      case t @ TypeRef(pre, sym, List()) if t.takesTypeArgs =>
-        val argTrees = t.typeParams.map(sym => appliedTypTree1(sym.asType.toType, param, arg))
-        AppliedTypeTree(mkAttributedRef(pre, sym), argTrees)
       case TypeRef(pre, sym, List()) =>
         mkAttributedRef(pre, sym)
       case TypeRef(pre, sym, args) =>
         val argTrees = args.map(appliedTypTree1(_, param, arg))
         AppliedTypeTree(mkAttributedRef(pre, sym), argTrees)
-      case t if t.takesTypeArgs =>
-        val argTrees = t.typeParams.map(sym => appliedTypTree1(sym.asType.toType, param, arg))
-        AppliedTypeTree(mkAttributedRef(tpe.typeConstructor), argTrees)
       case t =>
         tq"$tpe"
     }

--- a/core/src/test/scala/shapeless/generic1.scala
+++ b/core/src/test/scala/shapeless/generic1.scala
@@ -588,6 +588,8 @@ object SplitTestDefns {
   object Dummy1 {
     implicit def mkDummy1[F[_]]: Dummy1[F] = new Dummy1[F] {}
   }
+
+  trait Kleisli[F[_], A, B] extends (A => F[B])
 }
 
 class SplitTests {
@@ -666,5 +668,7 @@ class SplitTests {
     illTyped("""
     Split1[CCons1, Dummy1, Dummy1]
     """)
+
+    Split1[({ type λ[t] = Kleisli[Id, String, Option[t]] })#λ, Dummy1, Dummy1]
   }
 }


### PR DESCRIPTION
Unsound because they changed the kind of participating types
rather than just replacing the type `param` with the type `arg`.

Incidentally, resolves #652