### PR TITLE
Default Typeables for simple types and case classes get their names at compile time.

### DIFF
--- a/core/src/test/scala/shapeless/typeable.scala
+++ b/core/src/test/scala/shapeless/typeable.scala
@@ -564,6 +564,7 @@ class TypeableTests {
     val i1: A with B = new C
     assertEquals("Typeable[A with B]", typeableString(i1))
     assertEquals("Typeable[A]", typeableString(new A{}))
+    assertEquals("Typeable[A]", Typeable.simpleTypeable(classOf[A]).toString)
 
     val o: Option[Long] = Some(4l)
     assertEquals("Typeable[Option[Long]]", typeableString(o))


### PR DESCRIPTION
Doesn't change behavior at all (other than that nested types which previously triggered scala/bug#5425 now are printed like everything else), but does plausibly increase efficiency slightly when large numbers of calls to `.describe` are being made.

Fixes #707.