### PR TITLE
Fix ops.record.Selector with tagged type for Scala 2.12+

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -513,8 +513,12 @@ trait CaseClassMacros extends ReprTypes {
       val KeyTagPre = prefix(keyTagTpe)
       val KeyTagSym = keyTagTpe.typeSymbol
       fTpe.dealias match {
-        case RefinedType(List(v0, TypeRef(pre, KeyTagSym, List(k, v1))), _) if pre =:= KeyTagPre && v0 =:= v1 => Some((k, v0))
-        case _ => None
+        case RefinedType(List(v0, TypeRef(pre, KeyTagSym, List(k, v1))), _) if pre =:= KeyTagPre && v0 =:= v1 =>
+          Some((k, v0))
+        case RefinedType(List(v00, v01, TypeRef(pre, KeyTagSym, List(k, v1@RefinedType(List(v10, v11), _)))), _) if pre =:= KeyTagPre && v00 =:= v10 && v01 =:= v11 =>
+          Some((k, v1))
+        case _ =>
+          None
       }
     }
   }

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -1096,4 +1096,18 @@ class RecordTests {
 
     assertEquals(fields.toList, List('x, 'y, 'z))
   }
+
+  @Test
+  def testSelectorTagged {
+    import shapeless.syntax._
+    import shapeless.tag
+    import shapeless.tag._
+
+    trait TestTag
+    case class FooT(bar: String @@ TestTag)
+    val lgt = LabelledGeneric[FooT]
+    val fooT = FooT(tag[TestTag]("test"))
+
+    assertEquals(tag[TestTag]("test"), lgt.to(fooT).get('bar))
+  }
 }


### PR DESCRIPTION
I've played a bit with record types that contain tagged types inside. It seems that there are inconsistencies of how they are handled between Scala 2.{10,11} and 2.12+ when it comes to `ops.record.Selector` macro. I found that shape of `RefinedType` in https://github.com/milessabin/shapeless/blob/master/core/src/main/scala/shapeless/generic.scala#L516 is different in newer versions of the compiler.

This PR contains a test case that failed under 2.12+ and workaround solution that seems to fix the issue and works under all supported Scala versions.