### PR TITLE
Add syntax for injection into coproducts

### DIFF
--- a/core/src/main/scala/shapeless/syntax/inject.scala
+++ b/core/src/main/scala/shapeless/syntax/inject.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 Fabio Labella
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+package syntax
+
+object inject {
+  import ops.coproduct.Inject
+
+  /**
+   * @author Fabio Labella
+   */
+  implicit class InjectSyntax[T](val t: T) extends AnyVal {
+    /**
+     * Inject the receiver into a coproduct `C`.
+     * Only available if the coproduct contains the type `T`.
+     */
+    def inject[C <: Coproduct](implicit inj: Inject[C, T]): C = inj(t)
+  }
+}

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1937,6 +1937,23 @@ class CoproductTests {
     assertTypedEquals[Option[ISB]](Option(Inr(Inr(Inl(true)))), foo3)
     assertTypedEquals[Option[ISB]](Option.empty[ISB], foo4)
   }
+
+  @Test
+  def testInjectSyntax {
+    type ISBD = Int :+: String :+: Boolean :+: Double :+: CNil
+
+    import syntax.inject._
+
+    val i = 1.inject[ISBD]
+    assertEquals(Inl(1), i)
+
+    val b = true.inject[ISBD]
+    assertEquals(Inr(Inr(Inl(true))), b)
+
+    illTyped("1.inject[String :+: CNil]")
+    typed[ISBD](1.inject[ISBD])
+  }
+
 }
 
 package CoproductTestAux {


### PR DESCRIPTION
This small PR adds syntax to inject values into coproducts when there is an `Inject` in scope:

```scala
import shapeless_, syntax.inject._

true.inject[String :+: Boolean :+: CNil]
// Inr(Inl(true))
```