### PR TITLE
Expand gitignore for recent build changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,18 +6,19 @@ scratch/
 target/
 
 # Ignore project files for Eclipse
-/.classpath
-/*/.classpath
-/.settings
-/*/.settings
-/.project
-/*/.project
-/.worksheet
-/*/.worksheet
+.classpath
+.settings
+.project
+.worksheet
+
+# Ignore SBT files
+.js
+.jvm
+.cache-main
+.cache-tests
 
 # Ignore project files for IntelliJ
-/.idea
-/*/.idea
+.idea
 *.iml
 *.iws
 


### PR DESCRIPTION
There's now some more recursive folder nesting, so allow the hidden
files to be ignored deeper than just one level deep. Also, ignore the
`.js` and `.jvm` folders as well as the SBT jar cache folders.

@milessabin if you recall I think I provided the original version of this file, but it's been a year or so and there have been some changes that warrant a small update.