### PR TITLE
Simplify and add syntax for runtime inject

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,6 +20,7 @@ Dave Gurnell <d.j.gurnell@gmail.com> @davegurnell
 David Barri <japgolly@gmail.com> @japgolly
 Denis Mikhaylov <notxcain@gmail.com> @notxcain
 Eugene Burmako <xeno.by@gmail.com> @xeno_by
+Fabio Labella <fabio.labella2@gmail.com> @SystemFw
 Filipe Nepomuceno <filinep@gmail.com
 Frank S. Thomas <frank@timepit.eu> @fst9000
 George Leontiev <folone@gmail.com> @folone

--- a/core/src/main/scala/shapeless/syntax/inject.scala
+++ b/core/src/main/scala/shapeless/syntax/inject.scala
@@ -18,7 +18,7 @@ package shapeless
 package syntax
 
 object inject {
-  import ops.coproduct.Inject
+  import ops.coproduct.{Inject, RuntimeInject}
 
   /**
    * @author Fabio Labella
@@ -29,5 +29,13 @@ object inject {
      * Only available if the coproduct contains the type `T`.
      */
     def inject[C <: Coproduct](implicit inj: Inject[C, T]): C = inj(t)
+
+    /**
+     * Inject the receiver into a coproduct `C`, by trying to convert
+     * it to each element of C.
+     * Only available if the coproduct is not CNil.
+     */
+    def runtimeInject[C <: Coproduct](implicit rInj: RuntimeInject[C]): Option[C] =
+      rInj(t)
   }
 }

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1931,11 +1931,14 @@ class CoproductTests {
     val foo2 = Coproduct.runtimeInject[ISB]("foo": Any)
     val foo3 = Coproduct.runtimeInject[ISB](true: Any)
     val foo4 = Coproduct.runtimeInject[ISB](1.345: Any)
+    val foo5 = Coproduct.runtimeInject[ISB](null: Any)
 
     assertTypedEquals[Option[ISB]](Option(Inl(23)), foo1)
     assertTypedEquals[Option[ISB]](Option(Inr(Inl("foo"))), foo2)
     assertTypedEquals[Option[ISB]](Option(Inr(Inr(Inl(true)))), foo3)
     assertTypedEquals[Option[ISB]](Option.empty[ISB], foo4)
+    assertTypedEquals[Option[ISB]](Option.empty[ISB], foo5)
+    illTyped("Coproduct.runtimeInject[CNil](23: Any)")
   }
 
   @Test

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1927,6 +1927,8 @@ class CoproductTests {
 
   @Test
   def runtimeInject = {
+    import syntax.inject._
+
     val foo1 = Coproduct.runtimeInject[ISB](23: Any)
     val foo2 = Coproduct.runtimeInject[ISB]("foo": Any)
     val foo3 = Coproduct.runtimeInject[ISB](true: Any)
@@ -1939,6 +1941,7 @@ class CoproductTests {
     assertTypedEquals[Option[ISB]](Option.empty[ISB], foo4)
     assertTypedEquals[Option[ISB]](Option.empty[ISB], foo5)
     illTyped("Coproduct.runtimeInject[CNil](23: Any)")
+    assertTypedEquals[Option[ISB]](foo3, true.runtimeInject[ISB])
   }
 
   @Test

--- a/examples/src/main/scala/shapeless/examples/runtimeInject.scala
+++ b/examples/src/main/scala/shapeless/examples/runtimeInject.scala
@@ -35,8 +35,12 @@ object CoproductRuntimeInject extends App {
   val baz  = Coproduct.runtimeInject[FooIS]("baz": Any)
   val ouch = Coproduct.runtimeInject[FooIS](true: Any)
 
+  import syntax.inject._
+  val infix = 23.runtimeInject[FooIS]
+
   assert(foo  == Option(Inl(Foo("msg"))))
   assert(bar  == Option(Inr(Inl(23))))
   assert(baz  == Option(Inr(Inr(Inl("baz")))))
   assert(ouch == Option.empty[FooIS])
+  assert(infix == bar)
 }


### PR DESCRIPTION
The implementation of RuntimeInject feels slightly more complicated than it could be; this small PR adds a simplified implementation with the following benefits:
 - Shorter.
 - More straightforward: just a linear scan of the Coproduct, rather than mutual typelevel recursion.
 - Roughly half the number of implicit instances needed.
 - Rules out at compile time the impossible case of trying to convert to CNil, instead of allowing it and then always returning None at runtime.

It also adds syntax, and more tests.

I have to say I am unsure whether submitting this PR counts as bikeshedding, if that's the case please consider it withdrawn, with my apologies.
Also, there might be a reason why the current implementation is the way it is, but I'm failing to see it, so I figured this PR would be a good way of asking anyway :)