### PR TITLE
Add AlignByKeys class

### DIFF
--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -841,4 +841,36 @@ package record {
         def apply(l: FieldType[K, V] :: T) = field[K](hc(l.head: V)) :: mapValuesTail(l.tail)
       }
   }
+
+  /**
+    * Type class reordering record T by the HList of Keys K
+    *
+    * @author Mike Limansky
+    */
+  trait AlignByKeys[T <: HList, K <: HList] extends DepFn1[T] with Serializable {
+    override type Out <: HList
+  }
+
+  object AlignByKeys {
+    type Aux[T <: HList, K <: HList, O] = AlignByKeys[T, K] { type Out = O}
+
+    def apply[T <: HList, K <: HList](implicit ev: AlignByKeys[T, K]): Aux[T, K, ev.Out] = ev
+
+    implicit val hnilAlign: Aux[HNil, HNil, HNil] = new AlignByKeys[HNil, HNil] {
+      override type Out = HNil
+      override def apply(t: HNil): HNil = HNil
+    }
+
+    implicit def hlistAlign[T <: HList, KH, KT <: HList, V, R <: HList, TA <: HList](implicit
+      remover: Remover.Aux[T, KH, (V, R)],
+      tailAlign: AlignByKeys.Aux[R, KT, TA]
+    ): Aux[T, KH :: KT, FieldType[KH, V] :: TA] = new AlignByKeys[T, KH :: KT] {
+      override type Out = FieldType[KH, V] :: TA
+
+      override def apply(t: T): FieldType[KH, V] :: TA = {
+        val (v, r) = remover(t)
+        field[KH](v) :: tailAlign(r)
+      }
+    }
+  }
 }

--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -143,6 +143,11 @@ final class RecordOps[L <: HList](val l : L) extends AnyVal with Serializable {
   def mapValues(f: Poly)(implicit mapValues: MapValues[f.type, L]): mapValues.Out = mapValues(l)
 
   /**
+    * Align the keys on the order of HList of keys K
+    */
+  def alignByKeys[K <: HList](implicit alignByKeys: AlignByKeys[L, K]): alignByKeys.Out = alignByKeys(l)
+
+  /**
    * Returns a wrapped version of this record that provides `selectDynamic` access to fields.
    */
   def record: DynamicRecordOps[L] = DynamicRecordOps(l)

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -18,6 +18,7 @@ package shapeless
 
 import org.junit.Test
 import org.junit.Assert._
+import shapeless.ops.record.AlignByKeys
 
 class RecordTests {
   import labelled._
@@ -1097,6 +1098,23 @@ class RecordTests {
     val fields: (FieldType[Int, x.T] :: FieldType[String, y.T] :: FieldType[Boolean, z.T] :: HNil) = SwapRecord[TestRecord].apply
 
     assertEquals(fields.toList, List('x, 'y, 'z))
+  }
+
+  @Test
+  def alignByKeys: Unit = {
+    type TestRecord = Record.`'a -> String, 'b -> Int, 'c -> Double`.T
+
+    type Keys1 = HList.`'a, 'b, 'c`.T
+    type Keys2 = HList.`'b, 'c, 'a`.T
+    type Keys3 = HList.`'b, 'a, 'c`.T
+    type Keys4 = HList.`'c, 'a, 'b`.T
+
+    val v = Record(a  = "foo", b  = 42, c = 33.3)
+
+    assertTypedEquals[TestRecord](v, AlignByKeys[TestRecord, Keys1].apply(v))
+    assertTypedEquals[Record.`'b -> Int, 'c -> Double, 'a -> String`.T](Record(b = 42, c = 33.3, a = "foo"), AlignByKeys[TestRecord, Keys2].apply(v))
+    assertTypedEquals[Record.`'b -> Int, 'a -> String, 'c -> Double`.T](Record(b = 42, a = "foo", c = 33.3), AlignByKeys[TestRecord, Keys3].apply(v))
+    assertTypedEquals[Record.`'c -> Double, 'a -> String, 'b -> Int`.T](Record(c = 33.3, a = "foo", b = 42), AlignByKeys[TestRecord, Keys4].apply(v))
   }
 
   @Test

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -1113,8 +1113,9 @@ class RecordTests {
 
     assertTypedEquals[TestRecord](v, AlignByKeys[TestRecord, Keys1].apply(v))
     assertTypedEquals[Record.`'b -> Int, 'c -> Double, 'a -> String`.T](Record(b = 42, c = 33.3, a = "foo"), AlignByKeys[TestRecord, Keys2].apply(v))
-    assertTypedEquals[Record.`'b -> Int, 'a -> String, 'c -> Double`.T](Record(b = 42, a = "foo", c = 33.3), AlignByKeys[TestRecord, Keys3].apply(v))
-    assertTypedEquals[Record.`'c -> Double, 'a -> String, 'b -> Int`.T](Record(c = 33.3, a = "foo", b = 42), AlignByKeys[TestRecord, Keys4].apply(v))
+
+    assertTypedEquals[Record.`'b -> Int, 'a -> String, 'c -> Double`.T](Record(b = 42, a = "foo", c = 33.3), v.alignByKeys[Keys3])
+    assertTypedEquals[Record.`'c -> Double, 'a -> String, 'b -> Int`.T](Record(c = 33.3, a = "foo", b = 42), v.alignByKeys[Keys4])
   }
 
   @Test


### PR DESCRIPTION
This class allows to realign Records by keys provided as a type parameter.

Motivation. Assume you have record of type ```type A = Record.`'a->T1, 'b -> T2`.T``` and a function able to convert  ```type B = Record.`'b -> T2, 'a->T1`.T``` to some record ```type Res = Record.`'b -> U2, 'a->U1`.T```.  Using `AlignByKeys[A, Keys[Res].Out]` you can convert A to B  and then convert it to Res.

Real life example is here: https://github.com/limansky/beanpuree/blob/master/src/main/scala/me/limansky/beanpuree/BeanConverter.scala