### PR TITLE
Delayed forcing of type signatures in isCaseAccessorLike

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -645,7 +645,7 @@ trait CaseClassMacros extends ReprTypes {
   def isCaseObjectLike(sym: ClassSymbol): Boolean = sym.isModuleClass
 
   def isCaseAccessorLike(sym: TermSymbol): Boolean =
-    !isNonGeneric(sym) && sym.isPublic && (if(sym.owner.asClass.isCaseClass) sym.isCaseAccessor else sym.isAccessor)
+    sym.isPublic && (if(sym.owner.asClass.isCaseClass) sym.isCaseAccessor else sym.isAccessor) && !isNonGeneric(sym)
 
   def isSealedHierarchyClassSymbol(symbol: ClassSymbol): Boolean = {
     def helper(classSym: ClassSymbol): Boolean = {

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -122,6 +122,10 @@ package GenericTestsAux {
   sealed trait OB extends Overlapping
   case class OBC(s: String) extends OB
   case class OAB(i: Int) extends OA with OB
+
+  case object COSemiAuto {
+    implicit val gen = Generic[COSemiAuto.type]
+  }
 }
 
 class GenericTests {
@@ -653,6 +657,14 @@ class GenericTests {
   @Test
   def testCaseObjectsAndLazy {
     TC[Base1]
+  }
+
+  @Test
+  def testCaseObjectSemiAuto {
+    val gen = Generic[COSemiAuto.type]
+    assertSame(gen, COSemiAuto.gen)
+    assertTypedEquals[HNil](HNil, gen.to(COSemiAuto))
+    assertTypedEquals[COSemiAuto.type](COSemiAuto, gen.from(HNil))
   }
 }
 


### PR DESCRIPTION
There is no point in calling `isNonGeneric` if the other tests fail. However, it is more robust to avoid forcing the type signature whenever possible, see the added test e.g.

Resolves #757 