### PR TITLE
Fixed ops.record.Selector for refined types

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -513,20 +513,16 @@ trait CaseClassMacros extends ReprTypes {
       val KeyTagPre = prefix(keyTagTpe)
       val KeyTagSym = keyTagTpe.typeSymbol
       fTpe.dealias match {
-        case RefinedType(List(v0, TypeRef(pre, KeyTagSym, List(k, v1))), _) if pre =:= KeyTagPre && v0 =:= v1 => Some((k, v0))
+        case RefinedType(v0 :+ TypeRef(pre, KeyTagSym, List(k, v1)), scope)
+          if pre =:= KeyTagPre && refinedType(v0, NoSymbol, scope, NoPosition) =:= v1 =>
+            Some((k, v1))
         case _ => None
       }
     }
   }
 
-  def unpackFieldType(tpe: Type): (Type, Type) = {
-    val KeyTagPre = prefix(keyTagTpe)
-    val KeyTagSym = keyTagTpe.typeSymbol
-    tpe.dealias match {
-      case RefinedType(List(v0, TypeRef(pre, KeyTagSym, List(k, v1))), _) if pre =:= KeyTagPre && v0 =:= v1 => (k, v0)
-      case _ => abort(s"$tpe is not a field type")
-    }
-  }
+  def unpackFieldType(tpe: Type): (Type, Type) =
+    FieldType.unapply(tpe).getOrElse(abort(s"$tpe is not a field type"))
 
   def findField(lTpe: Type, kTpe: Type): Option[(Type, Int)] =
     unpackHListTpe(lTpe).zipWithIndex.collectFirst {


### PR DESCRIPTION
Refined types can have more than one parent before `KeyTag` and a block of declarations after it in normalized form, e.g.
```scala
Iterable[Int] with Tagged["tag"] with KeyTag["key"] {
  def reverse: Iterable[Int]
}
```
So we have to make sure to match all of them when generating `Selector` instances.

Fixes #734 and fixes #732