### PR TITLE
Don't import tupleNZippedOps from Prelude.

### DIFF
--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -16,6 +16,8 @@
 
 package shapeless
 
+import scala.Predef.{tuple2ToZippedOps => _, tuple3ToZippedOps => _, _}
+
 import org.junit.Test
 import org.junit.Assert._
 


### PR DESCRIPTION
This will break in the next 2.13 milestone release (it's already broken in the community build) on account of the PR scala/scala#6035, which gave `Tuple2` and `Tuple3` an extension method named `transpose`.

That `-Ypredef` PR is looking really useful right about now.