### PR TITLE
Fixed semiauto derivation of Default instances

### DIFF
--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -217,80 +217,73 @@ class DefaultMacros(val c: whitebox.Context) extends CaseClassMacros {
 
   def materialize[T: WeakTypeTag, L: WeakTypeTag]: Tree = {
     val tpe = weakTypeOf[T]
-
-    if (!isCaseClassLike(classSym(tpe)))
-      abort(s"$tpe is not a case class or case class like")
+    val cls = classSym(tpe)
 
     lazy val companion = companionRef(tpe)
+    def altCompanion = companion.symbol.info
 
-    // Fixes https://github.com/milessabin/shapeless/issues/474
-    tpe.typeSymbol.companion.info.members
+    val none = q"_root_.scala.None"
+    def some(value: Tree) = q"_root_.scala.Some($value)"
 
-    def methodFrom(tpe: Type, name: String): Option[Symbol] = {
-      val m = tpe.member(TermName(name))
-      if (m == NoSymbol)
-        None
-      else
-        Some(m)
-    }
+    // Symbol.alternatives is missing in Scala 2.10
+    def overloadsOf(sym: Symbol) =
+      if (sym.isTerm) sym.asTerm.alternatives
+      else if (sym.isType) sym :: Nil
+      else Nil
 
-    val primaryConstructor = tpe.decls.collectFirst {
-      case m if m.isMethod && m.asMethod.isPrimaryConstructor =>
-        m.asMethod
-    }.getOrElse {
-      c.abort(c.enclosingPosition, s"Cannot get primary constructor of $tpe")
-    }
-
-    def methodHasDefaults(m: MethodSymbol): Boolean =
-      m.asMethod.paramLists.flatten.exists(_.asTerm.isParamWithDefault)
+    def hasDefaultParams(method: MethodSymbol) =
+      method.paramLists.flatten.exists(_.asTerm.isParamWithDefault)
 
     // The existence of multiple apply overloads with default values gets checked
     // after the macro runs. Their existence can make the macro expansion fail,
     // as multiple overloads can define the functions we look for below, possibly
     // with wrong types, making the compilation fail with the wrong error.
     // We do this check here to detect that beforehand.
-    def overloadsWithDefaultCount(tpe: Type): Int = tpe.members.count { m =>
-      m.isMethod && m.name.toString == "apply" && methodHasDefaults(m.asMethod)
+    def overloadsWithDefaultParamsIn(tpe: Type) =
+      overloadsOf(tpe.member(TermName("apply"))).count {
+        alt => alt.isMethod && hasDefaultParams(alt.asMethod)
+      }
+
+    def defaultsFor(fields: List[(TermName, Type)]) = for {
+      ((_, argTpe), i) <- fields.zipWithIndex
+      default = tpe.companion.member(TermName(s"apply$$default$$${i + 1}")) orElse
+        altCompanion.member(TermName(s"$$lessinit$$greater$$default$$${i + 1}"))
+    } yield if (default.isTerm) {
+      val defaultTpe = appliedType(someTpe, devarargify(argTpe))
+      val defaultVal = some(q"$companion.$default")
+      (defaultTpe, defaultVal)
+    } else (noneTpe, none)
+
+    def mkDefault(defaults: List[(Type, Tree)]) = {
+      val (types, values) = defaults.unzip
+      val outTpe = mkHListTpe(types)
+      val outVal = mkHListValue(values)
+      q"_root_.shapeless.Default.mkDefault[$tpe, $outTpe]($outVal)"
     }
 
-    val mainOverloadsWithDefaultCount = overloadsWithDefaultCount(tpe.companion)
-    val secondOverloadsWithDefaultCount = overloadsWithDefaultCount(companion.symbol.info)
+    if (isCaseObjectLike(cls)) return mkDefault(Nil)
+    if (!isCaseClassLike(cls)) abort(s"$tpe is not a case class or case class like")
 
-    val oneOverloadWithDefaults = mainOverloadsWithDefaultCount == 1 || (
-      mainOverloadsWithDefaultCount == 0 && secondOverloadsWithDefaultCount == 1
-    )
+    // ClassSymbol.primaryConstructor is missing in Scala 2.10
+    val primaryCtor = overloadsOf(tpe.decl(termNames.CONSTRUCTOR)).find {
+      alt => alt.isMethod && alt.asMethod.isPrimaryConstructor
+    }.getOrElse {
+      c.abort(c.enclosingPosition, s"Cannot get primary constructor of $tpe")
+    }.asMethod
 
     // Checking if the primary constructor has default parameters, and returning
     // a Default instance with non-empty types / values only if that holds.
     // The apply$default$... methods below may still exist without these, if an additional
     // apply method has default parameters. We want to ignore them in this case.
-    val hasDefaults = oneOverloadWithDefaults && methodHasDefaults(primaryConstructor)
-
-    def wrapTpeTree(idx: Int, argTpe: Type) = {
-      if (hasDefaults) {
-        val methodOpt = methodFrom(tpe.companion, s"apply$$default$$${idx + 1}")
-          .orElse(methodFrom(companion.symbol.info, s"$$lessinit$$greater$$default$$${idx + 1}"))
-
-        methodOpt match {
-          case Some(method) =>
-            (appliedType(someTpe, argTpe), q"_root_.scala.Some($companion.$method)")
-          case None =>
-            (noneTpe, q"_root_.scala.None")
-        }
-      } else
-        (noneTpe, q"_root_.scala.None")
+    val hasUniqueDefaults = hasDefaultParams(primaryCtor) && {
+      val k = overloadsWithDefaultParamsIn(tpe.companion)
+      k == 1 || (k == 0 && overloadsWithDefaultParamsIn(altCompanion) == 1)
     }
 
-    val wrapTpeTrees = fieldsOf(tpe).zipWithIndex.map {case ((_, argTpe), idx) =>
-      wrapTpeTree(idx, devarargify(argTpe))
+    mkDefault {
+      val fields = fieldsOf(tpe)
+      if (hasUniqueDefaults) defaultsFor(fields)
+      else List.fill(fields.size)(noneTpe, none)
     }
-
-    val resultTpe = mkHListTpe(wrapTpeTrees.map { case (wrapTpe, _) => wrapTpe })
-
-    val resultTree = wrapTpeTrees.foldRight(q"_root_.shapeless.HNil": Tree) { case ((_, value), acc) =>
-      q"_root_.shapeless.::($value, $acc)"
-    }
-
-    q"_root_.shapeless.Default.mkDefault[$tpe, $resultTpe]($resultTree)"
   }
 }

--- a/core/src/test/scala/shapeless/default.scala
+++ b/core/src/test/scala/shapeless/default.scala
@@ -3,6 +3,7 @@ package shapeless
 import shapeless.record.Record
 
 import org.junit.Test
+import org.junit.Assert._
 import shapeless.test.illTyped
 import shapeless.testutil.assertTypedEquals
 
@@ -40,6 +41,24 @@ object DefaultTestDefinitions {
     }
   }
 
+  object SemiAuto {
+    case class CCl1(i: Int = 0)
+    object CCl1 {
+      implicit val default = Default[CCl1]
+    }
+
+    case class CCl2(i: Int)
+    trait CCl2Companion {
+      def default: Default[CCl2]
+    }
+    object CCl2 extends CCl2Companion {
+      implicit val default = Default[CCl2]
+    }
+
+    case object CObj {
+      implicit val default = Default[CObj.type]
+    }
+  }
 }
 
 class DefaultTests {
@@ -189,4 +208,20 @@ class DefaultTests {
     )
   }
 
+  @Test
+  def testSemiAuto {
+    import SemiAuto._
+
+    val default1 = Default[CCl1]
+    val default2 = Default[CCl2]
+    val default3 = Default[CObj.type]
+
+    assertSame(CCl1.default, default1)
+    assertSame(CCl2.default, default2)
+    assertSame(CObj.default, default3)
+
+    assertTypedEquals[Some[Int] :: HNil](Some(0) :: HNil, default1())
+    assertTypedEquals[None.type :: HNil](None :: HNil, default2())
+    assertTypedEquals[HNil](HNil, default3())
+  }
 }


### PR DESCRIPTION
Achieved via refactoring of `DefaultMacros.materialize`.

Fixes #747 