### PR TITLE
Fix exception message in csv example

### DIFF
--- a/examples/src/main/scala/shapeless/examples/csv.scala
+++ b/examples/src/main/scala/shapeless/examples/csv.scala
@@ -45,7 +45,7 @@ Markus,Persson,32"""
 // Implementation
 
 /** Exception to throw if something goes wrong during CSV parsing */
-class CSVException(s: String) extends RuntimeException
+class CSVException(s: String) extends RuntimeException(s)
 
 /** Trait for types that can be serialized to/deserialized from CSV */
 trait CSVConverter[T] {


### PR DESCRIPTION
Pass error string to super RuntimeException so that .getMessage behaves as expected.

