### PR TITLE
Remove faulty implementation of Coproduct ZipOne

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -333,7 +333,9 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
       exclude[MissingMethodProblem]("shapeless.CaseClassMacros.FieldType"),
       exclude[MissingMethodProblem]("shapeless.SingletonTypeUtils.parseSingletonSymbolType"),
       exclude[MissingMethodProblem]("shapeless.ops.hlist#IsHCons.cons"),
-      exclude[MissingMethodProblem]("shapeless.ops.coproduct#IsCCons.cons")
+      exclude[MissingMethodProblem]("shapeless.ops.coproduct#IsCCons.cons"),
+      exclude[MissingClassProblem]("shapeless.ops.coproduct$ZipOne$"),
+      exclude[MissingClassProblem]("shapeless.ops.coproduct$ZipOne")
     )
   }
 )

--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -454,37 +454,6 @@ object coproduct {
   }
 
   /**
-   * Type class supporting zipping this `Coproduct` with a `Coproduct` returning a `Coproduct` of tuples of the form
-   * ({element from input tuple}, {element index})
-   *
-   * @author Andreas Koestler
-   */
-  trait ZipOne[C1 <: Coproduct, C2 <: Coproduct] extends DepFn2[C1, C2] with Serializable { type Out <: Coproduct }
-
-  object ZipOne {
-    def apply[C1 <: Coproduct, C2 <: Coproduct](implicit zip: ZipOne[C1, C2]): Aux[C1, C2, zip.Out] = zip
-
-    type Aux[C1 <: Coproduct, C2 <: Coproduct, Out0 <: Coproduct] = ZipOne[C1, C2] {type Out = Out0}
-
-    implicit def singleZipOne[C1H, C2H]: Aux[C1H :+: CNil, C2H :+: CNil, (C1H, C2H) :+: CNil] =
-      new ZipOne[C1H :+: CNil, C2H :+: CNil] {
-        type Out = (C1H, C2H) :+: CNil
-
-        def apply(c: C1H :+: CNil, c2: C2H :+: CNil): Out = Coproduct[Out]((c.head.get, c2.head.get))
-      }
-
-    implicit def cpZipOne[C1H, C1T <: Coproduct, C2H, C2T <: Coproduct, OutC <: Coproduct]
-    (implicit
-     zot: ZipOne.Aux[C1T, C2T, OutC],
-     extend: ExtendRightBy[(C1H, C2H) :+: CNil, OutC]
-      ): Aux[C1H :+: C1T, C2H :+: C2T, extend.Out] = new ZipOne[C1H :+: C1T, C2H :+: C2T] {
-      type Out = extend.Out
-
-      def apply(c: C1H :+: C1T, c2: C2H :+: C2T): Out = extend(Coproduct[(C1H, C2H) :+: CNil](c.head.get, c2.head.get))
-    }
-  }
-
-  /**
    * Type class supporting zipping a `Coproduct` with its element indices, resulting in a `Coproduct` of tuples of the form
    * ({element from input tuple}, {element index})
    *


### PR DESCRIPTION
Fixes #772. Obviously breaks binary compatibility.