### PR TITLE
Handle consecutive Option columns in examples/csv deriveHConsOption, …

### DIFF
--- a/examples/src/main/scala/shapeless/examples/csv.scala
+++ b/examples/src/main/scala/shapeless/examples/csv.scala
@@ -28,15 +28,15 @@ import scala.util.{Try,Success,Failure}
  * */
 
 // The class to serialize or deserialize
-case class Person(name: String, surname: String, age: Int, id: Option[Int])
+case class Person(name: String, surname: String, age: Int, id: Option[Int], weight: Option[Int], height: Int)
 
 object CSVExample extends App {
 
   import CSVConverter._
 
-  val input = """John,Carmack,23,0
-Brian,Fargo,35
-Markus,Persson,32"""
+  val input = """John,Carmack,23,0,,100
+Brian,Fargo,35,,,110
+Markus,Persson,32,,,120"""
 
   println(CSVConverter[List[Person]].from(input))
 }
@@ -130,7 +130,7 @@ object CSVConverter {
             front <- scv.value.from(before)
             back <- sct.value.from(if (after.isEmpty) after else after.tail)
           } yield Some(front) :: back).orElse {
-            sct.value.from(s).map(None :: _)
+            sct.value.from(if (s.isEmpty) s else s.tail).map(None :: _)
           }
 
         case _ => fail("Cannot convert '" ++ s ++ "' to HList")


### PR DESCRIPTION
…and update CSVExample

This commit fixes an issue in the CSVExample where consecutive empty columns handled by deriveHConsOption would attempt to parse the remaining string unconditionally. Guard against this when head is None and orElse is called.

Useful for those basing work from examples/csv.scala