### PR TITLE
Fix link to SYB paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Classes as Object and Implicits][tcoi] is useful background material.
 [migration]: https://github.com/milessabin/shapeless/wiki/Migration-guide:-shapeless-1.2.4-to-2.0.0
 [migration210]: https://github.com/milessabin/shapeless/wiki/Migration-guide:-shapeless-2.0.0-to-2.1.0
 [milessabin]: https://twitter.com/milessabin
-[syb]: http://research.microsoft.com/en-us/um/people/simonpj/papers/hmap/
+[syb]: https://www.microsoft.com/en-us/research/publication/scrap-your-boilerplate-with-class/
 [higherrank]: http://camlunity.ru/swap/ocaml/Sexy%20Types.pdf
 [typelevel]: http://typelevel.org/
 [scalaz]: https://github.com/scalaz/scalaz


### PR DESCRIPTION
The link to Simon Peyton Jones's paper on scrap your boilerplate seems to get re-directed to his home page. It looks like it used to point directly to the paper - is this the right link now?