### PR TITLE
Use mkHListValue in LabelledMacros

### DIFF
--- a/core/src/main/scala/shapeless/labelled.scala
+++ b/core/src/main/scala/shapeless/labelled.scala
@@ -100,10 +100,7 @@ class LabelledMacros(val c: whitebox.Context) extends SingletonTypeUtils with Ca
     val labelValues = labels.map(mkSingletonSymbol)
 
     val labelsTpe = mkHListTpe(labelTpes)
-    val labelsValue =
-      labelValues.foldRight(q"_root_.shapeless.HNil": Tree) {
-        case (elem, acc) => q"_root_.shapeless.::($elem, $acc)"
-      }
+    val labelsValue = mkHListValue(labelValues)
 
     q"""
       new _root_.shapeless.DefaultSymbolicLabelling[$tTpe] {


### PR DESCRIPTION
I've found that LabelledMacros contains a copy of mkHListValue inside. Just to avoid duplication.