### PR TITLE
Add implicit OrElse combinator

### DIFF
--- a/core/src/main/scala/shapeless/orelse.scala
+++ b/core/src/main/scala/shapeless/orelse.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Georgi Krastev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shapeless
+
+/**
+ * Like `Option.orElse` on the type level and like `Either` on the value level.
+ *
+ * Instead of left and right constructors `OrElse` has primary and secondary implicits that lazily
+ * try to resolve first a value of type `A` or otherwise a value of type `B`.
+ */
+sealed trait OrElse[+A, +B] {
+  def fold[C](prim: A => C, sec: B => C): C
+  def unify[C >: A](implicit ev: B <:< C): C = fold(identity, ev)
+}
+
+class Primary[A](value: => A) extends OrElse[A, Nothing] {
+  def fold[C](prim: A => C, sec: Nothing => C) = prim(value)
+}
+
+class Secondary[B](value: => B) extends OrElse[Nothing, B] {
+  def fold[C](prim: Nothing => C, sec: B => C) = sec(value)
+}
+
+object OrElse extends OrElse0 {
+  implicit def primary[A, B](implicit a: Lazy[A]): A OrElse B =
+    new Primary(a.value)
+}
+
+private[shapeless] abstract class OrElse0 {
+  implicit def secondary[A, B](implicit b: Lazy[B]): A OrElse B =
+    new Secondary(b.value)
+}

--- a/core/src/test/scala/shapeless/orelse.scala
+++ b/core/src/test/scala/shapeless/orelse.scala
@@ -1,0 +1,37 @@
+package shapeless
+
+import test._
+import testutil.assertTypedEquals
+
+import org.junit.Test
+
+class OrElseTests {
+  sealed trait T
+  class A extends T
+  class B extends T
+  class C extends T
+  class D extends T
+
+  implicit val a: A = new A
+  implicit val b: B = new B
+
+  @Test
+  def testPrimaryFound {
+    assertTypedEquals[T](the[A OrElse C].unify, a)
+  }
+
+  @Test
+  def testSecondaryFound {
+    assertTypedEquals[T](the[C OrElse A].unify, a)
+  }
+
+  @Test
+  def testBothFound {
+    assertTypedEquals[T](the[A OrElse B].unify, a)
+  }
+
+  @Test
+  def testNeitherFound {
+    illTyped("the[C OrElse D]")
+  }
+}


### PR DESCRIPTION
Spin off from milessabin/kittens#73
* Like `Option.orElse` on the type level
* Like `Either` on the value level

I only added `fold` and `unify` to `OrElse`, but other methods from `Either` might also be useful.