### PR TITLE
Fix Lazy for tagged types

### DIFF
--- a/core/src/main/scala/shapeless/lazy.scala
+++ b/core/src/main/scala/shapeless/lazy.scala
@@ -180,7 +180,7 @@ trait OpenImplicitMacros {
   def openImplicitTpeParam: Option[Type] =
     openImplicitTpe.map {
       case TypeRef(_, _, List(tpe)) =>
-        tpe.map(_.dealias)
+        tpe.dealias
       case other =>
         c.abort(c.enclosingPosition, s"Bad materialization: $other")
     }

--- a/core/src/test/scala/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala/shapeless/labelledgeneric.scala
@@ -93,7 +93,7 @@ object ScalazTaggedAux {
     def apply(): String
   }
 
-  object TC {
+  object TC extends TCLowPriority {
     implicit val intTC: TC[Int] =
       new TC[Int] {
         def apply() = "Int"
@@ -114,22 +114,13 @@ object ScalazTaggedAux {
         def apply() = "HNil"
       }
 
-    implicit def hconsTCTagged[K <: Symbol, H, HT, T <: HList](implicit
-      key: Witness.Aux[K],
-      headTC: Lazy[TC[H @@ HT]],
-      tailTC: Lazy[TC[T]]
-    ): TC[FieldType[K, H @@ HT] :: T] =
-      new TC[FieldType[K, H @@ HT] :: T] {
-        def apply() = s"${key.value.name}: ${headTC.value()} :: ${tailTC.value()}"
-      }
-
     implicit def hconsTC[K <: Symbol, H, T <: HList](implicit
       key: Witness.Aux[K],
       headTC: Lazy[TC[H]],
-      tailTC: Lazy[TC[T]]
+      tailTC: TC[T]
     ): TC[FieldType[K, H] :: T] =
       new TC[FieldType[K, H] :: T] {
-        def apply() = s"${key.value.name}: ${headTC.value()} :: ${tailTC.value()}"
+        def apply() = s"${key.value.name}: ${headTC.value()} :: ${tailTC()}"
       }
 
     implicit def projectTC[F, G](implicit
@@ -138,6 +129,18 @@ object ScalazTaggedAux {
     ): TC[F] =
       new TC[F] {
         def apply() = s"Proj(${tc.value()})"
+      }
+  }
+
+  abstract class TCLowPriority {
+    // FIXME: Workaround #309
+    implicit def hconsTCTagged[K <: Symbol, H, HT, T <: HList](implicit
+      key: Witness.Aux[K],
+      headTC: Lazy[TC[H @@ HT]],
+      tailTC: TC[T]
+    ): TC[FieldType[K, H @@ HT] :: T] =
+      new TC[FieldType[K, H @@ HT] :: T] {
+        def apply() = s"${key.value.name}: ${headTC.value()} :: ${tailTC()}"
       }
   }
 }

--- a/core/src/test/scala/shapeless/lazy.scala
+++ b/core/src/test/scala/shapeless/lazy.scala
@@ -316,4 +316,21 @@ class LazyStrictTests {
       "lazily[W[String, Int]]", "No W\\[String, Int]"
     )
   }
+
+  @Test
+  def testInteractionWithTaggedTypes: Unit = {
+    import tag._
+
+    class Readable[A]
+    trait IdTag
+    type Id = String @@ IdTag
+
+    implicit def taggedStringReadable[T, M[_, _]](
+      implicit ev: String @@ T =:= M[String, T]
+    ): Readable[M[String, T]] = new Readable
+
+    implicitly[Readable[Id]]
+    implicitly[Lazy[Readable[Id]]]
+    implicitly[Strict[Readable[Id]]]
+  }
 }


### PR DESCRIPTION
Fixes #584 

Funny thing, this is also a partial fix for #309, but it looks like some types are automatically dealiased by Scala (e.g. `lgen.Repr` and `Record.{..fields}.T`) and in this case scala/bug#10506 kicks in.