### PR TITLE
Actualize versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ of shapeless. It then drops you immediately into a REPL session,
 ```text
 % curl -s https://raw.githubusercontent.com/milessabin/shapeless/master/scripts/try-shapeless.sh | bash
 Loading...
-Welcome to the Ammonite Repl 0.8.2
-(Scala 2.11.8 Java 1.8.0_102)
+Welcome to the Ammonite Repl 1.0.1
+(Scala 2.12.3 Java 1.8.0_102)
 @ 23 :: "foo" :: true :: HNil
 res0: Int :: String :: Boolean :: HNil = 23 :: foo :: true :: HNil
 @ Bye!
@@ -101,7 +101,7 @@ res0: Int :: String :: Boolean :: HNil = 23 :: foo :: true :: HNil
 [coursier]: https://github.com/alexarchambault/coursier
 [ammonite]: https://github.com/lihaoyi/Ammonite
 
-### shapeless-2.3.2 with SBT
+### shapeless-2.3.3 with SBT
 
 To include the Sonatype repositories in your SBT build you should add,
 
@@ -117,23 +117,23 @@ resolvers ++= Seq(
 
 
 Builds are available for Scala 2.10.x, 2.11.x and for 2.12.x. The main line of development for
-shapeless 2.3.2 is Scala 2.12.3. Scala 2.10.x is supported via the macro paradise compiler plugin.
+shapeless 2.3.3 is Scala 2.12.4. Scala 2.10.x is supported via the macro paradise compiler plugin.
 
 ```scala
-scalaVersion := "2.12.3"
+scalaVersion := "2.12.4"
 
 libraryDependencies ++= Seq(
-  "com.chuusai" %% "shapeless" % "2.3.2"
+  "com.chuusai" %% "shapeless" % "2.3.3"
 )
 ```
 
 If you are using Scala 2.10.x, you should also add the macro paradise plugin to your build,
 
 ```scala
-scalaVersion := "2.10.6"
+scalaVersion := "2.10.7"
 
 libraryDependencies ++= Seq(
-  "com.chuusai" %% "shapeless" % "2.3.2",
+  "com.chuusai" %% "shapeless" % "2.3.3",
   compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 ```
@@ -165,7 +165,7 @@ Scala.
 [tls]: https://github.com/typelevel/scala
 [si-7046-pr]: https://github.com/scala/scala/pull/5284
 
-### shapeless-2.3.2 with Maven
+### shapeless-2.3.3 with Maven
 
 shapeless is also available for projects using the Maven build tool via the following dependency,
 
@@ -173,7 +173,7 @@ shapeless is also available for projects using the Maven build tool via the foll
 <dependency>
   <groupId>com.chuusai</groupId>
   <artifactId>shapeless_2.11</artifactId>
-  <version>2.3.2</version>
+  <version>2.3.3</version>
 </dependency>
 ```
 
@@ -216,8 +216,8 @@ releases][olderusage] on the shapeless wiki.
 
 ## Building shapeless
 
-shapeless is built with SBT 0.13.13 or later, and its master branch is built with Scala 2.12.3 by default but also
-cross-builds for 2.10.6 and 2.11.8.
+shapeless is built with SBT 0.13.13 or later, and its master branch is built with Scala 2.12.4 by default but also
+cross-builds for 2.10.7 and 2.11.12.
 
 [namehashing]: https://github.com/sbt/sbt/issues/1640
 


### PR DESCRIPTION
I've just updated shapeless and Scala versions in readme.