### PR TITLE
Make Inject respect covariance

### DIFF
--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -33,8 +33,8 @@ object coproduct {
       def apply(i: I): H :+: T = Inr(tlInj(i))
     }
 
-    implicit def hdInject[H, T <: Coproduct]: Inject[H :+: T, H] = new Inject[H :+: T, H] {
-      def apply(i: H): H :+: T = Inl(i)
+    implicit def hdInject[H, HH <: H, T <: Coproduct]: Inject[H :+: T, HH] = new Inject[H :+: T, HH] {
+      def apply(i: HH): H :+: T = Inl(i)
     }
   }
 
@@ -512,7 +512,7 @@ object coproduct {
   /**
    * Type class supporting zipping a `Coproduct` with an `HList`, resulting in a `Coproduct` of tuples of the form
    * ({element from input `Coproduct`}, {element from input `HList`})
-   * 
+   *
    * @author William Harvey
    */
   trait ZipWith[H <: HList, V <: Coproduct] extends DepFn2[H, V] with Serializable { type Out <: Coproduct }
@@ -527,7 +527,7 @@ object coproduct {
       def apply(h: HNil, v: CNil) = v
     }
 
-    implicit def cpZipWith[HH, HT <: HList, VH, VT <: Coproduct](implicit zipWith: ZipWith[HT, VT]): 
+    implicit def cpZipWith[HH, HT <: HList, VH, VT <: Coproduct](implicit zipWith: ZipWith[HT, VT]):
         Aux[HH :: HT, VH :+: VT, (VH, HH) :+: zipWith.Out] = new ZipWith[HH :: HT, VH :+: VT] {
       type Out = (VH, HH) :+: zipWith.Out
       def apply(h: HH :: HT, v: VH :+: VT): Out = v match {

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -47,6 +47,12 @@ class CoproductTests {
     implicit val caseBoolean = at[Boolean](_ => 1)
   }
 
+  trait Dog
+  trait Cat
+  type DogCat = Dog :+: Cat :+: CNil
+  case object Rex extends Dog
+  case object Felix extends Cat
+
   @Test
   def testInject {
     implicitly[Inject[Int :+: CNil, Int]]
@@ -54,6 +60,8 @@ class CoproductTests {
     implicitly[Inject[Int :+: Int :+: Int :+: CNil, Int]]
     implicitly[Inject[String :+: Int :+: CNil, Int]]
     implicitly[Inject[Int :+: String :+: CNil, Int]]
+    implicitly[Inject[DogCat, Rex.type]]
+    implicitly[Inject[DogCat, Felix.type]]
 
     val foo1 = Coproduct[ISB](23)
     val foo2 = Coproduct[ISB]("foo")
@@ -1955,6 +1963,9 @@ class CoproductTests {
 
     val b = true.inject[ISBD]
     assertEquals(Inr(Inr(Inl(true))), b)
+
+    val dc = Rex.inject[DogCat]
+    assertEquals(Inl(Rex), dc)
 
     illTyped("1.inject[String :+: CNil]")
     typed[ISBD](1.inject[ISBD])


### PR DESCRIPTION
Addresses issue https://github.com/milessabin/shapeless/issues/728

Note I've chosen the constraint `HH <: H` rather than an implicit `HH <:< H` because the latter causes an ambiguous implicit error, the fix for which is either an `<:!<` in the other implicit method or a `LowPriority` trait. I felt both of those would compile too slowly for such a common class.