### PR TITLE
Ensure LowPriority is fine with the Aux pattern

### DIFF
--- a/core/src/main/scala/shapeless/lowpriority.scala
+++ b/core/src/main/scala/shapeless/lowpriority.scala
@@ -67,11 +67,18 @@ class LowPriorityMacros(val c: whitebox.Context) extends OpenImplicitMacros with
 
   def strictTpe = typeOf[Strict[_]].typeConstructor
 
+  // FIXME Also in LazyMacros
+  def stripRefinements(tpe: Type): Option[Type] =
+    tpe match {
+      case RefinedType(parents, _) => Some(parents.head)
+      case _ => None
+    }
+
   def mkLowPriority: Tree =
     secondOpenImplicitTpe match {
       case Some(tpe) =>
         c.inferImplicitValue(
-          appliedType(strictTpe, appliedType(lowPriorityForTpe, tpe)),
+          appliedType(strictTpe, appliedType(lowPriorityForTpe, stripRefinements(tpe.dealias).getOrElse(tpe))),
           silent = false
         )
 


### PR DESCRIPTION
I ran into issues with `LowPriority` when using it for type classes relying on the aux pattern… That PR fixes that.