### PR TITLE
 Match fields by name as well as by type in alignFields 

### DIFF
--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -127,6 +127,12 @@ package GenericTestsAux {
   case object COSemiAuto {
     implicit val gen = Generic[COSemiAuto.type]
   }
+
+  case class CCOrdered[A: Ordering](value: A)
+  class CCLikeOrdered[A: Ordering](val value: A)
+
+  case class CCDegen(i: Int)()
+  class CCLikeDegen(val i: Int)()
 }
 
 class GenericTests {
@@ -676,6 +682,30 @@ class GenericTests {
     assertSame(gen, COSemiAuto.gen)
     assertTypedEquals[HNil](HNil, gen.to(COSemiAuto))
     assertTypedEquals[COSemiAuto.type](COSemiAuto, gen.from(HNil))
+  }
+
+  @Test
+  def testGenericImplicitParams {
+    type Repr = Int :: HNil
+    val gen = Generic[CCOrdered[Int]]
+    val cc = CCOrdered(42)
+    val rep = 42 :: HNil
+
+    assertTypedEquals[CCOrdered[Int]](gen.from(rep), cc)
+    assertTypedEquals[Repr](gen.to(cc), rep)
+    illTyped("Generic[CCLikeOrdered[Int]]")
+  }
+
+  @Test
+  def testGenericDegenerate {
+    type Repr = Int :: HNil
+    val gen = Generic[CCDegen]
+    val cc = CCDegen(313)
+    val rep = 313 :: HNil
+
+    assertTypedEquals[CCDegen](gen.from(rep), cc)
+    assertTypedEquals[Repr](gen.to(cc), rep)
+    illTyped("Generic[CCLikeDegen]")
   }
 }
 

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -133,6 +133,10 @@ package GenericTestsAux {
 
   case class CCDegen(i: Int)()
   class CCLikeDegen(val i: Int)()
+
+  class Squared(x: Long) {
+    val x2 = x * x
+  }
 }
 
 class GenericTests {
@@ -706,6 +710,11 @@ class GenericTests {
     assertTypedEquals[CCDegen](gen.from(rep), cc)
     assertTypedEquals[Repr](gen.to(cc), rep)
     illTyped("Generic[CCLikeDegen]")
+  }
+
+  @Test
+  def testCtorFieldsMismatch {
+    illTyped("Generic[Squared]")
   }
 }
 


### PR DESCRIPTION
`alignFields` just zips fields and arguments and checks they match
(both name and type), instead of guessing based on the type.
Byname parameters are checked only by type to enable the emulation
of lazy parameters.

based on #794 