### PR TITLE
Remove GenTraversable constraint from ToSizedHList

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,11 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
 
       // Implicit reorderings
       exclude[DirectMissingMethodProblem]("shapeless.LowPriorityUnaryTCConstraint.hnilConstUnaryTC"),
-      exclude[ReversedMissingMethodProblem]("shapeless.LowPriorityUnaryTCConstraint.hnilUnaryTC")
+      exclude[ReversedMissingMethodProblem]("shapeless.LowPriorityUnaryTCConstraint.hnilUnaryTC"),
+
+      // Relaxed constraints
+      exclude[IncompatibleMethTypeProblem]("shapeless.ops.traversable#ToSizedHList.apply"),
+      exclude[ReversedMissingMethodProblem]("shapeless.ops.traversable#ToSizedHList.apply")
     )
   }
 )

--- a/core/src/main/scala/shapeless/ops/traversables.scala
+++ b/core/src/main/scala/shapeless/ops/traversables.scala
@@ -57,7 +57,7 @@ object traversable {
    * 
    * @author Rob Norris
    */
-  trait ToSizedHList[CC[T] <: GenTraversable[T], A, N <: Nat] extends Serializable {
+  trait ToSizedHList[CC[_], A, N <: Nat] extends Serializable {
     type Out
     def apply(cc: CC[A]): Out
   }
@@ -69,7 +69,7 @@ object traversable {
    */
   object ToSizedHList {
 
-    def apply[CC[T] <: GenTraversable[T], A, N <: Nat](
+    def apply[CC[_], A, N <: Nat](
       implicit ev: ToSizedHList[CC, A, N]
     ): ToSizedHList.Aux[CC, A, N, ev.Out] = 
       ev
@@ -78,7 +78,7 @@ object traversable {
     import ops.nat._
     import ops.sized._
 
-    type Aux[CC[T] <: GenTraversable[T], A, N <: Nat, Out0] =
+    type Aux[CC[_], A, N <: Nat, Out0] =
       ToSizedHList[CC, A, N] {
         type Out = Out0
       }


### PR DESCRIPTION
The instance method needs this sort of constraint, but I don't know of a
reason that the type class itself needs this constraint.

@tpolecat I think that you originally contributed this type class. What
do you think?