### PR TITLE
check $TRAVIS_REPO_SLUG

### DIFF
--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -8,6 +8,7 @@ COVERAGE="$SBT clean coverage test coverageReport"
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" &&
       "${TRAVIS_BRANCH}" == "master" &&
+      "${TRAVIS_REPO_SLUG}" == "milessabin/shapeless" &&
       $(cat version.sbt) =~ "-SNAPSHOT"
 ]]; then
 PUBLISH=publish


### PR DESCRIPTION
I want to execute travis-ci job in my fork repository. but "publish" task fail

> `TRAVIS_REPO_SLUG`: The slug (in form: `owner_name/repo_name`) of the repository currently being built.

https://docs.travis-ci.com/user/environment-variables/