### PR TITLE
upgrade sbt-api-mappings so build works on JDK 9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("org.scala-js"                      % "sbt-scalajs"           % "0.
 addSbtPlugin("com.github.gseitz"                 % "sbt-release"           % "1.0.7")
 addSbtPlugin("com.jsuereth"                      % "sbt-pgp"               % "1.1.0")
 addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"          % "2.2")
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "2.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "2.1.0")
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"         % "1.5.1")
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"      % "0.3.7")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject" % "0.4.0")


### PR DESCRIPTION
this came up in the context of the Scala community build, at
https://github.com/scala/community-builds/issues/609

also threw in an sbt version bump just 'cause