### PR TITLE
Define a typeclass `Perhaps` to reify implicit resolution failure

### DIFF
--- a/core/src/main/scala/shapeless/perhaps.scala
+++ b/core/src/main/scala/shapeless/perhaps.scala
@@ -1,0 +1,18 @@
+package shapeless
+
+/**
+  * Reifies implicit resolution failure as a value.
+  *
+  * Useful for expressing "If the implicit is available, do X. Else do Y.”
+  */
+final case class Perhaps[A](value: Option[A]) {
+  def fold[B](ifAbsent: => B, ifPresent: A => B): B = {
+    value.fold(ifAbsent)(ifPresent)
+  }
+}
+
+object Perhaps {
+  implicit def instance[A](implicit ev: A = null): Perhaps[A] = {
+    Perhaps(Option(ev))
+  }
+}

--- a/core/src/test/scala/shapeless/perhaps.scala
+++ b/core/src/test/scala/shapeless/perhaps.scala
@@ -1,0 +1,34 @@
+package shapeless
+
+import test._
+import testutil.assertTypedEquals
+
+import org.junit.Test
+
+class PerhapsTests {
+  class A
+  class B
+  implicit val b: B = new B
+
+  @Test
+  def testResolutionSuccess: Unit = {
+    assertTypedEquals[Option[B]](the[Perhaps[B]].value, Some(b))
+  }
+
+  @Test
+  def testResolutionFailure: Unit = {
+    assertTypedEquals[Option[A]](the[Perhaps[A]].value, None)
+  }
+
+  class C
+  implicit val c: C = null
+
+  /**
+    * This test documents a wart with this trick wherein if you have an implicit defined but its value is `null`, its
+    * resolution will be considered a failure.
+    */
+  @Test
+  def testResolutionFailureIfImplicitDefinedWithNullValue: Unit = {
+    assertTypedEquals[Option[C]](the[Perhaps[C]].value, None)
+  }
+}


### PR DESCRIPTION
In a similar spirit as `OrElse`.