### PR TITLE
adapt to post-M4 changes

### DIFF
--- a/core/jvm/src/test/scala_2.13+/shapeless/serializationtestutils.scala
+++ b/core/jvm/src/test/scala_2.13+/shapeless/serializationtestutils.scala
@@ -39,8 +39,9 @@ object serializationtestutils {
     }
 
   implicit def listSerializableIsIterableLike[T]: IsIterableLike[List[T]] { type A = T } =
-    new IsIterableLike[List[T]] with Serializable {
+    new collection.generic.IsIterable[List[T]] with Serializable {
       type A = T
-      val conversion: List[T] => IterableOps[T, Iterable, List[T]] = identity
+      type C = List[T]
+      override def apply(coll: List[T]) = coll
     }
 }

--- a/core/src/main/scala/shapeless/sized.scala
+++ b/core/src/main/scala/shapeless/sized.scala
@@ -52,7 +52,7 @@ class SizedOps[A0, Repr : AdditiveCollection, L <: Nat](s : Sized[Repr, L], itl:
   import ops.sized._
   import ops.hlist.Tupler
 
-  private implicit def conv(repr: Repr): IterableLike[A0, Repr] = itl.conversion(repr)
+  private implicit def conv(repr: Repr): IterableLike[A0, Repr] = itl(repr)
 
   /**
    * Returns the ''nth'' element of this `Sized`. Available only if there is evidence that this `Sized` has at least ''n''
@@ -163,7 +163,7 @@ class SizedOps[A0, Repr : AdditiveCollection, L <: Nat](s : Sized[Repr, L], itl:
       convThat : IsIterableLike[That] { type A = B },
       cbf : Factory[B, That],
       ev : AdditiveCollection[That]): Sized[That, sum.Out] =
-        wrap[That, sum.Out](cbf.fromSpecific(conv(s.unsized).iterator ++ convThat.conversion(that.unsized).iterator))
+        wrap[That, sum.Out](cbf.fromSpecific(conv(s.unsized).iterator ++ convThat(that.unsized).iterator))
 
   /**
    * Map across this collection. The resulting collection will be statically known to have the same number of elements

--- a/core/src/main/scala/shapeless/syntax/sized.scala
+++ b/core/src/main/scala/shapeless/syntax/sized.scala
@@ -30,13 +30,13 @@ final class SizedConv[A, Repr](r : Repr)(implicit iil: IsIterableLike[Repr], ev2
   import Sized._
 
   def sized[L <: Nat](implicit toInt : ToInt[L]) =
-    if(iil.conversion(r).size == toInt()) Some(wrap[Repr, L](r)) else None
+    if(iil(r).size == toInt()) Some(wrap[Repr, L](r)) else None
     
   def sized(l: Nat)(implicit toInt : ToInt[l.N]) =
-    if(iil.conversion(r).size == toInt()) Some(wrap[Repr, l.N](r)) else None
+    if(iil(r).size == toInt()) Some(wrap[Repr, l.N](r)) else None
     
   def ensureSized[L <: Nat](implicit toInt : ToInt[L]) = {
-    assert(iil.conversion(r).size == toInt())
+    assert(iil(r).size == toInt())
     wrap[Repr, L](r)
   }
 }

--- a/core/src/main/scala_2.13+/shapeless/versionspecifics.scala
+++ b/core/src/main/scala_2.13+/shapeless/versionspecifics.scala
@@ -21,7 +21,7 @@ import scala.reflect.macros.whitebox
 trait ScalaVersionSpecifics {
   private[shapeless] type BuildFrom[-F, -E, +T] = collection.BuildFrom[F, E, T]
   private[shapeless] type Factory[-E, +T] = collection.Factory[E, T]
-  private[shapeless] type IsIterableLike[Repr] = collection.generic.IsIterableLike[Repr]
+  private[shapeless] type IsIterableLike[Repr] = collection.generic.IsIterable[Repr] { type C = Repr }
   private[shapeless] type IterableLike[T, Repr] = collection.IterableOps[T, Iterable, Repr]
   private[shapeless] type GenMap[K, +V] = Map[K, V]
 


### PR DESCRIPTION
specifically scala/scala#6674

tested with 2.13.0-pre-a62cb07

I'm just trying to get Shapeless green again in the 2.13 community build, in a "I have no idea what I'm doing" kind of way... you may want to redo this in your own style rather than merge it