### PR TITLE
Remove spurious word from comment in klist example

### DIFF
--- a/examples/src/main/scala/shapeless/examples/klist.scala
+++ b/examples/src/main/scala/shapeless/examples/klist.scala
@@ -20,7 +20,7 @@ object KList {
   import shapeless._
   import UnaryTCConstraint._
   
-  // Function which will only accept HList's whose elements all have have Option as their
+  // Function which will only accept HList's whose elements all have Option as their
   // outer type constructor
   def acceptOption[L <: HList : *->*[Option]#λ](l : L) = true
   


### PR DESCRIPTION
Fix a minor documentation issue in klist example.