### PR TITLE
Fix bug in RotateLeft/RotateRight for Poly with more than 1 Case

### DIFF
--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -88,7 +88,7 @@ object PolyDefns extends Cases {
 
   object RotateLeft {
     implicit def rotateLeftCase[C, P <: Poly, N <: Nat, L <: HList, LOut, RL <: HList]
-      (implicit unpack: Unpack2[C, RotateLeft, P, N], cP: Case.Aux[P, L, LOut], rotateRight: hl.RotateRight.Aux[RL, N, L])
+      (implicit unpack: Unpack2[C, RotateLeft, P, N], rotateRight: hl.RotateRight.Aux[RL, N, L], cP: Case.Aux[P, L, LOut])
         : Case.Aux[C, RL, LOut] = new Case[C, RL] {
         type Result = LOut
 
@@ -105,7 +105,7 @@ object PolyDefns extends Cases {
 
   object RotateRight {
     implicit def rotateLeftCase[C, P <: Poly, N <: Nat, L <: HList, LOut, RL <: HList]
-      (implicit unpack: Unpack2[C, RotateRight, P, N], cP: Case.Aux[P, L, LOut], rotateLeft: hl.RotateLeft.Aux[RL, N, L])
+      (implicit unpack: Unpack2[C, RotateRight, P, N], rotateLeft: hl.RotateLeft.Aux[RL, N, L], cP: Case.Aux[P, L, LOut])
         : Case.Aux[C, RL, LOut] = new Case[C, RL] {
         type Result = LOut
 

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -295,15 +295,25 @@ class PolyTests {
       implicit val default = at[Int, String, Double] {
         case (i, s, d) => s"i: $i, s: $s, d: $d"
       }
+
+      implicit val another = at[Long, Char, Boolean] {
+        case (l, c, b) => s"l: $l, c: $c, b: $b"
+      }
     }
 
     val r1 = isd(1, "foo", 2.0)
     assertTypedEquals[String](s"i: 1, s: foo, d: ${2.0}", r1)
 
+    val r11 = isd(1L, 'f', true)
+    assertTypedEquals[String](s"l: 1, c: f, b: true", r11)
+
     val sdi = isd.rotateLeft[Nat._1]
 
     val r2 = sdi("foo", 2.0, 1)
     assertTypedEquals[String](s"i: 1, s: foo, d: ${2.0}", r2)
+
+    val r21 = sdi('f', true, 1L)
+    assertTypedEquals[String](s"l: 1, c: f, b: true", r21)
 
     val dis  = isd.rotateLeft[Nat._2]
 


### PR DESCRIPTION
Type parameter `RL` should be inferred before `L`, otherwise RotateLeft/RotateRight is not resolved for Poly with more than 1 Case.

```
[error] /home/travis/build/DmytroMitin/shapeless/core/src/test/scala/shapeless/poly.scala:312:17: could not find implicit value for parameter cse: shapeless.poly.Case[sdi.type,String :: Double :: Int :: shapeless.HNil]
[error]     val r2 = sdi("foo", 2.0, 1)
[error]                 ^
[error] /home/travis/build/DmytroMitin/shapeless/core/src/test/scala/shapeless/poly.scala:315:18: could not find implicit value for parameter cse: shapeless.poly.Case[sdi.type,Char :: Boolean :: Long :: shapeless.HNil]
[error]     val r21 = sdi('f', true, 1L)
[error]                  ^
[error] /home/travis/build/DmytroMitin/shapeless/core/src/test/scala/shapeless/poly.scala:320:17: could not find implicit value for parameter cse: shapeless.poly.Case[dis.type,Double :: Int :: String :: shapeless.HNil]
[error]     val r3 = dis(2.0, 1, "foo")
[error]                 ^
[error] three errors found
```
https://travis-ci.org/DmytroMitin/shapeless/jobs/496497621