### PR TITLE
Fix bug in Witness for TypeRef singleton type (error "type argument A.type is not a singleton type")

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ resolvers ++= Seq(
 [ci]: https://travis-ci.org/milessabin/shapeless
 
 
-Builds are available for Scala 2.10.x, 2.11.x and for 2.12.x. The main line of development for
-shapeless 2.3.3 is Scala 2.12.4. Scala 2.10.x is supported via the macro paradise compiler plugin.
+Builds are available for Scala 2.10.x, 2.11.x, 2.12.x and for 2.13.0-M5. The main line of development for
+shapeless 2.3.3 is Scala 2.12.8. Scala 2.10.x is supported via the macro paradise compiler plugin.
 
 ```scala
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.3.3"
@@ -139,6 +139,17 @@ libraryDependencies ++= Seq(
   compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 ```
+
+For using snapshots of Shapeless you should add,
+```scala
+scalaVersion := "2.12.8"
+
+libraryDependencies ++= Seq(
+  "com.chuusai" %% "shapeless" % "2.4.0-SNAPSHOT"
+)
+```
+
+
 
 ### shapeless and Typelevel Scala
 
@@ -215,7 +226,7 @@ releases][olderusage] on the shapeless wiki.
 
 ## Building shapeless
 
-shapeless is built with SBT 0.13.16 or later, and its master branch is built with Scala 2.12.4 by default but also
+shapeless is built with SBT 0.13.16 or later, and its master branch is built with Scala 2.12.8 by default but also
 cross-builds for 2.10.7 and 2.11.12.
 
 [namehashing]: https://github.com/sbt/sbt/issues/1640

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -291,11 +291,10 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils wi
     """
   }
 
-  def mkAttributedRef(pre: Type, sym: Symbol): Tree = {
+  def mkAttributedQualifier(tpe: Type): Tree = {
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    val gPre = pre.asInstanceOf[global.Type]
-    val gSym = sym.asInstanceOf[global.Symbol]
-    global.gen.mkAttributedRef(gPre, gSym).asInstanceOf[Tree]
+    val gTpe = tpe.asInstanceOf[global.Type]
+    global.gen.mkAttributedQualifier(gTpe).asInstanceOf[Tree]
   }
 
   def extractSingletonValue(tpe: Type): Tree =
@@ -304,11 +303,13 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils wi
 
       case ConstantType(c: Constant) => Literal(c)
 
-      case SingleType(p, v) => mkAttributedRef(p, v)
+      case t: SingleType => mkAttributedQualifier(t)
 
       case SingletonSymbolType(c) => mkSingletonSymbol(c)
 
       case ThisType(sym) => This(sym)
+
+      case t@TypeRef(_, sym, _) if sym.isModuleClass => mkAttributedQualifier(t)
 
       case _ =>
         c.abort(c.enclosingPosition, s"Type argument $tpe is not a singleton type")

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -562,6 +562,9 @@ class SingletonTypesTests {
     assertTypedEquals[Int](2, n)
   }
 
+  trait B
+  case object A extends B
+
   @Test
   def singletonWiden: Unit = {
     illTyped(" Widen[A.type] ", "could not find implicit value for parameter widen:.*")
@@ -586,13 +589,11 @@ class SingletonTypesTests {
 
   @Test
   def testWitnessTypeRefType: Unit = {
-    trait B
-    case object A extends B
-
     trait B1 {
       type T <: B
       def getT(implicit w: Witness.Aux[T]): T = w.value
     }
+    
     case class A1() extends B1 {
       type T = A.type
     }

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -562,10 +562,6 @@ class SingletonTypesTests {
     assertTypedEquals[Int](2, n)
   }
 
-
-  trait B
-  case object A extends B
-
   @Test
   def singletonWiden: Unit = {
     illTyped(" Widen[A.type] ", "could not find implicit value for parameter widen:.*")
@@ -586,6 +582,22 @@ class SingletonTypesTests {
     val c = new ClassThis
     assertTypedEquals[c.type](c.w1.value, c.w2.value)
     assertTypedEquals[ObjectThis.type](ObjectThis.w1.value, ObjectThis.w2.value)
+  }
+
+  @Test
+  def testWitnessTypeRefType: Unit = {
+    trait B
+    case object A extends B
+
+    trait B1 {
+      type T <: B
+      def getT(implicit w: Witness.Aux[T]): T = w.value
+    }
+    case class A1() extends B1 {
+      type T = A.type
+    }
+
+    assertTypedEquals[A.type](A1().getT, A)
   }
 }
 


### PR DESCRIPTION
Add one more matching case to `SingletonTypeMacros#extractSingletonValue(..)` when a singleton type (namely, type of an object) is a `TypeRef`.
Without this fix the following code doesn't compile
```
trait B
case object A extends B

trait B1 {
  type T <: B
  def getT(implicit w: Witness.Aux[T]): T = w.value
}
case class A1() extends B1 {
  type T = A.type
}

assertTypedEquals[A.type](A1().getT, A)
```

```
Information: shapeless.Witness.apply is not a valid implicit value for shapeless.Witness{type T = A.type} because:
hasMatchingSymbol reported error: Type argument A.type is not a singleton type
    assert(A1().getT == A)

Error: could not find implicit value for parameter w: shapeless.Witness{type T = A.type}
    assert(A1().getT == A)

Error: not enough arguments for method getT: (implicit w: shapeless.Witness{type T = A.type})A.type.
Unspecified value parameter w.
    assert(A1().getT == A)
```

Motivated by the discussion https://stackoverflow.com/questions/54786083/get-instance-of-singleton-type-in-scala

