### PR TITLE
More meaningful error message

### DIFF
--- a/core/src/main/scala/shapeless/refute.scala
+++ b/core/src/main/scala/shapeless/refute.scala
@@ -4,16 +4,21 @@ package shapeless
   *
   *  @author Zainab Ali
   */
+@annotation.implicitNotFound(msg = "Implicit instance for ${T} in scope.")
 trait Refute[T]
 
 object Refute {
 
-  /** This results in  ambigous implicits if there is implicit evidence of `T` */
-  implicit def ambiguousIfPresent[T](implicit ev: T): Refute[T] = new Refute[T] {}
+  trait Aux[A]
+  object Aux {
+    /** This results in  ambigous implicits if there is implicit evidence of `T` */
+    implicit def amb1[T](implicit ev: T): Aux[T] = null
+    implicit def amb2[T]: Aux[T] = null
+  }
 
   /** This always declares an instance of `Refute`
     *
     * This instance will only be found when there is no evidence of `T`
     * */
-  implicit def refute[T](implicit dummy: DummyImplicit): Refute[T] = new Refute[T] {}
+  implicit def refute[T](implicit dummy: Aux[T]): Refute[T] = new Refute[T] {}
 }

--- a/core/src/main/scala/shapeless/refute.scala
+++ b/core/src/main/scala/shapeless/refute.scala
@@ -9,16 +9,16 @@ trait Refute[T]
 
 object Refute {
 
-  trait Aux[A]
-  object Aux {
+  trait Impl[A]
+  object Impl {
     /** This results in  ambigous implicits if there is implicit evidence of `T` */
-    implicit def amb1[T](implicit ev: T): Aux[T] = null
-    implicit def amb2[T]: Aux[T] = null
+    implicit def amb1[T](implicit ev: T): Impl[T] = null
+    implicit def amb2[T]: Impl[T] = null
   }
 
   /** This always declares an instance of `Refute`
     *
     * This instance will only be found when there is no evidence of `T`
     * */
-  implicit def refute[T](implicit dummy: Aux[T]): Refute[T] = new Refute[T] {}
+  implicit def refute[T](implicit dummy: Impl[T]): Refute[T] = new Refute[T] {}
 }

--- a/core/src/test/scala/shapeless/refute.scala
+++ b/core/src/test/scala/shapeless/refute.scala
@@ -38,6 +38,7 @@ class RefuteTests {
     // Increases the code coverage, as the above tests cannot
     Refute.Aux.amb1[PresentEvidence](presentEvidence)
     Refute.Aux.amb2[PresentEvidence]
+    Refute.refute(new Refute.Aux[PresentEvidence]{})
   }
 
 }

--- a/core/src/test/scala/shapeless/refute.scala
+++ b/core/src/test/scala/shapeless/refute.scala
@@ -36,9 +36,9 @@ class RefuteTests {
   @Test
   def increaseCodeCoverage: Unit = {
     // Increases the code coverage, as the above tests cannot
-    Refute.Aux.amb1[PresentEvidence](presentEvidence)
-    Refute.Aux.amb2[PresentEvidence]
-    Refute.refute(new Refute.Aux[PresentEvidence]{})
+    Refute.Impl.amb1[PresentEvidence](presentEvidence)
+    Refute.Impl.amb2[PresentEvidence]
+    Refute.refute(new Refute.Impl[PresentEvidence]{})
   }
 
 }

--- a/core/src/test/scala/shapeless/refute.scala
+++ b/core/src/test/scala/shapeless/refute.scala
@@ -36,8 +36,8 @@ class RefuteTests {
   @Test
   def increaseCodeCoverage: Unit = {
     // Increases the code coverage, as the above tests cannot
-    Refute.ambiguousIfPresent[PresentEvidence](presentEvidence)
-    Refute.refute[PresentEvidence]
+    Refute.Aux.amb1[PresentEvidence](presentEvidence)
+    Refute.Aux.amb2[PresentEvidence]
   }
 
 }


### PR DESCRIPTION
This little trick will provide a more meaningful when no implicit instance of `Refute` can be inferred.