### PR TITLE
Add SelectAny typeclass to shapeless.ops.hlist

### DIFF
--- a/core/src/main/scala/shapeless/syntax/hlists.scala
+++ b/core/src/main/scala/shapeless/syntax/hlists.scala
@@ -138,6 +138,12 @@ final class HListOps[L <: HList](l : L) extends Serializable {
   def selectRange(a : Nat, b : Nat)(implicit sel: SelectRange[L,a.N,b.N]): sel.Out = sel(l)
 
   /**
+   * Returns the first element of `S` in this `HList`.
+   * Available only if there is evidence that this `HList` contains at least one element of `S`.
+   */
+  def selectFirst[S <: HList](implicit sel: SelectFirst[L, S]): sel.Out = sel(l)
+
+  /**
    * Returns all elements of type `U` of this `HList`. An explicit type argument must be provided.
    */
   def filter[U](implicit partition : Partition[L, U]) : partition.Prefix  = partition.filter(l)

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1460,6 +1460,32 @@ class HListTests {
   }
 
   @Test
+  def testSelectFirst: Unit = {
+    val sl = 1 :: true :: "foo" :: 2.0 :: HNil
+
+    val si = sl.selectFirst[Int::HNil]
+    assertTypedEquals[Int](1, si)
+
+    val sb = sl.selectFirst[Boolean::HNil]
+    assertTypedEquals[Boolean](true, sb)
+
+    val ss = sl.selectFirst[String::HNil]
+    assertTypedEquals[String]("foo", ss)
+
+    val sd = sl.selectFirst[Double::HNil]
+    assertEquals(2.0, sd, Double.MinPositiveValue)
+
+    val sib = sl.selectFirst[Int::Boolean::HNil]
+    assertTypedEquals[Int](1, sib)
+
+    val sulb = sl.selectFirst[Unit::Long::Boolean::HNil]
+    assertTypedEquals[Boolean](true, sulb)
+
+    val ssbi = sl.selectFirst[String::Boolean::Int::HNil]
+    assertTypedEquals[String]("foo", ssbi)
+  }
+
+  @Test
   def testFilter: Unit = {
     val l1 = 1 :: 2 :: HNil
     val f1 = l1.filter[Int]


### PR DESCRIPTION
Hi, I added `SelectAny` to `HList`.
I think this is useful for the following case:

```scala
final case object TeamA
final case object TeamB
final case object Admin
final case object Operator

type AllowedRoles = TeamA.type :: Admin.type :: Operator.type :: HNil
def access[A <: HList](roles: A)(implicit any: SelectAny[AllowedRoles, A]) = true

access(HNil)                       // compile fails!
access(TeamA :: HNil)              // true
access(TeamB :: HNil)              // compile fails!
access(Admin :: HNil)              // true
access(Operator :: HNil)           // true
access(TeamA :: Operator :: HNil)  // true
access(TeamB :: Operator :: HNil)  // true
access(TeamB :: Admin :: HNil)     // true
```