### PR TITLE
Ensure default values are only run when Default.apply is called

### DIFF
--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -39,7 +39,11 @@ trait Default[T] extends DepFn0 with Serializable {
 object Default {
   def apply[T](implicit default: Default[T]): Aux[T, default.Out] = default
 
+  // only kept to preserve binary compatibility
   def mkDefault[T, Out0 <: HList](defaults: Out0): Aux[T, Out0] =
+    mkDefaultByName(defaults)
+
+  def mkDefaultByName[T, Out0 <: HList](defaults: => Out0): Aux[T, Out0] =
     new Default[T] {
       type Out = Out0
       def apply() = defaults
@@ -258,7 +262,7 @@ class DefaultMacros(val c: whitebox.Context) extends CaseClassMacros {
       val (types, values) = defaults.unzip
       val outTpe = mkHListTpe(types)
       val outVal = mkHListValue(values)
-      q"_root_.shapeless.Default.mkDefault[$tpe, $outTpe]($outVal)"
+      q"_root_.shapeless.Default.mkDefaultByName[$tpe, $outTpe]($outVal)"
     }
 
     if (isCaseObjectLike(cls)) return mkDefault(Nil)

--- a/core/src/test/scala/shapeless/default.scala
+++ b/core/src/test/scala/shapeless/default.scala
@@ -59,6 +59,9 @@ object DefaultTestDefinitions {
       implicit val default = Default[CObj.type]
     }
   }
+
+  class DefaultRun extends Exception("Default value was run")
+  case class SideEffectingDefault(n: Int = throw new DefaultRun)
 }
 
 class DefaultTests {
@@ -223,5 +226,18 @@ class DefaultTests {
     assertTypedEquals[Some[Int] :: HNil](Some(0) :: HNil, default1())
     assertTypedEquals[None.type :: HNil](None :: HNil, default2())
     assertTypedEquals[HNil](HNil, default3())
+  }
+
+  @Test
+  def testByName: Unit = {
+    val default = Default[SideEffectingDefault]
+    val thrownException = try {
+      default()
+      false
+    } catch {
+      case _: DefaultRun =>
+        true
+    }
+    assert(thrownException, "Expected DefaultRun to be thrown")
   }
 }


### PR DESCRIPTION
Before this PR, getting a `Default` instance, like `Default[CC]`, was calling the default values straightaway. For example, the following would throw:
```scala
case class CC(n: Int = ???)
Default[CC] // throws because of ???, even though we didn't ask for the actual default values yet
```

With the changes here, default values are only called when `Default.apply` is called. Only the following would throw:
```scala
case class CC(n: Int = ???)
val default = Default[CC] // does not throw
default() // trying to get the default values, throws because of ???
```