### PR TITLE
Avoid use of mutable state in macro classloader

### DIFF
--- a/core/src/main/scala/shapeless/MacroState.scala
+++ b/core/src/main/scala/shapeless/MacroState.scala
@@ -1,0 +1,48 @@
+package shapeless
+
+import scala.reflect.{ClassTag, classTag}
+import scala.reflect.macros.Universe
+
+
+private[shapeless] object MacroState {
+  private class MacroStateAttachment(val state: collection.mutable.HashMap[Class[_], Any])
+
+  /**
+   * Associates some state with a global.Run. Preferable to using static state in the macro
+   * classloader (e.g vars in top level objects) so as to avoid race conditions under `-Ycache-macro-classloader`.
+   *
+   * @tparam T the type of the state. The class tag for this type will be used a a map key, so each user of
+   *           this facility should use a dedicated and distinct class to wrap the state.
+   * @param u The reflection universe, typically obtained from `context.universe` in a macro implementation.
+   * @param factory Factory to create the state.
+   */
+  def apply[T: ClassTag](u: Universe, factory: => T): T = {
+    // Cast needed for access to perRunCaches and convenient access to attachments
+    val g = u.asInstanceOf[scala.reflect.internal.SymbolTable]
+
+    // Sneakily use a symbol attachment on a well-known symbol to hold our map of macro states.
+    // Compiler plugins would typically use `val someState = global.perRunCaches.newMap` in a `Component` that
+    // is instantiated once per Global, but macros don't have an analagous place.
+    //
+    // An alternative would be a `Map[Universe, MacroState]`, but this would need to be carefully constructed
+    // with weak references to avoid leaking the `Universe` through the key or values.
+    val holderSymbol = g.definitions.AnyClass
+
+    // The erasure of `T` is the key for our internal map
+    val cls = classTag[T].runtimeClass
+
+    // classOf[MacroStateAttachment] is the key for the attachment lookup.
+    holderSymbol.attachments.get[MacroStateAttachment] match {
+      case Some(existing) =>
+        existing.state.getOrElseUpdate(cls, factory).asInstanceOf[T]
+      case None =>
+        val value = factory
+        // Use perRunCaches.newMap to clear this map before the next Run starts.
+        // The REPL or presentation compiler use a single Global to perform multiple compilation Runs.
+        val macroState = new MacroStateAttachment(g.perRunCaches.newMap())
+        macroState.state.put(cls, value)
+        holderSymbol.updateAttachment(macroState)
+        value
+    }
+  }
+}

--- a/core/src/main/scala/shapeless/MacroState.scala
+++ b/core/src/main/scala/shapeless/MacroState.scala
@@ -11,12 +11,12 @@ private[shapeless] object MacroState {
    * Associates some state with a global.Run. Preferable to using static state in the macro
    * classloader (e.g vars in top level objects) so as to avoid race conditions under `-Ycache-macro-classloader`.
    *
-   * @tparam T the type of the state. The class tag for this type will be used a a map key, so each user of
+   * @tparam T the type of the state. The erased `Class[_]` value for this type will be used a a map key, so each user of
    *           this facility should use a dedicated and distinct class to wrap the state.
    * @param u The reflection universe, typically obtained from `context.universe` in a macro implementation.
    * @param factory Factory to create the state.
    */
-  def apply[T: ClassTag](u: Universe, factory: => T): T = {
+  def getOrElseUpdate[T: ClassTag](u: Universe, factory: => T): T = {
     // Cast needed for access to perRunCaches and convenient access to attachments
     val g = u.asInstanceOf[scala.reflect.internal.SymbolTable]
 

--- a/core/src/main/scala/shapeless/cached.scala
+++ b/core/src/main/scala/shapeless/cached.scala
@@ -69,7 +69,7 @@ class CachedMacrosState {
 @macrocompat.bundle
 class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) with OpenImplicitMacros {
   import c.universe._
-  private val state = MacroState.apply[CachedMacrosState](c.universe, new CachedMacrosState)
+  private val state = MacroState.getOrElseUpdate[CachedMacrosState](c.universe, new CachedMacrosState)
 
   def deepCopyTree(t: Tree): Tree = {
     val treeDuplicator = new Transformer {

--- a/core/src/main/scala/shapeless/cached.scala
+++ b/core/src/main/scala/shapeless/cached.scala
@@ -59,7 +59,9 @@ object Cached {
   def implicitly[T](implicit cached: Cached[T]): T = cached.value
 }
 
-object CachedMacros {
+object CachedMacros
+
+class CachedMacrosState {
   var deriving = false
   var cache = List.empty[(Any, Any)]
 }
@@ -67,6 +69,7 @@ object CachedMacros {
 @macrocompat.bundle
 class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) with OpenImplicitMacros {
   import c.universe._
+  private val state = MacroState.apply[CachedMacrosState](c.universe, new CachedMacrosState)
 
   def deepCopyTree(t: Tree): Tree = {
     val treeDuplicator = new Transformer {
@@ -83,7 +86,7 @@ class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) with 
     // Getting the actual type parameter T, using the same trick as Lazy/Strict
     val tpe = openImplicitTpeParam.getOrElse(weakTypeOf[T])
 
-    val concurrentLazy = !CachedMacros.deriving && LazyMacros.dcRef(this).nonEmpty
+    val concurrentLazy = !state.deriving && LazyMacros.dcRef(this).nonEmpty
 
     // Ensuring we are not caching parts of trees derived during a Lazy/Strict lookup
     // (but caching the full tree of a Lazy/Strict is fine), as these can reference values
@@ -96,17 +99,17 @@ class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) with 
         "is disabled here."
       )
 
-    if (CachedMacros.deriving || concurrentLazy) {
+    if (state.deriving || concurrentLazy) {
       // Caching only the first (root) Cached, not subsequent ones as here
       val tree0 = c.inferImplicitValue(tpe)
       if (tree0 == EmptyTree)
         c.abort(c.enclosingPosition, s"Implicit $tpe not found")
       q"_root_.shapeless.Cached($tree0)"
     } else {
-      CachedMacros.deriving = true
+      state.deriving = true
 
       try {
-        val treeOpt = CachedMacros.cache.asInstanceOf[List[(Type, Tree)]].collectFirst {
+        val treeOpt = state.cache.asInstanceOf[List[(Type, Tree)]].collectFirst {
           case (eTpe, eTree) if eTpe =:= tpe => eTree
         }
 
@@ -120,11 +123,11 @@ class CachedMacros(override val c: whitebox.Context) extends LazyMacros(c) with 
           )
           val tree = c.untypecheck(tree0)
 
-          CachedMacros.cache = (tpe -> tree) :: CachedMacros.cache
+          state.cache = (tpe -> tree) :: state.cache
           tree
         })
       } finally {
-        CachedMacros.deriving = false
+        state.deriving = false
       }
     }
   }


### PR DESCRIPTION
Recent versions of Scala have an experimental option
(`-Ycache-macro-classloader`) to reuse a macro classloader across
multiple (possibly concurrent) compilations. It is motivated by
performance to reduce overhead of classloading and of the macro
implementation running without time to JIT.

However, this requires macro implenentations to avoid races and leaks
with any classloader-global state.

This commit introduces a generic facility for managing macro
state that should have the same lifecycle as a `Global#Run` and
uses it in the `Cached` macro.
