### PR TITLE
Fix #936

### DIFF
--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -549,19 +549,19 @@ package record {
 
     implicit def hconsRemoveAll[L <: HList, H, T <: HList, OutT <: HList, RemovedH, RemainderH <: HList, RemovedT <: HList, RemainderT <: HList]
       (implicit
-        rt: RemoveAll.Aux[L, T, (RemovedT, RemainderT)],
-        rh: Remove.Aux[RemainderT, H, (RemovedH, RemainderH)]
-      ): Aux[L, H :: T, (RemovedH :: RemovedT, RemainderH)] =
+        rh: Remove.Aux[L, H, (RemovedH, RemainderH)],
+        rt: RemoveAll.Aux[RemainderH, T, (RemovedT, RemainderT)]
+      ): Aux[L, H :: T, (RemovedH :: RemovedT, RemainderT)] =
         new RemoveAll[L, H :: T] {
-          type Out = (RemovedH :: RemovedT, RemainderH)
+          type Out = (RemovedH :: RemovedT, RemainderT)
 
           def apply(l: L): Out = {
-            val (removedT, remainderT) = rt(l)
-            val (removedH, remainderH) = rh(remainderT)
-            (removedH :: removedT, remainderH)
+            val (removedH, remainderH) = rh(l)
+            val (removedT, remainderT) = rt(remainderH)
+            (removedH :: removedT, remainderT)
           }
 
-          def reinsert(out: Out): L = rt.reinsert((out._1.tail, rh.reinsert((out._1.head, out._2))))
+          def reinsert(out: Out): L = rh.reinsert((out._1.head, rt.reinsert((out._1.tail, out._2))))
         }
   }
 

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -610,20 +610,29 @@ class RecordTests {
 
     type R = Record.`'i -> Int, 's -> String, 'c -> Char, 'j -> Int`.T
     type L = Record.`'c -> Char, 'j -> Int`.T
+    type L2 = Record.`'s -> String, 'c -> Char`.T
 
     type A1 = Record.`'i -> Int, 's -> String`.T
     type A2 = Int :: String :: HNil
+    type A3 = Record.`'i -> Int, 'j -> Int`.T
+    type A4 = Int :: Int :: HNil
 
     val r = Symbol("i") ->> 10 :: Symbol("s") ->> "foo" :: Symbol("c") ->> 'x' :: Symbol("j") ->> 42 :: HNil
 
     val removeAll1 = RemoveAll[R, A1]
     val removeAll2 = RemoveAll[R, A2]
+    val removeAll3 = RemoveAll[R, A3]
+    val removeAll4 = RemoveAll[R, A4]
 
     val (removed1, remaining1) = removeAll1(r)
     val (removed2, remaining2) = removeAll2(r)
+    val (removed3, remaining3) = removeAll3(r)
+    val (removed4, remaining4) = removeAll4(r)
 
     val r1 = removeAll1.reinsert((removed1, remaining1))
     val r2 = removeAll2.reinsert((removed2, remaining2))
+    val r3 = removeAll3.reinsert((removed3, remaining3))
+    val r4 = removeAll4.reinsert((removed4, remaining4))
 
     typed[A1](removed1)
     assertEquals(Symbol("i") ->> 10 :: Symbol("s") ->> "foo" :: HNil, removed1)
@@ -631,17 +640,35 @@ class RecordTests {
     typed[A2](removed2)
     assertEquals(10 :: "foo" :: HNil, removed2)
 
+    typed[A3](removed3)
+    assertEquals(Symbol("i") ->> 10 :: Symbol("j") ->> 42 :: HNil, removed3)
+
+    typed[A4](removed4)
+    assertEquals(10 :: 42 :: HNil, removed4)
+
     typed[L](remaining1)
     assertEquals(Symbol("c") ->> 'x' :: Symbol("j") ->> 42 :: HNil, remaining1)
 
     typed[L](remaining2)
     assertEquals(Symbol("c") ->> 'x' :: Symbol("j") ->> 42 :: HNil, remaining2)
 
+    typed[L2](remaining3)
+    assertEquals(Symbol("s") ->> "foo" :: Symbol("c") ->> 'x' :: HNil, remaining3)
+
+    typed[L2](remaining4)
+    assertEquals(Symbol("s") ->> "foo" :: Symbol("c") ->> 'x' :: HNil, remaining4)
+
     typed[R](r1)
     assertEquals(r, r1)
 
     typed[R](r2)
     assertEquals(r, r2)
+
+    typed[R](r3)
+    assertEquals(r, r3)
+
+    typed[R](r4)
+    assertEquals(r, r4)
   }
 
   @Test


### PR DESCRIPTION
Fixes #936. I've also added some new tests, a couple of which fail without the change.

The fix breaks binary compatibility. It would be possible to fix the issue in a way that doesn't, but I noticed that master already contains a number of changes that aren't compatible with 2.3.3.