### PR TITLE
Update sbt to 1.3.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.3.6


### PR DESCRIPTION
Normally @scala-steward would have sent a PR for this update but sbt 1.3.5 breaks the `+` command in this repo which prevents @scala-steward from working on shapeless.

Here is what happens to me when trying `+`:
```
sbt:root> + libraryDependencies
[info] Forcing Scala version to 2.10.7 on all projects.
[info] Reapplying settings...
[info] Set current project to root (in build file:/home/frank/data/code/shapeless/)
[error] Expected ';'
[error] project root / libraryDependencies
[error]                                   ^
```
The same command succeeds with 1.3.6.