### PR TITLE
Fix Typeable.isValClass for non-AnyVal `j.l.Number`s.

### DIFF
--- a/core/src/main/scala/shapeless/typeable.scala
+++ b/core/src/main/scala/shapeless/typeable.scala
@@ -119,7 +119,7 @@ object Typeable extends TupleTypeableInstances with LowPriorityTypeable {
   def namedSimpleTypeable[T](erased: Class[T], name: => String): Typeable[T] =
     new Typeable[T] {
       def cast(t: Any): Option[T] = {
-        if(t != null && erased.isAssignableFrom(t.getClass)) Some(t.asInstanceOf[T]) else None
+        if(t != null && erased.isInstance(t)) Some(t.asInstanceOf[T]) else None
       }
       def describe = name
     }
@@ -241,7 +241,7 @@ object Typeable extends TupleTypeableInstances with LowPriorityTypeable {
     new Typeable[CC[T]] {
       def cast(t: Any): Option[CC[T]] =
         if(t == null) None
-        else if(mCC.runtimeClass isAssignableFrom t.getClass) {
+        else if(mCC.runtimeClass isInstance t) {
           val cc = t.asInstanceOf[CC[Any]]
           if(cc.forall(_.cast[T].isDefined)) Some(t.asInstanceOf[CC[T]])
           else None
@@ -255,7 +255,7 @@ object Typeable extends TupleTypeableInstances with LowPriorityTypeable {
     new Typeable[M[K, V]] {
       def cast(t: Any): Option[M[K, V]] =
         if(t == null) None
-        else if(mM.runtimeClass isAssignableFrom t.getClass) {
+        else if(mM.runtimeClass isInstance t) {
           val m = t.asInstanceOf[Map[Any, Any]]
           if(m.forall(_.cast[(K, V)].isDefined)) Some(t.asInstanceOf[M[K, V]])
           else None
@@ -271,7 +271,7 @@ object Typeable extends TupleTypeableInstances with LowPriorityTypeable {
   def namedCaseClassTypeable[T](erased: Class[T], fields: Array[Typeable[_]], name: => String): Typeable[T] =
     new Typeable[T] {
       def cast(t: Any): Option[T] =
-        if(classOf[Product].isAssignableFrom(erased) && erased.isAssignableFrom(t.getClass)) {
+        if(classOf[Product].isAssignableFrom(erased) && erased.isInstance(t)) {
           val c = t.asInstanceOf[Product with T]
           val f = c.productIterator.toList
           if((f zip fields).forall { case (f, castF) => castF.cast(f).isDefined }) Some(c)

--- a/core/src/main/scala/shapeless/typeable.scala
+++ b/core/src/main/scala/shapeless/typeable.scala
@@ -75,7 +75,12 @@ object Typeable extends TupleTypeableInstances with LowPriorityTypeable {
   implicit val unitTypeable: Typeable[Unit] = ValueTypeable[Unit, runtime.BoxedUnit](classOf[runtime.BoxedUnit], "Unit")
 
   def isValClass[T](clazz: Class[T]) =
-    (classOf[jl.Number] isAssignableFrom clazz) ||
+    clazz == classOf[jl.Byte] ||
+    clazz == classOf[jl.Short] ||
+    clazz == classOf[jl.Integer] ||
+    clazz == classOf[jl.Long] ||
+    clazz == classOf[jl.Float] ||
+    clazz == classOf[jl.Double] ||
     clazz == classOf[jl.Boolean] ||
     clazz == classOf[jl.Character] ||
     clazz == classOf[runtime.BoxedUnit]

--- a/core/src/test/scala/shapeless/typeable.scala
+++ b/core/src/test/scala/shapeless/typeable.scala
@@ -217,6 +217,13 @@ class TypeableTests {
 
     val cr2 = r.cast[AnyVal]
     assertTrue(cr2.isEmpty)
+
+    val n: Any = BigInt(23)
+    val cn = n.cast[AnyRef]
+    assertTrue(cn.isDefined)
+
+    val cn2 = n.cast[AnyVal]
+    assertTrue(cn2.isEmpty)
   }
 
   @Test


### PR DESCRIPTION
Fixes #956

Also replace `clazz.isAssignableFrom(t.getClass)` by `clazz.isInstance(t)`.