### PR TITLE
Support building with scala.js 1.0.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,8 @@ addSbtPlugin("org.scoverage"                     % "sbt-scoverage"         % "1.
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"      % "0.4.0-M2")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossproject" % "1.0.0")
+
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -13,18 +13,20 @@ if [[ "${TRAVIS_PULL_REQUEST}" == "false" &&
 ]]; then
 PUBLISH=coreJVM/publish
 PUBLISHJS=coreJS/publish
+PUBLISHNAT=publish
 else
 PUBLISH=coreJVM/publishLocal
 PUBLISHJS=coreJS/publishLocal
+PUBLISHNAT=publishLocal
 fi
 
 if [[ "$NATIVE" == "true" ]]; then
-    ${SBT} clean validateNative coreNative/${PUBLISH}
+    ${SBT} clean validateNative coreNative/${PUBLISHNAT}
 #elif [[ "$TRAVIS_SCALA_VERSION" == 2.13.* ]]; then
 #    eval $COVERAGE && ${SBT} validate ${PUBLISH} && codecov
 else
   ${SBT} clean validateJVM ${PUBLISH}
-  for sjs in '1.0.0-RC2' '0.6.32'; do
+  for sjs in '1.0.0' '0.6.32'; do
     SCALAJS_VERSION=$sjs ${SBT} clean validateJS ${PUBLISHJS}
   done
 fi

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -11,9 +11,11 @@ if [[ "${TRAVIS_PULL_REQUEST}" == "false" &&
       "${TRAVIS_REPO_SLUG}" == "milessabin/shapeless" &&
       $(cat version.sbt) =~ "-SNAPSHOT"
 ]]; then
-PUBLISH=publish
+PUBLISH=coreJVM/publish
+PUBLISHJS=coreJS/publish
 else
-PUBLISH=publishLocal
+PUBLISH=coreJVM/publishLocal
+PUBLISHJS=coreJS/publishLocal
 fi
 
 if [[ "$NATIVE" == "true" ]]; then
@@ -21,5 +23,8 @@ if [[ "$NATIVE" == "true" ]]; then
 #elif [[ "$TRAVIS_SCALA_VERSION" == 2.13.* ]]; then
 #    eval $COVERAGE && ${SBT} validate ${PUBLISH} && codecov
 else
-    ${SBT} clean validate ${PUBLISH}
+  ${SBT} clean validateJVM ${PUBLISH}
+  for sjs in '1.0.0-RC2' '0.6.32'; do
+    SCALAJS_VERSION=$sjs ${SBT} clean validateJS ${PUBLISHJS}
+  done
 fi


### PR DESCRIPTION
This PR supports building shapeless on both Scala.js branches, 0.6.x and 1.0.x. I tried local publication and it seems to work fine but it should be checked when doing a real release

There maybe a better way to organize how the CI build goes but I'm not that familiar with travis