### PR TITLE
Replace anonymous classes created by macros with instance helpers

### DIFF
--- a/core/jvm/src/test/scala/shapeless/serialization.scala
+++ b/core/jvm/src/test/scala/shapeless/serialization.scala
@@ -153,7 +153,7 @@ object SerializationTestDefns {
   class Bar extends Quux
   class Baz extends Quux
 
-  trait TC1[F[_]]
+  trait TC1[F[_]] extends Serializable
   object TC1 extends TC10 {
     implicit def tc1Id: TC1[Id] = new TC1[Id] {}
   }

--- a/core/src/main/scala/shapeless/generic1.scala
+++ b/core/src/main/scala/shapeless/generic1.scala
@@ -39,6 +39,15 @@ object Generic1 extends Generic10 {
 
   implicit def mkGeneric11[T[_], U[_], FR[_[_], _[_]]]: Generic1[T, ({ type λ[t[_]] = FR[U, t] })#λ] =
     macro Generic1Macros.mkGeneric1Impl[T, ({ type λ[t[_]] = FR[U, t] })#λ]
+
+  def unsafeInstance[F[_], FR[_[_]], R0[_]](f: F[Any] => R0[Any], g: R0[Any] => F[Any])(implicit lazyFr: Lazy[FR[R0]]): Aux[F, FR, R0] = {
+    new Generic1[F, FR] {
+      type R[t] = R0[t]
+      def mkFrr: FR[R] = lazyFr.value
+      def to[T](ft: F[T]): R[T] = f(ft.asInstanceOf[F[Any]]).asInstanceOf[R[T]]
+      def from[T](rt: R[T]): F[T] = g(rt.asInstanceOf[R[Any]]).asInstanceOf[F[T]]
+    }
+  }
 }
 
 trait Generic10 {
@@ -73,6 +82,21 @@ object IsHCons1 extends IsHCons10 {
 
   implicit def mkIsHCons13[L[_], FH[_[_]], FT[_[_], _[_]], U[_]]: IsHCons1[L, FH, ({ type λ[t[_]] = FT[U, t] })#λ] =
     macro IsHCons1Macros.mkIsHCons1Impl[L, FH, ({ type λ[t[_]] = FT[U, t] })#λ]
+
+  def unsafeInstance[L[_] <: HList, FH[_[_]], FT[_[_]], H0[_], T0[_] <: HList](
+    f: (H0[Any], T0[Any]) => L[Any],
+    g: L[Any] => (H0[Any], T0[Any])
+  )(implicit lazyFhh: Lazy[FH[H0]], lazyFtt: Lazy[FT[T0]]): Aux[L, FH, FT, H0, T0] =
+    new IsHCons1[L, FH, FT] {
+      type H[x] = H0[x]
+      type T[x] = T0[x]
+      def mkFhh: FH[H] = lazyFhh.value
+      def mkFtt: FT[T] = lazyFtt.value
+      def pack[A](u: (H[A], T[A])): L[A] =
+        f(u._1.asInstanceOf[H[Any]], u._2.asInstanceOf[T[Any]]).asInstanceOf[L[A]]
+      def unpack[A](p: L[A]): (H[A], T[A]) =
+        g(p.asInstanceOf[L[Any]]).asInstanceOf[(H[A], T[A])]
+    }
 }
 
 trait IsHCons10 {
@@ -107,6 +131,21 @@ object IsCCons1 extends IsCCons10 {
 
   implicit def mkIsCCons13[L[_], FH[_[_]], FT[_[_], _[_]], U[_]]: IsCCons1[L, FH, ({ type λ[t[_]] = FT[U, t] })#λ] =
     macro IsCCons1Macros.mkIsCCons1Impl[L, FH, ({ type λ[t[_]] = FT[U, t] })#λ]
+
+  def unsafeInstance[L[_] <: Coproduct, FH[_[_]], FT[_[_]], H0[_], T0[_] <: Coproduct](
+    f: Either[H0[Any], T0[Any]] => L[Any],
+    g: L[Any] => Either[H0[Any], T0[Any]]
+  )(implicit lazyFhh: Lazy[FH[H0]], lazyFtt: Lazy[FT[T0]]): Aux[L, FH, FT, H0, T0] =
+    new IsCCons1[L, FH, FT] {
+      type H[x] = H0[x]
+      type T[x] = T0[x]
+      def mkFhh: FH[H] = lazyFhh.value
+      def mkFtt: FT[T] = lazyFtt.value
+      def pack[A](u: Either[H[A], T[A]]): L[A] =
+        f(u.asInstanceOf[Either[H[Any], T[Any]]]).asInstanceOf[L[A]]
+      def unpack[A](p: L[A]): Either[H[A], T[A]] =
+        g(p.asInstanceOf[L[Any]]).asInstanceOf[Either[H[A], T[A]]]
+    }
 }
 
 trait IsCCons10 {
@@ -141,6 +180,16 @@ object Split1 extends Split10 {
 
   implicit def mkSplit13[L[_], FO[_[_]], FI[_[_], _[_]], U[_]]: Split1[L, FO, ({ type λ[t[_]] = FI[U, t] })#λ] =
     macro Split1Macros.mkSplit1Impl[L, FO, ({ type λ[t[_]] = FI[U, t] })#λ]
+
+  def instance[FO[_[_]], FI[_[_]], O0[_], I0[_]](implicit lazyFoo: Lazy[FO[O0]], lazyFii: Lazy[FI[I0]]): Aux[({ type λ[x] = O0[I0[x]] })#λ, FO, FI, O0, I0] =
+    new Split1[({ type λ[x] = O0[I0[x]] })#λ, FO, FI] {
+      type O[x] = O0[x]
+      type I[x] = I0[x]
+      def mkFoo: FO[O] = lazyFoo.value
+      def mkFii: FI[I] = lazyFii.value
+      def pack[T](u: O[I[T]]): O[I[T]] = u
+      def unpack[T](p: O[I[T]]): O[I[T]] = p
+    }
 }
 
 trait Split10 {
@@ -151,89 +200,60 @@ trait Split10 {
 class Generic1Macros(val c: whitebox.Context) extends CaseClassMacros {
   import c.ImplicitCandidate
   import c.universe._
+  import definitions._
+
+  private val generic1 = objectRef[Generic1.type]
 
   def mkGeneric1Impl[T[_], FR[_[_]]](implicit tTag: WeakTypeTag[T[_]], frTag: WeakTypeTag[FR[Any]]): Tree = {
     val tpe = tTag.tpe.etaExpand
+    val frTpe = c.openImplicits.headOption match {
+      case Some(ImplicitCandidate(_, _, TypeRef(_, _, List(_, tpe)), _)) => tpe
+      case _ => frTag.tpe.typeConstructor
+    }
 
-    val frTpe =
-      c.openImplicits.headOption match {
-        case Some(ImplicitCandidate(_, _, TypeRef(_, _, List(_, tpe)), _)) => tpe
-        case other => frTag.tpe.typeConstructor
-      }
-
-    if(isReprType1(tpe))
+    if (isReprType1(tpe))
       abort("No Generic1 instance available for HList or Coproduct")
 
-    if(isProduct1(tpe))
-      mkProductGeneric1(tpe, frTpe)
-    else
-      mkCoproductGeneric1(tpe, frTpe)
+    if (isProduct1(tpe)) mkProductGeneric1(tpe, frTpe)
+    else mkCoproductGeneric1(tpe, frTpe)
   }
 
   def mkProductGeneric1(tpe: Type, frTpe: Type): Tree = {
     val ctorDtor = CtorDtor(tpe)
     val (p, ts) = ctorDtor.binding
-    val to = cq""" $p => ${mkHListValue(ts)} """
+    val to = cq"$p => ${mkHListValue(ts)}"
     val (rp, rts) = ctorDtor.reprBinding
-    val from = cq""" $rp => ${ctorDtor.construct(rts)} """
+    val from = cq"$rp => ${ctorDtor.construct(rts)}"
+    val name = TypeName(c.freshName)
+    val reprTpt = reprTypTree1(tpe, name)
+    val reprName = TypeName(c.freshName("R"))
 
-    val nme = TypeName(c.freshName)
-    val reprTpt = reprTypTree1(tpe, nme)
-    val rnme = TypeName(c.freshName)
-
-    val clsName = TypeName(c.freshName("anon$"))
     q"""
-      type Apply0[F[_], T] = F[T]
-      type Apply1[F[_[_]], T[_]] = F[T]
-
-      final class $clsName extends _root_.shapeless.Generic1[$tpe, $frTpe] {
-        type R[$nme] = $reprTpt
-
-        def mkFrr: Apply1[$frTpe, R] = _root_.shapeless.lazily[Apply1[$frTpe, R]]
-
-        def to[$nme](ft: Apply0[$tpe, $nme]): R[$nme] = (ft match { case $to }).asInstanceOf[R[$nme]]
-        def from[$nme](rt: R[$nme]): Apply0[$tpe, $nme] = rt match { case $from }
-      }
-      type $rnme[$nme] = $reprTpt
-      new $clsName(): _root_.shapeless.Generic1.Aux[$tpe, $frTpe, $rnme]
+      type $reprName[$name] = $reprTpt
+      $generic1.unsafeInstance[$tpe, $frTpe, $reprName]({ case $to }, { case $from })
     """
   }
 
   def mkCoproductGeneric1(tpe: Type, frTpe: Type): Tree = {
-    def mkCoproductCases(tpe: Type, index: Int): CaseDef = {
-      val name = TermName(c.freshName("pat"))
-
+    def mkCoproductCases(tpe: Type, index: Int) = {
+      val pat = TermName(c.freshName("pat"))
       val tc = tpe.typeConstructor
-      val params = tc.typeParams.map { _ => Bind(typeNames.WILDCARD, EmptyTree) }
-      val tpeTpt = AppliedTypeTree(mkAttributedRef(tc), params)
-
-      cq"$name: $tpeTpt => $index"
+      val params = tc.typeParams.map(_ => Bind(typeNames.WILDCARD, EmptyTree))
+      val tpt = AppliedTypeTree(mkAttributedRef(tc), params)
+      cq"$pat: $tpt => $index"
     }
 
-    val nme = TypeName(c.freshName)
-    val reprTpt = reprTypTree1(tpe, nme)
-    val rnme = TypeName(c.freshName)
+    val name = TypeName(c.freshName)
+    val reprTpt = reprTypTree1(tpe, name)
+    val reprName = TypeName(c.freshName("R"))
+    val coproduct = objectRef[Coproduct.type]
+    val toCases = ctorsOf1(tpe).zipWithIndex.map((mkCoproductCases _).tupled)
+    val to = q"$coproduct.unsafeMkCoproduct((ft: $AnyTpe) match { case ..$toCases }, ft).asInstanceOf[$reprName[$AnyTpe]]"
+    val from = q"$coproduct.unsafeGet(rt).asInstanceOf[${appliedType(tpe, AnyTpe)}]"
 
-    val to = {
-      val toCases = ctorsOf1(tpe).zipWithIndex map (mkCoproductCases _).tupled
-      q"""_root_.shapeless.Coproduct.unsafeMkCoproduct((ft: Any) match { case ..$toCases }, ft).asInstanceOf[R[$nme]]"""
-    }
-
-    val clsName = TypeName(c.freshName("anon$"))
     q"""
-      type Apply0[F[_], T] = F[T]
-      type Apply1[F[_[_]], T[_]] = F[T]
-
-      final class $clsName extends _root_.shapeless.Generic1[$tpe, $frTpe] {
-        type R[$nme] = $reprTpt
-
-        def mkFrr: Apply1[$frTpe, R] = _root_.shapeless.lazily[Apply1[$frTpe, R]]
-
-        def to[$nme](ft: Apply0[$tpe, $nme]): R[$nme] = $to
-        def from[$nme](rt: R[$nme]): Apply0[$tpe, $nme] = _root_.shapeless.Coproduct.unsafeGet(rt).asInstanceOf[Apply0[$tpe, $nme]]
-      }
-      type $rnme[$nme] = $reprTpt
-      new $clsName(): _root_.shapeless.Generic1.Aux[$tpe, $frTpe, $rnme]
+      type $reprName[$name] = $reprTpt
+      $generic1.unsafeInstance[$tpe, $frTpe, $reprName](ft => $to, rt => $from)
     """
   }
 }
@@ -246,18 +266,13 @@ class IsHCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
     (implicit lTag: WeakTypeTag[L[_]], fhTag: WeakTypeTag[FH[Any]], ftTag: WeakTypeTag[FT[Any]]): Tree =
       mkIsCons1(lTag.tpe, fhTag.tpe.typeConstructor, ftTag.tpe.typeConstructor)
 
-  val isCons1TC: Tree = tq"_root_.shapeless.IsHCons1"
+  val isCons1TC: Tree = objectRef[IsHCons1.type]
   val consTpe: Type = hconsTpe
 
-  def mkPackUnpack(nme: TypeName, lTpt: Tree, hdTpt: Tree, tlTpt: Tree): (Tree, Tree) =
-    (
-      q"""
-        def pack[$nme](u: ($hdTpt, $tlTpt)): $lTpt = _root_.shapeless.::(u._1, u._2)
-      """,
-      q"""
-        def unpack[$nme](p: $lTpt): ($hdTpt, $tlTpt) = (p.head, p.tail)
-      """
-    )
+  val mkPackUnpack: (Tree, Tree) = {
+    val cons = objectRef[::.type]
+    (q"$cons(_, _)", q"{ case $cons(hd, tl) => (hd, tl) }")
+  }
 }
 
 @macrocompat.bundle
@@ -268,77 +283,65 @@ class IsCCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
     (implicit lTag: WeakTypeTag[L[_]], fhTag: WeakTypeTag[FH[Any]], ftTag: WeakTypeTag[FT[Any]]): Tree =
       mkIsCons1(lTag.tpe, fhTag.tpe.typeConstructor, ftTag.tpe.typeConstructor)
 
-  val isCons1TC: Tree = tq"_root_.shapeless.IsCCons1"
+  val isCons1TC: Tree = objectRef[IsCCons1.type]
   val consTpe: Type = cconsTpe
 
-  def mkPackUnpack(nme: TypeName, lTpt: Tree, hdTpt: Tree, tlTpt: Tree): (Tree, Tree) =
+  val mkPackUnpack: (Tree, Tree) = {
+    val left = objectRef[Left.type]
+    val right = objectRef[Right.type]
+    val inl = objectRef[Inl.type]
+    val inr = objectRef[Inr.type]
+
     (
-      q"""
-        def pack[$nme](u: _root_.scala.Either[$hdTpt, $tlTpt]): $lTpt = u match {
-          case _root_.scala.Left(hd) => _root_.shapeless.Inl[$hdTpt, $tlTpt](hd)
-          case _root_.scala.Right(tl) => _root_.shapeless.Inr[$hdTpt, $tlTpt](tl)
-        }
-      """,
-      q"""
-        def unpack[$nme](p: $lTpt): _root_.scala.Either[$hdTpt, $tlTpt] = p match {
-          case _root_.shapeless.Inl(hd) => _root_.scala.Left[$hdTpt, $tlTpt](hd)
-          case _root_.shapeless.Inr(tl) => _root_.scala.Right[$hdTpt, $tlTpt](tl)
-        }
-      """
+      q"""{
+        case $left(hd) => $inl(hd)
+        case $right(tl) => $inr(tl)
+      }""",
+      q"""{
+        case $inl(hd) => $left(hd)
+        case $inr(tl) => $right(tl)
+      }"""
     )
+  }
 }
 
 @macrocompat.bundle
 trait IsCons1Macros extends CaseClassMacros {
   import c.ImplicitCandidate
+  import c.internal._
   import c.universe._
 
-  val isCons1TC: Tree
-  val consTpe: Type
-
-  def mkPackUnpack(nme: TypeName, lTpt: Tree, hdTpt: Tree, tlTpt: Tree): (Tree, Tree)
+  def isCons1TC: Tree
+  def consTpe: Type
+  def mkPackUnpack: (Tree, Tree)
 
   def mkIsCons1(lTpe: Type, fhTpe0: Type, ftTpe0: Type): Tree = {
     val lParam = lTpe.typeParams.head
     val lParamTpe = lParam.asType.toType
     val lDealiasedTpe = appliedType(lTpe, lParamTpe).dealias
 
-    val (fhTpe, ftTpe) =
-      c.openImplicits.headOption match {
-        case Some(ImplicitCandidate(_, _, TypeRef(_, _, List(_, fh, ft)), _)) => (fh, ft)
-        case other => (fhTpe0, ftTpe0)
-      }
+    val (fhTpe, ftTpe) = c.openImplicits.headOption match {
+      case Some(ImplicitCandidate(_, _, TypeRef(_, _, List(_, fh, ft)), _)) => (fh, ft)
+      case _ => (fhTpe0, ftTpe0)
+    }
 
-    if(!(lDealiasedTpe.typeConstructor =:= consTpe))
+    if (!(lDealiasedTpe.typeConstructor =:= consTpe))
       abort("Not H/CCons")
 
     val TypeRef(_, _, List(hd, tl)) = lDealiasedTpe
-
-    val lPoly = c.internal.polyType(List(lParam), lDealiasedTpe)
-    val hdPoly = c.internal.polyType(List(lParam), hd)
-    val tlPoly = c.internal.polyType(List(lParam), tl)
-
-    val nme = TypeName(c.freshName)
-    val lTpt = appliedTypTree1(lPoly, lParamTpe, nme)
-    val hdTpt = appliedTypTree1(hdPoly, lParamTpe, nme)
-    val tlTpt = appliedTypTree1(tlPoly, lParamTpe, nme)
-
-    val (pack, unpack) = mkPackUnpack(nme, lTpt, hdTpt, tlTpt)
+    val hdPoly = polyType(List(lParam), hd)
+    val tlPoly = polyType(List(lParam), tl)
+    val name = TypeName(c.freshName)
+    val hdTpt = appliedTypTree1(hdPoly, lParamTpe, name)
+    val tlTpt = appliedTypTree1(tlPoly, lParamTpe, name)
+    val hdName = TypeName(c.freshName("H"))
+    val tlName = TypeName(c.freshName("T"))
+    val (pack, unpack) = mkPackUnpack
 
     q"""
-      type Apply0[F[_], T] = F[T]
-      type Apply1[F[_[_]], T[_]] = F[T]
-
-      new $isCons1TC[$lTpe, $fhTpe, $ftTpe] {
-        type H[$nme] = $hdTpt
-        type T[$nme] = $tlTpt
-
-        def mkFhh: Apply1[$fhTpe, H] = _root_.shapeless.lazily[Apply1[$fhTpe, H]]
-        def mkFtt: Apply1[$ftTpe, T] = _root_.shapeless.lazily[Apply1[$ftTpe, T]]
-
-        $pack
-        $unpack
-      }
+      type $hdName[$name] = $hdTpt
+      type $tlName[$name] = $tlTpt
+      $isCons1TC.unsafeInstance[$lTpe, $fhTpe, $ftTpe, $hdName, $tlName]($pack, $unpack)
     """
   }
 }
@@ -346,67 +349,53 @@ trait IsCons1Macros extends CaseClassMacros {
 @macrocompat.bundle
 class Split1Macros(val c: whitebox.Context) extends CaseClassMacros {
   import c.ImplicitCandidate
+  import c.internal._
   import c.universe._
 
   def mkSplit1Impl[L[_], FO[_[_]], FI[_[_]]]
     (implicit lTag: WeakTypeTag[L[_]], foTag: WeakTypeTag[FO[Any]], fiTag: WeakTypeTag[FI[Any]]): Tree = {
     val lTpe = lTag.tpe
 
-    val (foTpe, fiTpe) =
-      c.openImplicits.headOption match {
-        case Some(ImplicitCandidate(_, _, TypeRef(_, _, List(_, fo, fi)), _)) => (fo, fi)
-        case other => (foTag.tpe.typeConstructor, fiTag.tpe.typeConstructor)
-      }
+    val (foTpe, fiTpe) = c.openImplicits.headOption match {
+      case Some(ImplicitCandidate(_, _, TypeRef(_, _, List(_, fo, fi)), _)) => (fo, fi)
+      case _ => (foTag.tpe.typeConstructor, fiTag.tpe.typeConstructor)
+    }
 
-    if(isReprType1(lTpe))
+    if (isReprType1(lTpe))
       abort("No Split1 instance available for HList or Coproduct")
 
     val lParam = lTpe.typeParams.head
     val lParamTpe = lParam.asType.toType
     val lDealiasedTpe = appliedType(lTpe, lParamTpe).dealias
 
-    val nme = TypeName(c.freshName)
-
     def balanced(args: List[Type]): Boolean =
-      args.find(_.contains(lParam)).map { pivot =>
-        !(pivot =:= lParamTpe) &&
-        args.forall { arg =>
+      args.find(_.contains(lParam)).exists { pivot =>
+        !(pivot =:= lParamTpe) && args.forall { arg =>
           arg =:= pivot || !arg.contains(lParam)
         }
-      }.getOrElse(false)
-
-    val (oTpt, iTpt) =
-      lDealiasedTpe match {
-        case tpe @ TypeRef(pre, sym, args) if balanced(args) =>
-          val pivot = (args.find(_.contains(lParam)): @unchecked) match {
-            case Some(p) => p
-          }
-          val oPoly = c.internal.polyType(List(lParam), appliedType(tpe.typeConstructor, args.map { arg => if(arg =:= pivot) lParamTpe else arg }))
-          val oTpt = appliedTypTree1(oPoly, lParamTpe, nme)
-          val iPoly = c.internal.polyType(List(lParam), pivot)
-          val iTpt = appliedTypTree1(iPoly, lParamTpe, nme)
-          (oTpt, iTpt)
-        case other =>
-          c.abort(c.enclosingPosition, s"Can't split $other into a non-trivial outer and inner type constructor")
       }
 
-    val lPoly = c.internal.polyType(List(lParam), lDealiasedTpe)
-    val lTpt = appliedTypTree1(lPoly, lParamTpe, nme)
+    val name = TypeName(c.freshName)
+    val (oTpt, iTpt) = lDealiasedTpe match {
+      case tpe @ TypeRef(_, _, args) if balanced(args) =>
+        val pivot = args.find(_.contains(lParam)).get
+        val oPoly = polyType(List(lParam), appliedType(tpe.typeConstructor, args.map(arg => if (arg =:= pivot) lParamTpe else arg)))
+        val oTpt = appliedTypTree1(oPoly, lParamTpe, name)
+        val iPoly = polyType(List(lParam), pivot)
+        val iTpt = appliedTypTree1(iPoly, lParamTpe, name)
+        (oTpt, iTpt)
+      case other =>
+        c.abort(c.enclosingPosition, s"Can't split $other into a non-trivial outer and inner type constructor")
+    }
+
+    val oName = TypeName(c.freshName("O"))
+    val iName = TypeName(c.freshName("I"))
+    val split1 = objectRef[Split1.type]
 
     q"""
-      type Apply0[F[_], T] = F[T]
-      type Apply1[F[_[_]], T[_]] = F[T]
-
-      new _root_.shapeless.Split1[$lTpe, $foTpe, $fiTpe] {
-        type O[$nme] = $oTpt
-        type I[$nme] = $iTpt
-
-        def mkFoo: Apply1[$foTpe, O] = _root_.shapeless.lazily[Apply1[$foTpe, O]]
-        def mkFii: Apply1[$fiTpe, I] = _root_.shapeless.lazily[Apply1[$fiTpe, I]]
-
-        def pack[$nme](u: O[I[$nme]]): $lTpt = u
-        def unpack[$nme](p: $lTpt): O[I[$nme]] = p
-      }
+      type $oName[$name] = $oTpt
+      type $iName[$name] = $iTpt
+      $split1.instance[$foTpe, $fiTpe, $oName, $iName]
     """
   }
 }

--- a/core/src/main/scala/shapeless/singletons.scala
+++ b/core/src/main/scala/shapeless/singletons.scala
@@ -16,12 +16,13 @@
 
 package shapeless
 
+import shapeless.syntax.SingletonOps
+
 import scala.language.dynamics
 import scala.language.experimental.macros
-
 import scala.reflect.macros.whitebox
-
 import tag.@@
+
 import scala.util.Try
 
 /** Provides the value corresponding to a singleton type.
@@ -75,7 +76,22 @@ object WitnessWith extends LowPriorityWitnessWith {
   type Aux[TC[_], T0] = WitnessWith[TC] { type T = T0 }
   type Lt[TC[_], Lub] = WitnessWith[TC] { type T <: Lub }
 
-  implicit def apply1[TC[_], T](t: T): WitnessWith.Lt[TC, T] = macro SingletonTypeMacros.convertInstanceImpl1[TC]
+  implicit def apply1[TC[_], T](t: T): WitnessWith.Lt[TC, T] =
+    macro SingletonTypeMacros.convertInstanceImpl1[TC]
+
+  def depInstance[TC[_] <: AnyRef, T0](v: T0, tc: TC[T0]): Aux[TC, T0] { val instance: tc.type } =
+    new WitnessWith[TC] {
+      type T = T0
+      val value: T = v
+      val instance: tc.type = tc
+    }
+
+  def instance[TC[_], T0](v: T0, tc: TC[T0]): Aux[TC, T0] =
+    new WitnessWith[TC] {
+      type T = T0
+      val value: T = v
+      val instance: TC[T] = tc
+    }
 }
 
 trait NatWith[TC[_ <: Nat]] {
@@ -91,6 +107,18 @@ object NatWith {
 
   implicit def apply2[B, T <: B, TC[_ <: B, _ <: Nat]](i: Int): NatWith[({ type λ[t <: Nat] = TC[T, t] })#λ] =
     macro SingletonTypeMacros.convertInstanceImplNat1[B, T, TC]
+
+  def depInstance[TC[_ <: Nat] <: AnyRef, N0 <: Nat](tc: TC[N0]): Aux[TC, N0] { val instance: tc.type } =
+    new NatWith[TC] {
+      type N = N0
+      val instance: tc.type = tc
+    }
+
+  def instance[TC[_ <: Nat], N0 <: Nat](tc: TC[N0]): Aux[TC, N0] =
+    new NatWith[TC] {
+      type N = N0
+      val instance: TC[N] = tc
+    }
 }
 
 /**
@@ -237,58 +265,28 @@ trait SingletonTypeUtils extends ReprTypes {
 @macrocompat.bundle
 class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils with NatMacroDefns {
   import c.universe._
-  import internal.decorators._
+  import definitions._
 
   def mkWitness(sTpe: Type, s: Tree): Tree = {
-    q"""
-      _root_.shapeless.Witness.mkWitness[$sTpe]($s.asInstanceOf[$sTpe])
-    """
+    val witness = objectRef[Witness.type]
+    q"$witness.mkWitness[$sTpe]($s.asInstanceOf[$sTpe])"
   }
 
-  def mkWitnessWith(parent: Type, sTpe: Type, s: Tree, i: Tree): Tree = {
-    val name = TypeName(c.freshName("anon$"))
-    val iTpe = i.tpe.finalResultType
-
-    q"""
-      {
-        final class $name extends $parent {
-          val instance: $iTpe = $i
-          type T = $sTpe
-          val value: $sTpe = $s
-        }
-        new $name
-      }
-    """
+  def mkWitnessWith(tcTpe: Type, sTpe: Type, s: Tree, i: Tree): Tree = {
+    val witnessWith = objectRef[WitnessWith.type]
+    if (appliedType(tcTpe, AnyValTpe) <:< AnyRefTpe) q"$witnessWith.depInstance[$tcTpe, $sTpe]($s, $i)"
+    else q"$witnessWith.instance[$tcTpe, $sTpe]($s, $i)"
   }
 
-  def mkWitnessNat(parent: Type, sTpe: Type, s: Tree, i: Tree): Tree = {
-    val name = TypeName(c.freshName("anon$"))
-    val iTpe = i.tpe.finalResultType
-
-    q"""
-      {
-        final class $name extends $parent {
-          val instance: $iTpe = $i
-          type N = $sTpe
-          val value: $sTpe = $s
-        }
-        new $name
-      }
-    """
+  def mkWitnessNat(tcTpe: Type, nTpe: Type, tc: Tree): Tree = {
+    val natWith = objectRef[NatWith.type]
+    if (appliedType(tcTpe, AnyValTpe) <:< AnyRefTpe) q"$natWith.depInstance[$tcTpe, $nTpe]($tc)"
+    else q"$natWith.instance[$tcTpe, $nTpe]($tc)"
   }
 
   def mkOps(sTpe: Type, w: Tree): Tree = {
-    val name = TypeName(c.freshName("anon$"))
-
-    q"""
-      {
-        final class $name extends _root_.shapeless.syntax.SingletonOps {
-          type T = $sTpe
-          val witness = $w
-        }
-        new $name
-      }
-    """
+    val ops = objectRef[SingletonOps.type]
+    q"$ops.instance[$sTpe]($w)"
   }
 
   def mkAttributedQualifier(tpe: Type): Tree = {
@@ -370,45 +368,34 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils wi
     }
 
   def convertInstanceImplNatAux(i: Tree, tcTpe: Type): Tree = {
-      val (n, nTpe) =
-        i match {
-          case NatLiteral(n) => (mkNatValue(n), mkNatTpe(n))
-          case _ =>
-            c.abort(c.enclosingPosition, s"Expression $i does not evaluate to a non-negative Int literal")
-        }
-      val nwTC = typeOf[NatWith[Any]].typeConstructor
-      val parent = appliedType(nwTC, List(tcTpe))
-      val instTpe = appliedType(tcTpe, List(nTpe))
+      val nTpe = i match {
+        case NatLiteral(n) => mkNatTpe(n)
+        case _ => c.abort(c.enclosingPosition, s"Expression $i does not evaluate to a non-negative Int literal")
+      }
+
+      val instTpe = appliedType(tcTpe, nTpe)
       val iInst = inferInstance(instTpe)
-      mkWitnessNat(parent, nTpe, n, iInst)
+      mkWitnessNat(tcTpe, nTpe, iInst)
   }
 
   def convertInstanceImpl1[TC[_]](t: Tree)
     (implicit tcTag: WeakTypeTag[TC[_]]): Tree =
       extractResult(t) { (sTpe, value) =>
         val tc = tcTag.tpe.typeConstructor
-        val wwTC = typeOf[WitnessWith[Nothing]].typeConstructor
-        val parent = appliedType(wwTC, List(tc))
-        val tci = appliedType(tc, List(sTpe))
+        val tci = appliedType(tc, sTpe)
         val i = inferInstance(tci)
-        mkWitnessWith(parent, sTpe, value, i)
+        mkWitnessWith(tc, sTpe, value, i)
       }
 
   def convertInstanceImpl2[H, TC2[_ <: H, _], S <: H](t: Tree)
     (implicit tc2Tag: WeakTypeTag[TC2[_, _]], sTag: WeakTypeTag[S]): Tree =
       extractResult(t) { (sTpe, value) =>
         val tc2 = tc2Tag.tpe.typeConstructor
-        val s = sTag.tpe
-
-        val parent = weakTypeOf[WitnessWith[({ type λ[X] = TC2[S, X] })#λ]].map {
-          case TypeRef(prefix, sym, args) if sym.isFreeType =>
-            internal.typeRef(NoPrefix, tc2.typeSymbol, args)
-          case tpe => tpe
-        }
-
-        val tci = appliedType(tc2, List(s, sTpe))
+        val tparam = tc2.typeParams.last.asType
+        val tc = c.internal.polyType(tparam :: Nil, appliedType(tc2, sTag.tpe, tparam.toType))
+        val tci = appliedType(tc2, sTag.tpe, sTpe)
         val i = inferInstance(tci)
-        mkWitnessWith(parent, sTpe, value, i)
+        mkWitnessWith(tc, sTpe, value, i)
       }
 
   def mkSingletonOps(t: Tree): Tree =
@@ -440,9 +427,12 @@ class SingletonTypeMacros(val c: whitebox.Context) extends SingletonTypeUtils wi
       case _ => tpe.widen
     }
 
-    if (widenTpe =:= tpe)
+    if (widenTpe =:= tpe) {
       c.abort(c.enclosingPosition, s"Don't know how to widen $tpe")
-    else
-      q"_root_.shapeless.Widen.instance[$tpe, $widenTpe](x => x)"
+    } else {
+      val widen = objectRef[Widen.type]
+      val predef = objectRef[Predef.type]
+      q"$widen.instance[$tpe, $widenTpe]($predef.identity)"
+    }
   }
 }

--- a/core/src/main/scala/shapeless/syntax/singletons.scala
+++ b/core/src/main/scala/shapeless/syntax/singletons.scala
@@ -46,3 +46,12 @@ trait SingletonOps {
    */
   def ->>[V](v: V): FieldType[T, V] = field[T](v)
 }
+
+object SingletonOps {
+
+  def instance[T0](w: Witness.Aux[T0]): SingletonOps { type T = T0; val witness: w.type } =
+    new SingletonOps {
+      type T = T0
+      val witness: w.type = w
+    }
+}


### PR DESCRIPTION
This reduces the size of the generated bytecode and
the number of emitted classfiles (on Scala 2.12+).

Thanks to @neko-kai for pointing out this inefficiency.

 - [x] `Generic`
 - [x] `DefaultSymbolicLabelling`
 - [x] `Witness`
 - [x] `WitnessWith`
 - [x] `NatWith`
 - [x] `SingletonOps`
 - [x] `Generic1`
 - [x] `Split1`
 - [x] `IsHCons1`
 - [x] `IsCCons1`

`Annotations` and `Default` already have helpers.