### PR TITLE
Tighten fieldsOf and isCaseAccessorLike

### DIFF
--- a/core/src/main/scala/shapeless/annotation.scala
+++ b/core/src/main/scala/shapeless/annotation.scala
@@ -237,28 +237,21 @@ class AnnotationMacros(val c: whitebox.Context) extends CaseClassMacros {
       if (isProduct(tpe)) {
         val constructorSyms = tpe
           .member(termNames.CONSTRUCTOR)
-          .asMethod
-          .paramLists
-          .flatten
-          .map { sym => sym.name.decodedName.toString -> sym }
+          .asMethod.paramLists.flatten
+          .map(sym => nameAsString(sym.name) -> sym)
           .toMap
 
         fieldsOf(tpe).map { case (name, _) =>
-          val paramConstrSym = constructorSyms(name.decodedName.toString)
-
-          val annots = extract(typeAnnotation, paramConstrSym)
-          annots.collectFirst {
+          extract(typeAnnotation, constructorSyms(nameAsString(name))).collectFirst {
             case ann if ann.tree.tpe =:= annTpe => construct0(ann.tree.children.tail)
           }
         }
       } else if (isCoproduct(tpe))
         ctorsOf(tpe).map { cTpe =>
-
-        val annots = extract(typeAnnotation, cTpe.typeSymbol)
-        annots.collectFirst {
-          case ann if ann.tree.tpe =:= annTpe => construct0(ann.tree.children.tail)
+          extract(typeAnnotation, cTpe.typeSymbol).collectFirst {
+            case ann if ann.tree.tpe =:= annTpe => construct0(ann.tree.children.tail)
+          }
         }
-      }
       else
         abort(s"$tpe is not case class like or the root of a sealed family of types")
 

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -349,13 +349,13 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
   }
 
   def fieldsOf(tpe: Type): List[(TermName, Type)] = {
-    val tSym = tpe.typeSymbol
-    if(tSym.isClass && isAnonOrRefinement(tSym)) Nil
-    else
-      tpe.decls.sorted collect {
-        case sym: TermSymbol if isCaseAccessorLike(sym) =>
-          (sym.name.toTermName, sym.typeSignatureIn(tpe).finalResultType)
-      }
+    val clazz = tpe.typeSymbol.asClass
+    val isCaseClass = clazz.isCaseClass
+    if (isAnonOrRefinement(clazz)) Nil
+    else tpe.decls.sorted.collect {
+      case sym: TermSymbol if isCaseAccessorLike(sym, isCaseClass) =>
+        (sym.name, sym.typeSignatureIn(tpe).finalResultType)
+    }
   }
 
   def productCtorsOf(tpe: Type): List[Symbol] = tpe.decls.toList.filter(_.isConstructor)
@@ -646,9 +646,11 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
 
   def isCaseObjectLike(sym: ClassSymbol): Boolean = sym.isModuleClass
 
-  def isCaseAccessorLike(sym: TermSymbol): Boolean = {
-    def isGetter = if (sym.owner.asClass.isCaseClass) sym.isCaseAccessor else sym.isGetter
-    sym.isPublic && isGetter && !isNonGeneric(sym)
+  def isCaseAccessorLike(sym: TermSymbol, inCaseClass: Boolean): Boolean = {
+    val isGetter =
+      if (inCaseClass) sym.isCaseAccessor && !sym.isMethod
+      else sym.isGetter && sym.isPublic && (sym.isParamAccessor || sym.isLazy)
+    isGetter && !isNonGeneric(sym)
   }
 
   def isSealedHierarchyClassSymbol(symbol: ClassSymbol): Boolean = {

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -98,6 +98,9 @@ package GenericTestsAux {
   class NonCCA(val i: Int, val s: String) extends AbstractNonCC
   class NonCCB(val b: Boolean, val d: Double) extends AbstractNonCC
   class NonCCWithVars(var c: Char, var l: Long) extends AbstractNonCC
+  class NonCCWithVal(val n: Int) extends AbstractNonCC {
+    val isEven: Boolean = n % 2 == 0
+  }
 
   class NonCCWithCompanion private (val i: Int, val s: String)
   object NonCCWithCompanion {
@@ -445,11 +448,13 @@ class GenericTests {
     val ncca = new NonCCA(23, "foo")
     val nccb = new NonCCB(true, 2.0)
     val nccc = new NonCCWithVars('c', 42)
+    val nccd = new NonCCWithVal(313)
     val ancc: AbstractNonCC = ncca
 
     val genA = Generic[NonCCA]
     val genB = Generic[NonCCB]
     val genC = Generic[NonCCWithVars]
+    val genD = Generic[NonCCWithVal]
     val genAbs = Generic[AbstractNonCC]
 
     val rA = genA.to(ncca)
@@ -461,8 +466,11 @@ class GenericTests {
     val rC = genC.to(nccc)
     assertTypedEquals[Char :: Long :: HNil]('c' :: 42L :: HNil, rC)
 
+    val rD = genD.to(nccd)
+    assertTypedEquals[Int :: HNil](313 :: HNil, rD)
+
     val rAbs = genAbs.to(ancc)
-    assertTypedEquals[NonCCA :+: NonCCB :+: NonCCWithVars :+: CNil](Inl(ncca), rAbs)
+    assertTypedEquals[NonCCA :+: NonCCB :+: NonCCWithVal :+: NonCCWithVars :+: CNil](Inl(ncca), rAbs)
 
     val fA = genA.from(13 :: "bar" :: HNil)
     typed[NonCCA](fA)
@@ -478,6 +486,10 @@ class GenericTests {
     typed[NonCCWithVars](fC)
     assertEquals('k', fC.c)
     assertEquals(313L, fC.l)
+
+    val fD = genD.from(99 :: HNil)
+    typed[NonCCWithVal](fD)
+    assertEquals(99, fD.n)
 
     val fAbs = genAbs.from(Inr(Inl(nccb)))
     typed[AbstractNonCC](fAbs)

--- a/core/src/test/scala/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala/shapeless/labelledgeneric.scala
@@ -31,6 +31,11 @@ object LabelledGenericTestsAux {
   case class ExtendedBook(author: String, title: String, id: Int, price: Double, inPrint: Boolean)
   case class BookWithMultipleAuthors(title: String, id: Int, authors: String*)
 
+  case class Private1(private val a: Int)
+  case class Private2(private val a: Int, b: Int)
+  case class Private3(a: Int, private val b: String)
+  case class Private4(private val a: Int, b: String)
+
   val tapl = Book("Benjamin Pierce", "Types and Programming Languages", 262162091, 44.11)
   val tapl2 = Book("Benjamin Pierce", "Types and Programming Languages (2nd Ed.)", 262162091, 46.11)
   val taplExt = ExtendedBook("Benjamin Pierce", "Types and Programming Languages", 262162091, 44.11, true)
@@ -172,6 +177,39 @@ class LabelledGenericTests {
 
     val values = b0.values
     assertEquals("Benjamin Pierce" :: "Types and Programming Languages" :: 262162091 :: 44.11 :: HNil, values)
+  }
+
+  @Test
+  def testPrivateFields: Unit = {
+    val gen1 = LabelledGeneric[Private1]
+    val gen2 = LabelledGeneric[Private2]
+    val gen3 = LabelledGeneric[Private3]
+    val gen4 = LabelledGeneric[Private4]
+    val ab = Symbol("a").narrow :: Symbol("b").narrow :: HNil
+
+    val p1 = Private1(1)
+    val r1 = gen1.to(p1)
+    assertTypedEquals(Symbol("a").narrow :: HNil, r1.keys)
+    assertTypedEquals(1 :: HNil, r1.values)
+    assertEquals(p1, gen1.from(r1))
+
+    val p2 = Private2(2, 12)
+    val r2 = gen2.to(p2)
+    assertTypedEquals(ab, r2.keys)
+    assertTypedEquals(2 :: 12 :: HNil, r2.values)
+    assertEquals(p2, gen2.from(r2))
+
+    val p3 = Private3(3, "p3")
+    val r3 = gen3.to(p3)
+    assertTypedEquals(ab, r3.keys)
+    assertTypedEquals(3 :: "p3" :: HNil, r3.values)
+    assertEquals(p3, gen3.from(r3))
+
+    val p4 = Private4(4, "p4")
+    val r4 = gen4.to(p4)
+    assertTypedEquals(ab, r4.keys)
+    assertTypedEquals(4 :: "p4" :: HNil, r4.values)
+    assertEquals(p4, gen4.from(r4))
   }
 
   @Test


### PR DESCRIPTION
  * For case classes return case accessor fields (not methods).
    This skips synthetic `x$access$1` methods which appear in the wrong order.

  * For non-case classes restrict to parameter accessors or lazy vals.
    This way we can support both by-name parameters and vals in the body.

Fixes #968 
Fixes #934 
Fixes #768 