### PR TITLE
Expose CaseClassMacros as blackbox

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -297,7 +297,7 @@ trait ReprTypes {
 
 @macrocompat.bundle
 trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
-  val c: whitebox.Context
+  val c: blackbox.Context
 
   import c.universe._
   import internal.constantType

--- a/core/src/main/scala/shapeless/generic1.scala
+++ b/core/src/main/scala/shapeless/generic1.scala
@@ -307,6 +307,7 @@ class IsCCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
 
 @macrocompat.bundle
 trait IsCons1Macros extends CaseClassMacros {
+  val c: whitebox.Context
   import c.ImplicitCandidate
   import c.internal._
   import c.universe._


### PR DESCRIPTION
`blackbox.Context` is a superclass of `whitebox.Context` so it's ok.

Fixes #916 