### PR TITLE
Remove GC setting from .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,4 +3,3 @@
 -Xms2g
 -Xmx3g
 -Xss2m
--XX:+UseG1GC


### PR DESCRIPTION
If you have locally configured a different GC it would prevent sbt from starting.

Fixes #814