### PR TITLE
Constrain tuple syntax with IsTuple

### DIFF
--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -20,16 +20,11 @@ package std
 
 import shapeless.ops.hlist.ProductToHList
 
-trait LowPriorityTuple {
-  implicit def productTupleOps[P <: Product](p: P): TupleOps[P] = new TupleOps(p)
-}
-
-object tuple extends LowPriorityTuple {
-  implicit def unitTupleOps(u: Unit): TupleOps[Unit] = new TupleOps(u)
-
+object tuple {
   // Duplicated here from shapeless.HList so that explicit imports of tuple._ don't
   // clobber the conversion to HListOps.
   implicit def hlistOps[L <: HList](l : L) : HListOps[L] = new HListOps(l)
+  implicit def productTupleOps[P: IsTuple](p: P): TupleOps[P] = new TupleOps(p)
 }
 
 final class TupleOps[T](t: T) extends Serializable {

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -18,7 +18,7 @@ package shapeless
 
 import org.junit.Test
 import org.junit.Assert._
-
+import shapeless.ops.tuple.IsComposite
 import shapeless.test._
 import testutil._
 
@@ -49,6 +49,7 @@ class TupleTests {
   case class Pear() extends Fruit
   case class Banana() extends Fruit
 
+  case class Foo(i: Int, s: String)
   type PWS = Product with Serializable with Fruit
 
   type YYYY = (Any, Any, Any, Any)
@@ -1462,8 +1463,7 @@ class TupleTests {
 
   @Test
   def testPropagation: Unit = {
-    def useHead[P <: Product](p: P)(implicit ic: ops.tuple.IsComposite[P]) = p.head
-
+    def useHead[P: IsTuple: IsComposite](p: P) = p.head
     val h = useHead((23, "foo", true))
     typed[Int](h)
   }
@@ -1972,5 +1972,12 @@ class TupleTests {
     illTyped("""
       (23, "foo").align[(String, String)]
     """)
+  }
+
+  @Test
+  def testCompatibilityWithProductSyntax: Unit = {
+    import syntax.std.product._
+    assertEquals(List(2, "a"), Foo(2, "a").to[List])
+    assertEquals(List(2, "a"), (2, "a").to[List])
   }
 }


### PR DESCRIPTION
  * Resolves ambiguity with product syntax (fixes #307)
  * Allows to correctly generalize (including unit)