### PR TITLE
Poly builders require no import

### DIFF
--- a/core/src/main/scala/shapeless/poly.scala
+++ b/core/src/main/scala/shapeless/poly.scala
@@ -187,6 +187,7 @@ object PolyDefns extends Cases {
  */
 trait Poly extends PolyApply with Serializable {
   import poly._
+  type λ = this.type
 
   def compose(f: Poly) = new Compose[this.type, f.type](this, f)
 

--- a/core/src/test/scala/shapeless/poly.scala
+++ b/core/src/test/scala/shapeless/poly.scala
@@ -383,8 +383,7 @@ class PolyTests {
 
   @Test
   def testPoly1Builder: Unit = {
-    val myPoly = Poly1.at[Int]( x => x).at[String](_.length).at[Boolean](if(_) 1 else 0).build
-    import myPoly._
+    val myPoly = Poly1.at[Int](x => x).at[String](_.length).at[Boolean](if(_) 1 else 0)
 
     val r1 = myPoly(10)
     assertTypedEquals[Int](10, r1)
@@ -398,11 +397,10 @@ class PolyTests {
 
   @Test
   def testPoly2Builder: Unit = {
-    val myPoly = Poly2.at[Int, Int]((acc, x) => acc + x).
-                       at[Int, String]((acc, s) => acc + s.length).
-                       at[Int, Boolean]((acc, b) => acc + (if(b) 1 else 0)).
-                       build
-    import myPoly._
+    val myPoly = Poly2
+      .at[Int, Int]((acc, x) => acc + x)
+      .at[Int, String]((acc, s) => acc + s.length)
+      .at[Int, Boolean]((acc, b) => acc + (if(b) 1 else 0))
 
     val r1 = myPoly(5, 10)
     assertTypedEquals[Int](15, r1)
@@ -416,12 +414,8 @@ class PolyTests {
 
   @Test
   def testPoly1BuilderMap: Unit = {
-    val myPoly = Poly1.at[Int]( x => x.toString).at[String](_.length > 2).at[Boolean](if(_) 1 else 0).build
-
-    import myPoly._
-
-    val r = (10 :: "hello" :: true :: HNil).map(myPoly)
-
+    val myPoly = Poly1.at[Int]( x => x.toString).at[String](_.length > 2).at[Boolean](if(_) 1 else 0)
+    val r = (10 :: "hello" :: true :: HNil).map(myPoly.build)
     assertTypedEquals[String::Boolean::Int::HNil](("10"::true::1::HNil), r)
   }
 
@@ -431,12 +425,8 @@ class PolyTests {
       .at[Int, Int]((acc, x) => acc + x)
       .at[Int, String]((acc, s) => acc + s.length)
       .at[Int, Boolean]((acc, b) => acc + (if(b) 1 else 0))
-      .build
 
-    import myPoly._
-
-    val r = (10 :: "hello" :: true :: HNil).foldLeft(0)(myPoly)
-
+    val r = (10 :: "hello" :: true :: HNil).foldLeft(0)(myPoly.build)
     assertTypedEquals[Int](16, r)
   }
 }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -259,10 +259,11 @@ object Boilerplate {
         |
         |trait PolyApply {
         |  import poly._
+        |  type λ <: Singleton
         -  def apply
         -    [${`A..N`}]
         -    (${`a:A..n:N`})
-        -    (implicit cse : Case[this.type, ${`A::N`}])
+        -    (implicit cse : Case[λ, ${`A::N`}])
         -  : cse.Result =
         -    cse(${`a::n`})
         -
@@ -387,7 +388,8 @@ object Boilerplate {
         |  */
         |object PolyNBuilders {
         -
-        - trait Poly${arity}Builder[HL <: HList] { self =>
+        - trait Poly${arity}Builder[HL <: HList] extends PolyApply { self =>
+        -   type λ = build.type
         -   val functions: HL
         -   class AtAux[${`A..N`}] {
         -     def apply[Out](λ: (${`A..N`}) => Out): Poly${arity}Builder[((${`A..N`}) => Out) :: HL] = {


### PR DESCRIPTION
The insight is that `build` is now an object (see c9cf7499d87dc55fc5a15c42abdb7a4c981aa5a6).
All we need is a stable path to it which we get if we capture the
preceding part of the definition in a val.

@milessabin in light of this do we want to rename `build` to something else?
I couldn't come up with a better name right away, so opening this PR to discuss.

Addresses #632 