### PR TITLE
Cache coursier directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jdk:
 
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
     - $HOME/.sbt
 


### PR DESCRIPTION
Recent builds have failed because they download dependencies every time.