### PR TITLE
Make +publishLocal publish full cross-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ env:
     - SCALA_JS_VERSION=1.0.1
     - SCALA_NATIVE=true
   global:
-    - CI_RELEASE=publishSigned
-    - CI_SNAPSHOT_RELEASE=publish
     - secure: eXcMQIb0hHeaJsJGaJYhLS8aONu5YnhK1NOHJZGTBIb6ukSd48uXm6xNgBMozgkOEUBXyrBU9ZnCOxSS+HmJZDbK0Wkr90C4sZH7dHBZYMN3hNfCp5SjPFY2+TgrYZ24G8s/BPei6725AlbXM0vmdXPsvxaOvT36d2Ej7xto8+c=
     - secure: c3IO3G34aTFD+fh/5vqc3sCgwMaClPDziYQDCEUqQBOQFdTS7wbBZFVpqTUUlkMLkeyHZ0BGSLUiDZnu8TGGITtgJBaCUchhLYK5WOavyzCl/NPVOBebviazgtBOzPDKyYDcahjmxCGrMspTiRei86VgCdkNIvldJJm7zK1OAOU=
 
@@ -49,7 +47,10 @@ notifications:
 jobs:
   include:
     - stage: release
-      script: sbt ++$TRAVIS_SCALA_VERSION! ci-release
+      script:
+      - |
+        sbt ci-release
+        SCALA_JS_VERSION=0.6.32 sbt clean sonatypeBundleClean ci-release
   exclude:
     - scala: [2.12.11]
       env: SCALA_NATIVE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,29 @@
 os: linux
+dist: trusty
 language: scala
 
-dist: trusty
+jdk:
+  - oraclejdk8
+
+scala:
+  - 2.11.12
+  - 2.12.11
+  - 2.13.1
+
+env:
+  - {}
+  - SCALA_JS_VERSION=0.6.32
+  - SCALA_JS_VERSION=1.0.1
+  - SCALA_NATIVE=true
+
+stages:
+  - name: test
+  - name: release
+    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
 before_install:
   - git fetch --tags
-  - '[ -z "$SCALA_NATIVE" ] || curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x'
-
-scala:
-- 2.11.12
-- 2.12.11
-- 2.13.1
-
-jdk:
-- openjdk11
+  - '[[ -z "$SCALA_NATIVE" ]] || curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x'
 
 cache:
   directories:
@@ -22,21 +32,6 @@ cache:
     - $HOME/.sbt
 
 script: sbt ++$TRAVIS_SCALA_VERSION! clean validateCI
-
-stages:
-  - name: test
-  - name: release
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
-
-env:
-  matrix:
-    - {}
-    - SCALA_JS_VERSION=0.6.32
-    - SCALA_JS_VERSION=1.0.1
-    - SCALA_NATIVE=true
-  global:
-    - secure: eXcMQIb0hHeaJsJGaJYhLS8aONu5YnhK1NOHJZGTBIb6ukSd48uXm6xNgBMozgkOEUBXyrBU9ZnCOxSS+HmJZDbK0Wkr90C4sZH7dHBZYMN3hNfCp5SjPFY2+TgrYZ24G8s/BPei6725AlbXM0vmdXPsvxaOvT36d2Ej7xto8+c=
-    - secure: c3IO3G34aTFD+fh/5vqc3sCgwMaClPDziYQDCEUqQBOQFdTS7wbBZFVpqTUUlkMLkeyHZ0BGSLUiDZnu8TGGITtgJBaCUchhLYK5WOavyzCl/NPVOBebviazgtBOzPDKyYDcahjmxCGrMspTiRei86VgCdkNIvldJJm7zK1OAOU=
 
 notifications:
   irc: "chat.freenode.net#shapeless"
@@ -47,10 +42,12 @@ notifications:
 jobs:
   include:
     - stage: release
+      env:
+        - secure: eXcMQIb0hHeaJsJGaJYhLS8aONu5YnhK1NOHJZGTBIb6ukSd48uXm6xNgBMozgkOEUBXyrBU9ZnCOxSS+HmJZDbK0Wkr90C4sZH7dHBZYMN3hNfCp5SjPFY2+TgrYZ24G8s/BPei6725AlbXM0vmdXPsvxaOvT36d2Ej7xto8+c=
+        - secure: c3IO3G34aTFD+fh/5vqc3sCgwMaClPDziYQDCEUqQBOQFdTS7wbBZFVpqTUUlkMLkeyHZ0BGSLUiDZnu8TGGITtgJBaCUchhLYK5WOavyzCl/NPVOBebviazgtBOzPDKyYDcahjmxCGrMspTiRei86VgCdkNIvldJJm7zK1OAOU=
       script:
-      - |
-        sbt ci-release
-        SCALA_JS_VERSION=0.6.32 sbt clean sonatypeBundleClean ci-release
+        - sbt ci-release
+        - SCALA_JS_VERSION=0.6.32 sbt clean sonatypeBundleClean ci-release
   exclude:
     - scala: [2.12.11]
       env: SCALA_NATIVE=true

--- a/build.sbt
+++ b/build.sbt
@@ -5,20 +5,20 @@ import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 import sbtcrossproject.CrossProject
 
 val Scala211 = "2.11.12"
+val Scala212 = "2.12.11"
+val Scala213 = "2.13.1"
+
+val isScalaNative = System.getenv("SCALA_NATIVE") != null
+val hasScalaJsVersion = System.getenv("SCALA_JS_VERSION") != null
+
 inThisBuild(Seq(
   organization := "com.chuusai",
-  scalaVersion := "2.13.1",
+  scalaVersion := Scala213,
+  crossScalaVersions := Seq(Scala211, Scala212, Scala213),
   mimaFailOnNoPrevious := false
 ))
 
-val platform: sbtcrossproject.Platform =
-  if (sys.env.contains("SCALA_NATIVE")) NativePlatform
-  else if (isCustomScalaJSVersion) JSPlatform
-  else JVMPlatform
-
-lazy val isCustomScalaJSVersion = sys.env.contains("SCALA_JS_VERSION")
-
-addCommandAlias("root", ";project root")
+addCommandAlias("root", ";project shapeless")
 addCommandAlias("core", ";project coreJVM")
 addCommandAlias("scratch", ";project scratchJVM")
 addCommandAlias("examples", ";project examplesJVM")
@@ -27,16 +27,8 @@ addCommandAlias("validate", ";root;validateJVM;validateJS")
 addCommandAlias("validateJVM", ";coreJVM/compile;coreJVM/mimaReportBinaryIssues;coreJVM/test;examplesJVM/compile;coreJVM/doc")
 addCommandAlias("validateJS", ";coreJS/compile;coreJS/mimaReportBinaryIssues;coreJS/test;examplesJS/compile;coreJS/doc")
 addCommandAlias("validateNative", ";coreNative/compile;nativeTest/run")
-addCommandAlias("validateJVM-", ";coreJVM/compile;coreJVM/mimaReportBinaryIssues;coreJVM/test;coreJVM/doc")
-
+addCommandAlias("validateCI", if (isScalaNative) "validateNative" else if (hasScalaJsVersion) "validateJS" else "validateJVM")
 addCommandAlias("runAll", ";examplesJVM/runAll")
-addCommandAlias("releaseAll", ";root;release skip-tests")
-
-addCommandAlias("validateCI", platform match {
-  case JVMPlatform => "validateJVM"
-  case JSPlatform => "validateJS"
-  case NativePlatform => "validateNative"
-})
 
 lazy val scoverageSettings = Seq(
   coverageMinimum := 60,
@@ -93,20 +85,16 @@ def configureJUnit(crossProject: CrossProject) = {
   )
 }
 
-lazy val fullCrossScalaVersions = List(
-  crossScalaVersions := Seq(Scala211, "2.12.11", "2.13.1")
-)
-
 lazy val commonJsSettings = Seq(
   scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
   parallelExecution in Test := false,
   coverageEnabled := false
-) ++ fullCrossScalaVersions
+)
 
 lazy val commonJvmSettings = Seq(
   parallelExecution in Test := false,
   coverageExcludedPackages := "shapeless.examples.*"
-) ++ fullCrossScalaVersions
+)
 
 lazy val commonNativeSettings = Seq(
   scalaVersion := Scala211,
@@ -115,8 +103,11 @@ lazy val commonNativeSettings = Seq(
 
 lazy val coreSettings = commonSettings ++ publishSettings
 
-noPublishSettings
-crossScalaVersions := List()
+lazy val shapeless = project.in(file("."))
+  .aggregate(coreJS, coreJVM)
+  .dependsOn(coreJS, coreJVM)
+  .settings(coreSettings:_*)
+  .settings(noPublishSettings)
 
 lazy val CrossTypeMixed: sbtcrossproject.CrossType = new sbtcrossproject.CrossType {
   def projectDir(crossBase: File, projectType: String): File =
@@ -142,15 +133,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(
   .configureCross(buildInfoSetup)
   .enablePlugins(SbtOsgi)
   .settings(coreOsgiSettings:_*)
-  .settings(
-    sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue
-  )
+  .settings(sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue)
   .settings(mimaSettings:_*)
   .jsSettings(commonJsSettings:_*)
   .jvmSettings(commonJvmSettings:_*)
   .jvmSettings(scoverageSettings:_*)
-  .jvmSettings(skip in publish := isCustomScalaJSVersion)
-  .nativeSettings(skip in publish := isCustomScalaJSVersion)
+  .jvmSettings(skip in publish := hasScalaJsVersion)
+  .nativeSettings(skip in publish := hasScalaJsVersion)
   .nativeSettings(
     commonNativeSettings,
     // disable scaladoc generation on native

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 scalacOptions += "-deprecation"
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.30"
 
-val scalaJSVersion = sys.env.getOrElse("SCALA_JS_VERSION", "1.0.1")
+val scalaJsVersion = Option(System.getenv("SCALA_JS_VERSION")).getOrElse("1.0.1")
 
 addSbtPlugin("com.typesafe"                      % "sbt-mima-plugin"       % "0.7.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-osgi"              % "0.9.5")
@@ -9,7 +9,7 @@ addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"         % "0.
 addSbtPlugin("com.geirsson"                      % "sbt-ci-release"        % "1.5.2")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "3.0.0")
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"         % "1.6.1")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"           % scalaJSVersion)
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"           % scalaJsVersion)
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"      % "0.4.0-M2")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossproject" % "1.0.0")


### PR DESCRIPTION
Previously, running `sbt +publishLocal` only published the active platform
(JVM, JS or Native). Now, the command publishes the full cross-build for
both Scala versions (2.11/2.12/2.13) and platforms (JVM, JS, Native).
This change makes it possible for the `sbt ci-release` to release all
modules in one step excluding Scala.js v0.6.x. The Travis script has
been updated to handle Scala.js v0.6.x in a separate sbt command, using
a similar setup as the MUnit build (see https://github.com/scalameta/munit)