### PR TITLE
Enable publishing of native module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ target/
 .*.swp
 .swo
 .*.swo
+lowered.hnir

--- a/.jvmopts
+++ b/.jvmopts
@@ -2,4 +2,4 @@
 -Dsbt.supershell=true
 -Xms2g
 -Xmx3g
--Xss2m
+-Xss4m

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,11 @@ env:
   - {}
   - SCALA_JS_VERSION=0.6.32
   - SCALA_JS_VERSION=1.0.1
-  - SCALA_NATIVE=true
 
 stages:
   - name: test
   - name: release
     if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
-
-before_install:
-  - git fetch --tags
-  - '[[ -z "$SCALA_NATIVE" ]] || curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x'
 
 cache:
   directories:
@@ -41,15 +36,15 @@ notifications:
 
 jobs:
   include:
-    - stage: release
+    - stage: test
       env:
-        - secure: eXcMQIb0hHeaJsJGaJYhLS8aONu5YnhK1NOHJZGTBIb6ukSd48uXm6xNgBMozgkOEUBXyrBU9ZnCOxSS+HmJZDbK0Wkr90C4sZH7dHBZYMN3hNfCp5SjPFY2+TgrYZ24G8s/BPei6725AlbXM0vmdXPsvxaOvT36d2Ej7xto8+c=
-        - secure: c3IO3G34aTFD+fh/5vqc3sCgwMaClPDziYQDCEUqQBOQFdTS7wbBZFVpqTUUlkMLkeyHZ0BGSLUiDZnu8TGGITtgJBaCUchhLYK5WOavyzCl/NPVOBebviazgtBOzPDKyYDcahjmxCGrMspTiRei86VgCdkNIvldJJm7zK1OAOU=
+        - SCALA_NATIVE=true
+      before_install:
+        - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+    - stage: release
+      before_install:
+        - git fetch --tags
+        - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
       script:
         - sbt ci-release
         - SCALA_JS_VERSION=0.6.32 sbt clean sonatypeBundleClean ci-release
-  exclude:
-    - scala: [2.12.11]
-      env: SCALA_NATIVE=true
-    - scala: [2.13.1]
-      env: SCALA_NATIVE=true

--- a/build.sbt
+++ b/build.sbt
@@ -104,10 +104,11 @@ lazy val commonNativeSettings = Seq(
 lazy val coreSettings = commonSettings ++ publishSettings
 
 lazy val shapeless = project.in(file("."))
-  .aggregate(coreJS, coreJVM)
-  .dependsOn(coreJS, coreJVM)
+  .aggregate(coreJS, coreJVM, coreNative)
+  .dependsOn(coreJS, coreJVM, coreNative)
   .settings(coreSettings:_*)
   .settings(noPublishSettings)
+  .settings(crossScalaVersions := List())
 
 lazy val CrossTypeMixed: sbtcrossproject.CrossType = new sbtcrossproject.CrossType {
   def projectDir(crossBase: File, projectType: String): File =
@@ -147,7 +148,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(
     //   [error] bnd: Invalid syntax for version: ${@}, for cmd: range, arguments; [range, [==,=+), ${@}]
     publishArtifact in (Compile, packageDoc) := false,
     publishArtifact in packageDoc := false,
-    sources in (Compile,doc) := Seq.empty
+    sources in (Compile,doc) := Seq.empty,
+    sources in Test := Seq.empty
   )
 
 lazy val coreJVM = core.jvm


### PR DESCRIPTION
Previously, the coreNative module was not published in the
`+publishLocal` command. Now, the root project aggregates `coreNative`
so that the module is correctly published. To make `sbt test` still
work like before, testing is disabled in Scala Native.