### PR TITLE
Switch LabelledGeneric from Symbol to String

### DIFF
--- a/core/jvm/src/test/scala/shapeless/serialization.scala
+++ b/core/jvm/src/test/scala/shapeless/serialization.scala
@@ -312,7 +312,7 @@ class SerializationTests {
 
     val r = Symbol("foo") ->> 23 :: Symbol("bar") ->> "foo" :: Symbol("baz") ->> true :: HNil
 
-    type U = Union.`'foo -> Int, 'bar -> String, 'baz -> Boolean`.T
+    type U = Union.`"foo" -> Int, "bar" -> String, "baz" -> Boolean`.T
     val u = Union[U](bar = "quux")
 
     val t = (23, "foo", true)
@@ -1192,7 +1192,7 @@ class SerializationTests {
     val l10 = optic.hlistNthLens[Int :: String :: Boolean :: HNil, _1]
     val l11 = optic.recordLens[Record.`'foo -> Int, 'bar -> String, 'baz -> Boolean`.T](Symbol("bar"))
     val l12 = optic[Tree[Int]].l.r.l.t
-    val l13 = optic[Node[Int]] >> Symbol("r")
+    val l13 = optic[Node[Int]] >> "r"
     val l14 = optic[Node[Int]] >> _1
 
     assertSerializable(l1)

--- a/core/jvm/src/test/scala/shapeless/serialization.scala
+++ b/core/jvm/src/test/scala/shapeless/serialization.scala
@@ -950,8 +950,8 @@ class SerializationTests {
     assertSerializable(Generic[(Int, String, Boolean)])
     assertSerializable(Generic[Option[Int]])
 
-    assertSerializable(DefaultSymbolicLabelling[(Int, String, Boolean)])
-    assertSerializable(DefaultSymbolicLabelling[Option[Int]])
+    assertSerializable(Labelling[(Int, String, Boolean)])
+    assertSerializable(Labelling[Option[Int]])
 
     assertSerializable(LabelledGeneric[(Int, String, Boolean)])
     assertSerializable(LabelledGeneric[Option[Int]])

--- a/core/src/main/scala/shapeless/coproduct.scala
+++ b/core/src/main/scala/shapeless/coproduct.scala
@@ -156,7 +156,7 @@ object Coproduct extends Dynamic {
    * type TwoTrueStr = Coproduct.`2, true, "str"`.T
    * }}}
    */
-  def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.coproductTypeImpl
+  def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.coproductType
 
   /** Allows to inject a runtime value of type `Any` in a `Coproduct` */
   def runtimeInject[C <: Coproduct](x: Any)(implicit rinj: RuntimeInject[C]): Option[C] = rinj(x)

--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -119,7 +119,7 @@ object Default {
     implicit def asRecord[T, Labels <: HList, Options <: HList](
       implicit
       default: Default.Aux[T, Options],
-      labelling: DefaultSymbolicLabelling.Aux[T, Labels],
+      labelling: Labelling.Aux[T, Labels],
       helper: Helper[Options, Labels]
     ): Aux[T, helper.Out] = new AsRecord[T] {
       type Out = helper.Out

--- a/core/src/main/scala/shapeless/default.scala
+++ b/core/src/main/scala/shapeless/default.scala
@@ -69,7 +69,7 @@ object Default {
    *
    *   val default = Default.AsRecord[CC]
    *
-   *   // default.Out is  Record.`'s -> String`.T
+   *   // default.Out is  Record.`"s" -> String`.T
    *   // default() returns Record(s = "b")
    * }}}
    *
@@ -93,41 +93,38 @@ object Default {
 
       type Aux[L <: HList, Labels <: HList, Out0 <: HList] = Helper[L, Labels] { type Out = Out0 }
 
-      implicit def hnilHelper: Aux[HNil, HNil, HNil] =
+      implicit val hnilHelper: Aux[HNil, HNil, HNil] =
         new Helper[HNil, HNil] {
           type Out = HNil
           def apply(l: HNil) = HNil
         }
 
-      implicit def hconsSomeHelper[K <: Symbol, H, T <: HList, LabT <: HList, OutT <: HList]
-       (implicit
-         tailHelper: Aux[T, LabT, OutT]
-       ): Aux[Some[H] :: T, K :: LabT, FieldType[K, H] :: OutT] =
+      implicit def hconsSomeHelper[K, H, T <: HList, LabT <: HList](
+        implicit tailHelper: Helper[T, LabT]
+      ): Aux[Some[H] :: T, K :: LabT, FieldType[K, H] :: tailHelper.Out] =
         new Helper[Some[H] :: T, K :: LabT] {
-          type Out = FieldType[K, H] :: OutT
-          def apply(l: Some[H] :: T) = field[K](l.head.get) :: tailHelper(l.tail)
+          type Out = FieldType[K, H] :: tailHelper.Out
+          def apply(l: Some[H] :: T): Out = field[K](l.head.get) :: tailHelper(l.tail)
         }
 
-      implicit def hconsNoneHelper[K <: Symbol, T <: HList, LabT <: HList, OutT <: HList]
-       (implicit
-         tailHelper: Aux[T, LabT, OutT]
-       ): Aux[None.type :: T, K :: LabT, OutT] =
+      implicit def hconsNoneHelper[K, T <: HList, LabT <: HList](
+        implicit tailHelper: Helper[T, LabT]
+      ): Aux[None.type :: T, K :: LabT, tailHelper.Out] =
         new Helper[None.type :: T, K :: LabT] {
-          type Out = OutT
-          def apply(l: None.type :: T) = tailHelper(l.tail)
+          type Out = tailHelper.Out
+          def apply(l: None.type :: T): Out = tailHelper(l.tail)
         }
     }
 
-    implicit def asRecord[T, Labels <: HList, Options <: HList, Rec <: HList]
-     (implicit
-       default: Default.Aux[T, Options],
-       labelling: DefaultSymbolicLabelling.Aux[T, Labels],
-       helper: Helper.Aux[Options, Labels, Rec]
-     ): Aux[T, Rec] =
-      new AsRecord[T] {
-        type Out = Rec
-        def apply() = helper(default())
-      }
+    implicit def asRecord[T, Labels <: HList, Options <: HList](
+      implicit
+      default: Default.Aux[T, Options],
+      labelling: DefaultSymbolicLabelling.Aux[T, Labels],
+      helper: Helper[Options, Labels]
+    ): Aux[T, helper.Out] = new AsRecord[T] {
+      type Out = helper.Out
+      def apply(): Out = helper(default())
+    }
   }
 
 

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -219,7 +219,7 @@ object LabelledGeneric {
     * @tparam T the type
     * @tparam Repr0 the labelled generic representation of the type
     */
-  type Aux[T, Repr0] = LabelledGeneric[T]{ type Repr = Repr0 }
+  type Aux[T, Repr0] = LabelledGeneric[T] { type Repr = Repr0 }
 
   /** Provides an instance of LabelledGeneric for the given T. As with [[shapeless.Generic]],
     * use this method or {{{the[LabelledGeneric[T]]}}} to obtain an instance for suitable given T. */
@@ -494,54 +494,58 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
       case (elem, acc) => q"_root_.shapeless.::($elem, $acc)"
     }
 
-  def mkCompoundTpe(nil: Type, cons: Type, items: List[Type]): Type =
-    items.foldRight(nil) {
-      case (tpe, acc) => appliedType(cons, List(devarargify(tpe), acc))
+  def mkCompoundTpe(nil: Type, cons: Type, items: Seq[Type]): Type =
+    items.foldRight(nil) { (tpe, acc) =>
+      appliedType(cons, List(devarargify(tpe), acc))
     }
 
-  def mkHListTpe(items: List[Type]): Type =
+  def mkHListTpe(items: Seq[Type]): Type =
     mkCompoundTpe(hnilTpe, hconsTpe, items)
 
-  def mkCoproductTpe(items: List[Type]): Type =
+  def mkCoproductTpe(items: Seq[Type]): Type =
     mkCompoundTpe(cnilTpe, cconsTpe, items)
 
-  def unpackHListTpe(tpe: Type): List[Type] = {
-    @tailrec
-    def unfold(u: Type, acc: List[Type]): List[Type] = {
-      val HNilTpe = hnilTpe
-      val HConsPre = prefix(hconsTpe)
-      val HConsSym = hconsTpe.typeSymbol
-      if(u <:< HNilTpe) acc
-      else (u baseType HConsSym) match {
-        case TypeRef(pre, _, List(hd, tl)) if pre =:= HConsPre => unfold(tl, hd :: acc)
-        case _ => abort(s"$tpe is not an HList type")
-      }
-    }
+  def unpackHList(tpe: Type): Vector[Type] =
+    unpackReprType(tpe, hnilTpe, hconsTpe)
 
-    unfold(tpe, List()).reverse
+  def unpackCoproduct(tpe: Type): Vector[Type] =
+    unpackReprType(tpe, cnilTpe, cconsTpe)
+
+  def unpackReprType(tpe: Type, nil: Type, cons: Type): Vector[Type] = {
+    val consSym = cons.typeSymbol
+    @tailrec def unpack(tpe: Type, acc: Vector[Type]): Vector[Type] =
+      if (tpe <:< nil) acc else tpe.baseType(consSym) match {
+        case TypeRef(_, _, List(head, tail)) => unpack(tail, acc :+ head)
+        case _ => abort(s"$tpe is not an HList or Coproduct type")
+      }
+
+    unpack(tpe, Vector.empty)
   }
 
   object FieldType {
     import internal._
 
-    def apply(kTpe: Type, vTpe: Type): Type =
-      refinedType(List(vTpe, typeRef(prefix(keyTagTpe), keyTagTpe.typeSymbol, List(kTpe, vTpe))), NoSymbol)
+    private val KeyTagSym = keyTagTpe.typeSymbol
 
-    def unapply(fTpe: Type): Option[(Type, Type)] = {
-      val KeyTagPre = prefix(keyTagTpe)
-      val KeyTagSym = keyTagTpe.typeSymbol
-      fTpe.dealias match {
-        case RefinedType(v0 :+ TypeRef(pre, KeyTagSym, List(k, v1)), scope)
-          if pre =:= KeyTagPre && refinedType(v0, NoSymbol, scope, NoPosition) =:= v1 =>
-            Some((k, v1))
-        case _ => None
-      }
+    def apply(key: Type, value: Type): Type =
+      appliedType(fieldTypeTpe, key, value)
+
+    def unapply(field: Type): Option[(Type, Type)] = field.dealias match {
+      case RefinedType(List(value, TypeRef(_, KeyTagSym, List(key, _))), scope)
+        if scope.isEmpty => Some(key -> value)
+      case RefinedType(parents :+ TypeRef(_, KeyTagSym, List(key, value)), scope)
+        if value =:= refinedType(parents, scope) => Some(key -> value)
+      case _ =>
+        None
     }
   }
 
-  def findField(lTpe: Type, kTpe: Type): Option[(Type, Int)] =
-    unpackHListTpe(lTpe).zipWithIndex.collectFirst {
-      case (FieldType(k, v), i) if k =:= kTpe => (v, i)
+  def findField(record: Type, key: Type): Option[(Type, Int)] =
+    findField(unpackHList(record), key)
+
+  def findField(fields: Seq[Type], key: Type): Option[(Type, Int)] =
+    fields.iterator.zipWithIndex.collectFirst {
+      case (FieldType(k, v), i) if k =:= key => (v, i)
     }
 
   def appliedTypTree1(tpe: Type, param: Type, arg: TypeName): Tree = {

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -279,7 +279,7 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
 
   import c.universe._
 
-  def abort(msg: String) =
+  def abort(msg: String): Nothing =
     c.abort(c.enclosingPosition, msg)
 
   def isReprType(tpe: Type): Boolean =

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -482,11 +482,14 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
       abort(s"$tpe is not a case class, case class-like, a sealed trait or Unit")
   }
 
-  def nameAsString(name: Name): String = name.decodedName.toString.trim
+  def nameAsString(name: Name): String =
+    name.decodedName.toString.trim
 
-  def nameAsValue(name: Name): Constant = Constant(nameAsString(name))
+  def nameAsValue(name: Name): Constant =
+    Constant(nameAsString(name))
 
-  def nameOf(tpe: Type) = tpe.typeSymbol.name
+  def nameOf(tpe: Type): Name =
+    tpe.typeSymbol.name
 
   def mkHListValue(elems: List[Tree]): Tree =
     elems.foldRight(q"_root_.shapeless.HNil": Tree) {

--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -226,32 +226,30 @@ object LabelledGeneric {
   def apply[T](implicit lgen: LabelledGeneric[T]): Aux[T, lgen.Repr] = lgen
 
   /** Handles the Product case (fields in a case class, for example) */
-  implicit def materializeProduct[T, K <: HList, V <: HList, R <: HList]
-    (implicit
-      lab: DefaultSymbolicLabelling.Aux[T, K],
-      gen: Generic.Aux[T, V],
-      zip: hlist.ZipWithKeys.Aux[K, V, R],
-      ev: R <:< V
-    ): Aux[T, R] =
-    new LabelledGeneric[T] {
-      type Repr = R
-      def to(t: T): Repr = zip(gen.to(t))
-      def from(r: Repr): T = gen.from(r)
-    }
+  implicit def materializeProduct[T, K <: HList, V <: HList, R <: HList](
+    implicit
+    lab: Labelling.Aux[T, K],
+    gen: Generic.Aux[T, V],
+    zip: hlist.ZipWithKeys.Aux[K, V, R],
+    ev: R <:< V
+  ): Aux[T, R] = new LabelledGeneric[T] {
+    type Repr = R
+    def to(t: T): Repr = zip(gen.to(t))
+    def from(r: Repr): T = gen.from(r)
+  }
 
   /** Handles the Coproduct case (specifying subclasses derive from a sealed trait) */
-  implicit def materializeCoproduct[T, K <: HList, V <: Coproduct, R <: Coproduct]
-    (implicit
-      lab: DefaultSymbolicLabelling.Aux[T, K],
-      gen: Generic.Aux[T, V],
-      zip: coproduct.ZipWithKeys.Aux[K, V, R],
-      ev: R <:< V
-    ): Aux[T, R] =
-    new LabelledGeneric[T] {
-      type Repr = R
-      def to(t: T): Repr = zip(gen.to(t))
-      def from(r: Repr): T = gen.from(r)
-    }
+  implicit def materializeCoproduct[T, K <: HList, V <: Coproduct, R <: Coproduct](
+    implicit
+    lab: Labelling.Aux[T, K],
+    gen: Generic.Aux[T, V],
+    zip: coproduct.ZipWithKeys.Aux[K, V, R],
+    ev: R <:< V
+  ): Aux[T, R] = new LabelledGeneric[T] {
+    type Repr = R
+    def to(t: T): Repr = zip(gen.to(t))
+    def from(r: Repr): T = gen.from(r)
+  }
 }
 
 class nonGeneric extends StaticAnnotation

--- a/core/src/main/scala/shapeless/hlists.scala
+++ b/core/src/main/scala/shapeless/hlists.scala
@@ -113,7 +113,7 @@ object HList extends Dynamic {
    * type TwoTrueStr = HList.`2, true, "str"`.T
    * }}}
    */
-  def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.hlistTypeImpl
+  def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.hlistType
 
   @tailrec
   def unsafeGet(l: HList, i: Int): Any =

--- a/core/src/main/scala/shapeless/labelled.scala
+++ b/core/src/main/scala/shapeless/labelled.scala
@@ -37,21 +37,20 @@ object labelled {
   }
 }
 
-trait DefaultSymbolicLabelling[T] extends DepFn0 with Serializable { type Out <: HList }
+trait Labelling[T] extends DepFn0 with Serializable { type Out <: HList }
 
-object DefaultSymbolicLabelling {
-  type Aux[T, Out0] = DefaultSymbolicLabelling[T] { type Out = Out0 }
+object Labelling {
+  type Aux[T, Out0] = Labelling[T] { type Out = Out0 }
 
-  def apply[T](implicit lab: DefaultSymbolicLabelling[T]): Aux[T, lab.Out] = lab
+  def apply[T](implicit lab: Labelling[T]): Aux[T, lab.Out] = lab
 
-  implicit def mkDefaultSymbolicLabelling[T]: DefaultSymbolicLabelling[T] =
+  implicit def mkDefaultSymbolicLabelling[T]: Labelling[T] =
     macro LabelledMacros.mkDefaultSymbolicLabellingImpl[T]
 
-  def instance[T, L <: HList](labels: L): Aux[T, L] =
-    new DefaultSymbolicLabelling[T] {
-      type Out = L
-      def apply(): L = labels
-    }
+  def instance[T, L <: HList](labels: L): Aux[T, L] = new Labelling[T] {
+    type Out = L
+    def apply(): L = labels
+  }
 }
 
 /**
@@ -115,7 +114,7 @@ class LabelledMacros(val c: whitebox.Context) extends SingletonTypeUtils with Ca
 
     val labelsType = mkHListTpe(labels.map(constantType))
     val labelsValue = mkHListValue(labels.map(Literal.apply))
-    val labelling = objectRef[DefaultSymbolicLabelling.type]
+    val labelling = objectRef[Labelling.type]
     q"$labelling.instance[$tpe, $labelsType]($labelsValue.asInstanceOf[$labelsType])"
   }
 

--- a/core/src/main/scala/shapeless/lenses.scala
+++ b/core/src/main/scala/shapeless/lenses.scala
@@ -22,7 +22,6 @@ import labelled.{ FieldType, field }
 import ops.coproduct.{ Inject, Selector => CSelector }
 import ops.hlist.{ At, Init, Last, Prepend, Selector, ReplaceAt, Replacer, Tupler }
 import ops.record.{ Selector => RSelector, Updater }
-import tag.@@
 
 trait Lens[S, A] extends LPLens[S, A] { outer =>
   def get(s: S): A
@@ -43,8 +42,9 @@ trait Lens[S, A] extends LPLens[S, A] { outer =>
 
   def >>(k: Witness)(implicit mkLens: MkFieldLens[A, k.T]): Lens[S, mkLens.Elem] = mkLens() compose this
 
-  def selectDynamic(k: String)
-    (implicit mkLens: MkSelectDynamicOptic[Lens[S, A], A, Symbol @@ k.type, Nothing]): mkLens.Out = mkLens(this)
+  def selectDynamic(k: String)(
+    implicit mkLens: MkSelectDynamicOptic[Lens[S, A], A, k.type, Nothing]
+  ): mkLens.Out = mkLens(this)
 
   def apply[B](implicit mkPrism: MkCtorPrism[A, B]): Prism[S, B] = mkPrism() compose this
 
@@ -62,8 +62,9 @@ trait Lens[S, A] extends LPLens[S, A] { outer =>
 }
 
 trait LPLens[S, A] extends Dynamic with Serializable { self: Lens[S, A] =>
-  def selectDynamic[B](k: String)
-    (implicit mkLens: MkSelectDynamicOptic[Lens[S, A], A, Symbol @@ k.type, B], dummy: DummyImplicit): mkLens.Out = mkLens(this)
+  def selectDynamic[B](k: String)(
+    implicit mkLens: MkSelectDynamicOptic[Lens[S, A], A, k.type, B], dummy: DummyImplicit
+  ): mkLens.Out = mkLens(this)
 }
 
 trait Prism[S, A] extends LPPrism[S, A] { outer =>
@@ -81,8 +82,9 @@ trait Prism[S, A] extends LPPrism[S, A] { outer =>
     def set(t: T)(a: A): T = g.modify(t)(outer.set(_)(a))
   }
 
-  def selectDynamic(k: String)
-    (implicit mkPrism: MkSelectDynamicOptic[Prism[S, A], A, Symbol @@ k.type, Nothing]): mkPrism.Out = mkPrism(this)
+  def selectDynamic(k: String)(
+    implicit mkPrism: MkSelectDynamicOptic[Prism[S, A], A, k.type, Nothing]
+  ): mkPrism.Out = mkPrism(this)
 
   def apply[B](implicit mkPrism: MkCtorPrism[A, B]): Prism[S, B] = mkPrism() compose this
 
@@ -106,8 +108,9 @@ trait Prism[S, A] extends LPPrism[S, A] { outer =>
 }
 
 trait LPPrism[S, A] extends Dynamic with Serializable { self: Prism[S, A] =>
-  def selectDynamic[B](k: String)
-    (implicit mkPrism: MkSelectDynamicOptic[Prism[S, A], A, Symbol @@ k.type, B], dummy: DummyImplicit): mkPrism.Out = mkPrism(this)
+  def selectDynamic[B](k: String)(
+    implicit mkPrism: MkSelectDynamicOptic[Prism[S, A], A, k.type, B], dummy: DummyImplicit
+  ): mkPrism.Out = mkPrism(this)
 }
 
 trait ProductLensBuilder[C, P <: Product] extends Lens[C, P] with Serializable {
@@ -538,14 +541,14 @@ trait Segment[P, S, T <: HList] {
 trait LowPrioritySegment {
   type Aux[P, S, T <: HList, Out0 <: HList] = Segment[P, S, T] { type Out = Out0 }
 
-  implicit def two[P, S, T <: HList]: Aux[P, S, T, Coselect[S] :: Select[Symbol @@ P] :: T] = new Segment[P, S, T] {
-    type Out = Coselect[S] :: Select[Symbol @@ P] :: T
+  implicit def two[P, S, T <: HList]: Aux[P, S, T, Coselect[S] :: Select[P] :: T] = new Segment[P, S, T] {
+    type Out = Coselect[S] :: Select[P] :: T
   }
 }
 
 object Segment extends LowPrioritySegment {
-  implicit def one[P, T <: HList]: Aux[P, Nothing, T, Select[Symbol @@ P] :: T] = new Segment[P, Nothing, T] {
-    type Out = Select[Symbol @@ P] :: T
+  implicit def one[P, T <: HList]: Aux[P, Nothing, T, Select[P] :: T] = new Segment[P, Nothing, T] {
+    type Out = Select[P] :: T
   }
 }
 

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -2371,28 +2371,32 @@ object hlist {
    *
    * @author Cody Allen
    */
-  trait ZipWithKeys[K <: HList, V <: HList] extends DepFn1[V] with Serializable { type Out <: HList }
+  sealed abstract class ZipWithKeys[K <: HList, V <: HList] extends DepFn1[V] with Serializable {
+    type Out <: HList
+  }
 
   object ZipWithKeys {
     import shapeless.labelled._
 
-    def apply[K <: HList, V <: HList]
-      (implicit zipWithKeys: ZipWithKeys[K, V]): Aux[K, V, zipWithKeys.Out] = zipWithKeys
-
-    type Aux[K <: HList, V <: HList, Out0 <: HList] = ZipWithKeys[K, V] { type Out = Out0 }
-
-    implicit val hnilZipWithKeys: Aux[HNil, HNil, HNil] = new ZipWithKeys[HNil, HNil] {
-      type Out = HNil
-      def apply(v: HNil) = HNil
+    private val instance = new ZipWithKeys[HList, HList] {
+      type Out = HList
+      def apply(v: HList): HList = v
     }
 
-    implicit def hconsZipWithKeys[KH, VH, KT <: HList, VT <: HList, ZwkOut <: HList] (implicit zipWithKeys: ZipWithKeys.Aux[KT, VT, ZwkOut], wkh: Witness.Aux[KH])
-        : Aux[KH :: KT, VH :: VT, FieldType[KH, VH] :: ZwkOut] =
-          new ZipWithKeys[KH :: KT, VH :: VT] {
-            type Out = FieldType[KH, VH] :: ZwkOut
-            def apply(v: VH :: VT): Out =
-              field[wkh.T](v.head) :: zipWithKeys(v.tail)
-          }
+    def apply[K <: HList, V <: HList](
+      implicit zipWithKeys: ZipWithKeys[K, V]
+    ): Aux[K, V, zipWithKeys.Out] = zipWithKeys
+
+    type Aux[K <: HList, V <: HList, Out0 <: HList] =
+      ZipWithKeys[K, V] { type Out = Out0 }
+
+    implicit def hnilZipWithKeys: Aux[HNil, HNil, HNil] =
+      instance.asInstanceOf[Aux[HNil, HNil, HNil]]
+
+    implicit def hconsZipWithKeys[KH, VH, KT <: HList, VT <: HList, KVT <: HList](
+      implicit wkh: Witness.Aux[KH], zipWithKeys: ZipWithKeys.Aux[KT, VT, KVT]
+    ): Aux[KH :: KT, VH :: VT, FieldType[KH, VH] :: KVT] =
+      instance.asInstanceOf[Aux[KH :: KT, VH :: VT, FieldType[KH, VH] :: KVT]]
   }
 
   /**

--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -34,43 +34,37 @@ package record {
    *
    * @author Miles Sabin
    */
-  @annotation.implicitNotFound(msg = "No field ${K} in record ${L}")
-  trait Selector[L <: HList, K] extends DepFn1[L] with Serializable {
-    type Out
-    def apply(l : L): Out
-  }
+  @annotation.implicitNotFound(msg = "No field ${K} in record ${R}")
+  sealed abstract class Selector[R <: HList, K] extends DepFn1[R] with Serializable
 
   object Selector {
-    type Aux[L <: HList, K, Out0] = Selector[L, K] { type Out = Out0 }
+    type Aux[R <: HList, K, O] = Selector[R, K] { type Out = O }
+    def apply[R <: HList, K](implicit selector: Selector[R, K]): Aux[R, K, selector.Out] = selector
 
-    def apply[L <: HList, K](implicit selector: Selector[L, K]): Aux[L, K, selector.Out] = selector
-
-    implicit def mkSelector[L <: HList, K, O]: Aux[L, K, O] = macro SelectorMacros.applyImpl[L, K]
+    implicit def materialize[R <: HList, K, O]: Aux[R, K, O] =
+      macro SelectorMacros.materialize[R, K]
   }
 
-  class UnsafeSelector(i: Int) extends Selector[HList, Any] {
+  final class UnsafeSelector(i: Int) extends Selector[HList, Any] {
     type Out = Any
-    def apply(l: HList): Any = HList.unsafeGet(l, i)
+    def apply(record: HList): Any = HList.unsafeGet(record, i)
   }
 
   @macrocompat.bundle
   class SelectorMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 
-    def applyImpl[L <: HList, K](implicit lTag: WeakTypeTag[L], kTag: WeakTypeTag[K]): Tree = {
-      val lTpe = lTag.tpe.dealias
-      val kTpe = kTag.tpe.dealias
-      if(!(lTpe <:< hlistTpe))
-        abort(s"$lTpe is not a record type")
+    def materialize[R <: HList: WeakTypeTag, K: WeakTypeTag]: Tree = {
+      val record = weakTypeOf[R].dealias
+      val key = weakTypeOf[K].dealias
+      if (!(record <:< hlistTpe))
+        abort(s"$record is not a record type")
 
-      findField(lTpe, kTpe) match {
+      findField(record, key) match {
         case Some((v, i)) =>
-          q"""
-            new _root_.shapeless.ops.record.UnsafeSelector($i).
-              asInstanceOf[_root_.shapeless.ops.record.Selector.Aux[$lTpe, $kTpe, $v]]
-          """
+          q"new ${typeOf[UnsafeSelector]}($i).asInstanceOf[${reify(Selector)}.Aux[$record, $key, $v]]"
         case _ =>
-          abort(s"No field $kTpe in record type $lTpe")
+          abort(s"No field $key in record type $record")
       }
     }
   }
@@ -110,42 +104,42 @@ package record {
    *
    * @author Miles Sabin
    */
-  trait Updater[L <: HList, F] extends DepFn2[L, F] with Serializable { type Out <: HList }
-
-  object Updater {
-    type Aux[L <: HList, F, Out0 <: HList] = Updater[L, F] { type Out = Out0 }
-
-    def apply[L <: HList, F](implicit updater: Updater[L, F]): Aux[L, F, updater.Out] = updater
-
-    implicit def mkUpdater[L <: HList, F, O]: Aux[L, F, O] = macro UpdaterMacros.applyImpl[L, F]
+  @annotation.implicitNotFound(msg = "No element of type ${E} in ${L}")
+  sealed abstract class Updater[L <: HList, E] extends DepFn2[L, E] with Serializable {
+    type Out <: HList
   }
 
-  class UnsafeUpdater(i: Int) extends Updater[HList, Any] {
+  object Updater {
+    type Aux[L <: HList, E, O <: HList] = Updater[L, E] { type Out = O }
+    def apply[L <: HList, E](implicit updater: Updater[L, E]): Aux[L, E, updater.Out] = updater
+
+    implicit def meterialize[L <: HList, F, O]: Aux[L, F, O] =
+      macro UpdaterMacros.materialize[L, F]
+  }
+
+  final class UnsafeUpdater(i: Int) extends Updater[HList, Any] {
     type Out = HList
-    def apply(l: HList, f: Any): HList = HList.unsafeUpdateAppend(l, i, f)
+    def apply(l: HList, e: Any): HList = HList.unsafeUpdateAppend(l, i, e)
   }
 
   @macrocompat.bundle
   class UpdaterMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 
-    def applyImpl[L <: HList, F](implicit lTag: WeakTypeTag[L], fTag: WeakTypeTag[F]): Tree = {
-      val lTpe = lTag.tpe.dealias
-      val fTpe = fTag.tpe.dealias
-      if(!(lTpe <:< hlistTpe))
-        abort(s"$lTpe is not a record type")
+    def materialize[L <: HList: WeakTypeTag, E: WeakTypeTag]: Tree = {
+      val list = weakTypeOf[L].dealias
+      val element = weakTypeOf[E].dealias
+      if (!(list <:< hlistTpe))
+        abort(s"$list is not a record type")
 
-      val lTpes = unpackHListTpe(lTpe)
-      val (uTpes, i) = {
-        val i0 = lTpes.indexWhere(_ =:= fTpe)
-        if(i0 < 0) (lTpes :+ fTpe, lTpes.length)
-        else (lTpes.updated(i0, fTpe), i0)
+      val (updated, i) = {
+        val elements = unpackHList(list)
+        val i = elements.indexWhere(_ =:= element)
+        if (i < 0) (elements :+ element, elements.length)
+        else (elements.updated(i, element), i)
       }
-      val uTpe = mkHListTpe(uTpes)
-      q"""
-        new _root_.shapeless.ops.record.UnsafeUpdater($i)
-          .asInstanceOf[_root_.shapeless.ops.record.Updater.Aux[$lTpe, $fTpe, $uTpe]]
-      """
+
+      q"new ${typeOf[UnsafeUpdater]}($i).asInstanceOf[${reify(Updater)}.Aux[$list, $element, ${mkHListTpe(updated)}]]"
     }
   }
 
@@ -354,60 +348,43 @@ package record {
    *
    * @author Joni Freeman
    */
-  @annotation.implicitNotFound(msg = "No field ${F} with value of type ${A} in record ${L}")
-  trait Modifier[L <: HList, F, A, B] extends DepFn2[L, A => B] with Serializable { type Out <: HList }
-
-  object Modifier {
-    def apply[L <: HList, F, A, B](implicit modifier: Modifier[L, F, A, B]): Aux[L, F, A, B, modifier.Out] = modifier
-
-    type Aux[L <: HList, F, A, B, Out0 <: HList] = Modifier[L, F, A, B] { type Out = Out0 }
-
-    implicit def mkModifier[L <: HList, K, A, B, O <: HList]: Aux[L, K, A, B, O] = macro ModifierMacros.applyImpl[L, K, A, B]
-
-    @deprecated("Retained for binary compatability", "2.3.1")
-    def hlistModify1[F, A, B, T <: HList]: Aux[FieldType[F, A] :: T, F, A, B, FieldType[F, B] :: T] =
-      new Modifier[FieldType[F, A] :: T, F, A, B] {
-        type Out = FieldType[F, B] :: T
-        def apply(l: FieldType[F, A] :: T, f: A => B): Out = field[F](f(l.head)) :: l.tail
-      }
-
-    @deprecated("Retained for binary compatability", "2.3.1")
-    def hlistModify[H, T <: HList, F, A, B]
-      (implicit mt: Modifier[T, F, A, B]): Aux[H :: T, F, A, B, H :: mt.Out] =
-        new Modifier[H :: T, F, A, B] {
-          type Out = H :: mt.Out
-          def apply(l: H :: T, f: A => B): Out = l.head :: mt(l.tail, f)
-        }
+  @annotation.implicitNotFound(msg = "No field ${K} with value of type ${A} in record ${R}")
+  sealed abstract class Modifier[R <: HList, K, A, B] extends DepFn2[R, A => B] with Serializable {
+    type Out <: HList
   }
 
-  class UnsafeModifier(i: Int) extends Modifier[HList, Any, Any, Any] {
+  object Modifier {
+    type Aux[R <: HList, K, A, B, O <: HList] = Modifier[R, K, A, B] { type Out = O }
+    def apply[R <: HList, K, A, B](implicit modifier: Modifier[R, K, A, B]): Aux[R, K, A, B, modifier.Out] = modifier
+
+    implicit def materialize[R <: HList, K, A, B, O <: HList]: Aux[R, K, A, B, O] =
+      macro ModifierMacros.materialize[R, K, A, B]
+  }
+
+  final class UnsafeModifier(i: Int) extends Modifier[HList, Any, Any, Any] {
     type Out = HList
-    def apply(l: HList, f: Any => Any): HList = HList.unsafeUpdateWith(l, i, f)
+    def apply(record: HList, f: Any => Any): HList = HList.unsafeUpdateWith(record, i, f)
   }
 
   @macrocompat.bundle
   class ModifierMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 
-    def applyImpl[L <: HList, K, A, B]
-      (implicit lTag: WeakTypeTag[L], kTag: WeakTypeTag[K], aTag: WeakTypeTag[A], bTag: WeakTypeTag[B]): Tree = {
-      val lTpe = lTag.tpe.dealias
-      val kTpe = kTag.tpe.dealias
-      if(!(lTpe <:< hlistTpe))
-        abort(s"$lTpe is not a record type")
-      val aTpe = aTag.tpe
-      val bTpe = bTag.tpe
+    def materialize[R <: HList: WeakTypeTag, K: WeakTypeTag, A: WeakTypeTag, B: WeakTypeTag]: Tree = {
+      val record = weakTypeOf[R].dealias
+      val key = weakTypeOf[K].dealias
+      if (!(record <:< hlistTpe))
+        abort(s"$record is not a record type")
 
-      findField(lTpe, kTpe) match {
-        case Some((v, i)) if v <:< aTpe =>
-          val (prefix, List(_, suffix @ _*)) = unpackHListTpe(lTpe).splitAt(i)
-          val outTpe = mkHListTpe(prefix ++ (FieldType(kTpe, bTpe) :: suffix.toList))
-          q"""
-            new _root_.shapeless.ops.record.UnsafeModifier($i).
-              asInstanceOf[_root_.shapeless.ops.record.Modifier.Aux[$lTpe, $kTpe, $aTpe, $bTpe, $outTpe]]
-          """
+      val a = weakTypeOf[A]
+      val b = weakTypeOf[B]
+      val fields = unpackHList(record)
+      findField(fields, key) match {
+        case Some((v, i)) if v <:< a =>
+          val out = mkHListTpe(fields.updated(i, FieldType(key, b)))
+          q"new ${typeOf[UnsafeModifier]}($i).asInstanceOf[${reify(Modifier)}.Aux[$record, $key, $a, $b, $out]]"
         case _ =>
-          abort(s"No field $kTpe in record type $lTpe")
+          abort(s"No field $key in record type $record")
       }
     }
   }
@@ -417,62 +394,42 @@ package record {
    *
    * @author Miles Sabin
    */
-  @annotation.implicitNotFound(msg = "No field ${K} in record ${L}")
-  trait Remover[L <: HList, K] extends DepFn1[L] with Serializable
-
-  trait LowPriorityRemover {
-    type Aux[L <: HList, K, Out0] = Remover[L, K] { type Out = Out0 }
-
-    @deprecated("Retained for binary compatability", "2.3.1")
-    def hlistRemove[H, T <: HList, K, V, OutT <: HList]
-      (implicit rt: Aux[T, K, (V, OutT)]): Aux[H :: T, K, (V, H :: OutT)] =
-        new Remover[H :: T, K] {
-          type Out = (V, H :: OutT)
-          def apply(l : H :: T): Out = {
-            val (v, tail) = rt(l.tail)
-            (v, l.head :: tail)
-          }
-        }
+  @annotation.implicitNotFound(msg = "No field ${K} in record ${R}")
+  sealed abstract class Remover[R <: HList, K] extends DepFn1[R] with Serializable {
+    type Out <: (Any, HList)
   }
 
-  object Remover extends LowPriorityRemover {
-    def apply[L <: HList, K](implicit remover: Remover[L, K]): Aux[L, K, remover.Out] = remover
+  object Remover {
+    type Aux[R <: HList, K, O] = Remover[R, K] { type Out = O }
+    def apply[R <: HList, K](implicit remover: Remover[R, K]): Aux[R, K, remover.Out] = remover
 
-    implicit def mkRemover[L <: HList, K, V, O <: HList]: Aux[L, K, (V, O)] = macro RemoverMacros.applyImpl[L, K]
-
-    @deprecated("Retained for binary compatability", "2.3.1")
-    def hlistRemove1[K, V, T <: HList]: Aux[FieldType[K, V] :: T, K, (V, T)] =
-      new Remover[FieldType[K, V] :: T, K] {
-        type Out = (V, T)
-        def apply(l: FieldType[K, V] :: T): Out = (l.head, l.tail)
-      }
+    implicit def materialize[R <: HList, K, V, O <: HList]: Aux[R, K, (V, O)] =
+      macro RemoverMacros.materialize[R, K]
   }
 
-  class UnsafeRemover(i: Int) extends Remover[HList, Any] {
+  final class UnsafeRemover(i: Int) extends Remover[HList, Any] {
     type Out = (Any, HList)
-    def apply(l: HList): (Any, HList) = HList.unsafeRemove(l, i)
+    def apply(record: HList): (Any, HList) = HList.unsafeRemove(record, i)
   }
 
   @macrocompat.bundle
   class RemoverMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 
-    def applyImpl[L <: HList, K](implicit lTag: WeakTypeTag[L], kTag: WeakTypeTag[K]): Tree = {
-      val lTpe = lTag.tpe.dealias
-      val kTpe = kTag.tpe.dealias
-      if(!(lTpe <:< hlistTpe))
-        abort(s"$lTpe is not a record type")
+    def materialize[R <: HList: WeakTypeTag, K: WeakTypeTag]: Tree = {
+      val record = weakTypeOf[R].dealias
+      val key = weakTypeOf[K].dealias
+      if (!(record <:< hlistTpe))
+        abort(s"$record is not a record type")
 
-      findField(lTpe, kTpe) match {
+      val fields = unpackHList(record)
+      findField(fields, key) match {
         case Some((v, i)) =>
-          val (prefix, List(_, suffix @ _*)) = unpackHListTpe(lTpe).splitAt(i)
-          val outTpe = mkHListTpe(prefix ++ suffix)
-          q"""
-            new _root_.shapeless.ops.record.UnsafeRemover($i).
-              asInstanceOf[_root_.shapeless.ops.record.Remover.Aux[$lTpe, $kTpe, ($v, $outTpe)]]
-          """
+          val (prefix, suffix) = fields.splitAt(i)
+          val out = mkHListTpe(prefix ++ suffix.tail)
+          q"new ${typeOf[UnsafeRemover]}($i).asInstanceOf[${reify(Remover)}.Aux[$record, $key, ($v, $out)]]"
         case _ =>
-          abort(s"No field $kTpe in record type $lTpe")
+          abort(s"No field $key in record type $record")
       }
     }
   }
@@ -592,29 +549,28 @@ package record {
         }
   }
 
-  trait LacksKey[L <: HList, K]
-
+  @annotation.implicitNotFound(msg = "Record ${R} contains field ${K}")
+  final class LacksKey[R <: HList, K]
   object LacksKey {
-    implicit def apply[L <: HList, K]: LacksKey[L, K] = macro LacksKeyMacros.applyImpl[L, K]
+    def apply[R <: HList, K](implicit ev: LacksKey[R, K]): LacksKey[R, K] = ev
+
+    implicit def materialize[R <: HList, K]: LacksKey[R, K] =
+      macro LacksKeyMacros.materialize[R, K]
   }
 
   @macrocompat.bundle
   class LacksKeyMacros(val c: whitebox.Context) extends CaseClassMacros {
     import c.universe._
 
-    def applyImpl[L <: HList, K](implicit lTag: WeakTypeTag[L], kTag: WeakTypeTag[K]): Tree = {
-      val lTpe = lTag.tpe.dealias
-      val kTpe = kTag.tpe.dealias
-      if(!(lTpe <:< hlistTpe))
-        abort(s"$lTpe is not a record type")
+    def materialize[R <: HList: WeakTypeTag, K: WeakTypeTag]: Tree = {
+      val record = weakTypeOf[R].dealias
+      val key = weakTypeOf[K].dealias
+      if (!(record <:< hlistTpe))
+        abort(s"$record is not a record type")
 
-      findField(lTpe, kTpe) match {
-        case None =>
-          q"""
-            new _root_.shapeless.ops.record.LacksKey[$lTpe, $kTpe] {}
-          """
-        case _ =>
-          abort(s"Record type $lTpe contains field $kTpe")
+      findField(record, key) match {
+        case None => q"new ${weakTypeOf[LacksKey[R, K]]}"
+        case _ => abort(s"Record type $record contains field $key")
       }
     }
   }

--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -631,13 +631,14 @@ package record {
 
     type Aux[L <: HList, Out0 <: HList] = Keys[L] { type Out = Out0 }
 
-    implicit def hnilKeys[L <: HNil]: Aux[L, HNil] =
-      new Keys[L] {
-        type Out = HNil
-        def apply(): Out = HNil
-      }
+    implicit val hnilKeys: Aux[HNil, HNil] = new Keys[HNil] {
+      type Out = HNil
+      def apply(): Out = HNil
+    }
 
-    implicit def hlistKeys[K, V, T <: HList](implicit wk: Witness.Aux[K], kt: Keys[T]): Aux[FieldType[K, V] :: T, K :: kt.Out] =
+    implicit def hlistKeys[K, V, T <: HList](
+      implicit wk: Witness.Aux[K], kt: Keys[T]
+    ): Aux[FieldType[K, V] :: T, K :: kt.Out] =
       new Keys[FieldType[K, V] :: T] {
         type Out = K :: kt.Out
         def apply(): Out = wk.value :: kt()

--- a/core/src/main/scala/shapeless/records.scala
+++ b/core/src/main/scala/shapeless/records.scala
@@ -58,7 +58,7 @@ object record {
   object Record extends Dynamic {
     def applyDynamic(method: String)(rec: Any*): HList = macro RecordMacros.mkRecordEmptyImpl
     def applyDynamicNamed(method: String)(rec: Any*): HList = macro RecordMacros.mkRecordNamedImpl
-    def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.recordTypeImpl
+    def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.recordType
   }
 }
 

--- a/core/src/main/scala/shapeless/syntax/records.scala
+++ b/core/src/main/scala/shapeless/syntax/records.scala
@@ -18,7 +18,6 @@ package shapeless
 package syntax
 
 import scala.language.dynamics
-import tag.@@
 
 /**
  * Record operations on `HList`'s with field-like elements.
@@ -164,5 +163,5 @@ final case class DynamicRecordOps[L <: HList](l : L) extends Dynamic {
   /**
    * Allows dynamic-style access to fields of the record whose keys are Symbols.
    */
-  def selectDynamic(key: String)(implicit selector: Selector[L, Symbol @@ key.type]): selector.Out = selector(l)
+  def selectDynamic(key: String)(implicit selector: Selector[L, key.type]): selector.Out = selector(l)
 }

--- a/core/src/main/scala/shapeless/syntax/unions.scala
+++ b/core/src/main/scala/shapeless/syntax/unions.scala
@@ -18,7 +18,6 @@ package shapeless
 package syntax
 
 import scala.language.dynamics
-import tag.@@
 
 /**
  * Discriminated union operations on `Coproducts`'s with field-like elements.
@@ -87,5 +86,5 @@ final case class DynamicUnionOps[C <: Coproduct](c : C) extends Dynamic {
   /**
    * Allows dynamic-style access to fields of the union whose keys are Symbols.
    */
-  def selectDynamic(key: String)(implicit selector: Selector[C, Symbol @@ key.type]): selector.Out = selector(c)
+  def selectDynamic(key: String)(implicit selector: Selector[C, key.type]): selector.Out = selector(c)
 }

--- a/core/src/main/scala/shapeless/unions.scala
+++ b/core/src/main/scala/shapeless/unions.scala
@@ -52,7 +52,7 @@ object union {
    */
   object Union extends Dynamic {
     def applyDynamicNamed[U <: Coproduct](method: String)(elems: Any*): U = macro UnionMacros.mkUnionNamedImpl[U]
-    def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.unionTypeImpl
+    def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.unionType
   }
 }
 

--- a/core/src/main/scala/shapeless/unions.scala
+++ b/core/src/main/scala/shapeless/unions.scala
@@ -36,7 +36,7 @@ object union {
    * appears to the compiler as stable,
    *
    * {{{
-   * type Xyz = Union.`'x -> Int, 'y -> String, 'z -> Boolean`.T
+   * type Xyz = Union.`"x" -> Int, "y" -> String, "z" -> Boolean`.T
    * }}}
    *
    * The use of singleton-typed `Symbols` as keys would make this type extremely
@@ -47,12 +47,11 @@ object union {
    *
    * {{{
    * val y = Union[Xyz](y = "foo")
-   * y.get('y) // == Some("foo")
+   * y.get("y") // == Some("foo")
    * }}}
    */
   object Union extends Dynamic {
     def applyDynamicNamed[U <: Coproduct](method: String)(elems: Any*): U = macro UnionMacros.mkUnionNamedImpl[U]
-
     def selectDynamic(tpeSelector: String): Any = macro LabelledMacros.unionTypeImpl
   }
 }
@@ -63,13 +62,9 @@ class UnionMacros(val c: whitebox.Context) {
   import internal.constantType
   import labelled.FieldType
 
-  val fieldTypeTpe = typeOf[FieldType[_, _]].typeConstructor
-  val SymTpe = typeOf[scala.Symbol]
-  val atatTpe = typeOf[tag.@@[_,_]].typeConstructor
-
   def mkUnionNamedImpl[U <: Coproduct : WeakTypeTag](method: Tree)(elems: Tree*): Tree = {
-    def mkSingletonSymbolType(c: Constant): Type =
-      appliedType(atatTpe, List(SymTpe, constantType(c)))
+    val fieldTypeTpe = typeOf[FieldType[_, _]].typeConstructor
+    val coproduct = reify(Coproduct)
 
     def mkFieldTpe(keyTpe: Type, valueTpe: Type): Type =
       appliedType(fieldTypeTpe, List(keyTpe, valueTpe.widen))
@@ -78,22 +73,19 @@ class UnionMacros(val c: whitebox.Context) {
       q"$value.asInstanceOf[${mkFieldTpe(keyTpe, value.tpe)}]"
 
     def promoteElem(elem: Tree): Tree = elem match {
-      case q""" $prefix(${Literal(k: Constant)}, $v) """ => mkElem(mkSingletonSymbolType(k), v)
-      case _ =>
-        c.abort(c.enclosingPosition, s"$elem has the wrong shape for a record field")
+      case q"$_(${Literal(k)}, $v)" => mkElem(constantType(k), v)
+      case _ => c.abort(c.enclosingPosition, s"$elem has the wrong shape for a record field")
     }
 
     val q"${methodString: String}" = method
-    if(methodString != "apply")
+    if (methodString != "apply")
       c.abort(c.enclosingPosition, s"this method must be called as 'apply' not '$methodString'")
 
-    val elem =
-      elems match {
-        case Seq(e) => e
-        case _ =>
-          c.abort(c.enclosingPosition, s"only one branch of a union may be inhabited")
-      }
+    val elem = elems match {
+      case Seq(e) => e
+      case _ => c.abort(c.enclosingPosition, "only one branch of a union may be inhabited")
+    }
 
-    q""" _root_.shapeless.Coproduct[${weakTypeOf[U]}](${promoteElem(elem)}) """
+    q"$coproduct[${weakTypeOf[U]}](${promoteElem(elem)})"
   }
 }

--- a/core/src/test/scala/shapeless/default.scala
+++ b/core/src/test/scala/shapeless/default.scala
@@ -109,7 +109,7 @@ class DefaultTests {
   @Test
   def simpleAsRecord: Unit = {
     val default = Default.AsRecord[CC].apply()
-    assertTypedEquals[Record.`'s -> String, 'flagOpt -> Option[Boolean]`.T](
+    assertTypedEquals[Record.`"s" -> String, "flagOpt" -> Option[Boolean]`.T](
       Record(s = "b", flagOpt = Some(true)),
       default
     )
@@ -118,7 +118,7 @@ class DefaultTests {
   @Test
   def simpleFromPathAsRecord: Unit = {
     val default = Default.AsRecord[definitions.CC].apply()
-    assertTypedEquals[Record.`'s -> String, 'flagOpt -> Option[Boolean]`.T](
+    assertTypedEquals[Record.`"s" -> String, "flagOpt" -> Option[Boolean]`.T](
       Record(s = "b", flagOpt = Some(true)),
       default
     )

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -3154,7 +3154,7 @@ class HListTests {
     NonSingletonHNilTC(SFoo())
 
     val quux = Quux(23, "foo", true)
-    val ib = selectAll(Symbol("i"), Symbol("b")).from(quux)
+    val ib = selectAll("i", "b").from(quux)
     typed[(Int, Boolean)](ib)
     assertEquals((23, true), ib)
   }

--- a/core/src/test/scala/shapeless/implicits.scala
+++ b/core/src/test/scala/shapeless/implicits.scala
@@ -182,8 +182,8 @@ class CachedTest {
     val h: Int = gen.to(q).head
     val th: String = gen.to(q).tail.head
 
-    val lh: FieldType[Witness.`'i`.T, Int] = lgen.to(q).head
-    val lth: FieldType[Witness.`'s`.T, String] = lgen.to(q).tail.head
+    val lh: FieldType[Witness.`"i"`.T, Int] = lgen.to(q).head
+    val lth: FieldType[Witness.`"s"`.T, String] = lgen.to(q).tail.head
   }
 
   @Test

--- a/core/src/test/scala/shapeless/labelledgeneric.scala
+++ b/core/src/test/scala/shapeless/labelledgeneric.scala
@@ -57,11 +57,11 @@ object LabelledGenericTestsAux {
     (Symbol("authors") ->> Seq("Erich Gamma", "Richard Helm", "Ralph Johnson", "John Vlissides")) ::
     HNil
 
-  type BookRec = Record.`'author -> String, 'title -> String, 'id -> Int, 'price -> Double`.T
+  type BookRec = Record.`"author" -> String, "title" -> String, "id" -> Int, "price" -> Double`.T
   type BookKeys = Keys[BookRec]
   type BookValues = Values[BookRec]
 
-  type BookWithMultipleAuthorsRec = Record.`'title -> String, 'id -> Int, 'authors -> Seq[String]`.T
+  type BookWithMultipleAuthorsRec = Record.`"title" -> String, "id" -> Int, "authors" -> Seq[String]`.T
 
 
   sealed trait Tree
@@ -106,54 +106,35 @@ object ScalazTaggedAux {
   }
 
   object TC extends TCLowPriority {
-    implicit val intTC: TC[Int] =
-      new TC[Int] {
-        def apply() = "Int"
-      }
+    implicit val intTC: TC[Int] = instance("Int")
+    implicit val booleanTC: TC[Boolean] = instance("Boolean")
+    implicit val taggedIntTC: TC[Int @@ CustomTag] = instance("TaggedInt")
+    implicit val hnilTC: TC[HNil] = instance("HNil")
 
-    implicit val booleanTC: TC[Boolean] =
-      new TC[Boolean] {
-        def apply() = "Boolean"
-      }
+    implicit def hconsTC[K <: String, H, T <: HList](
+      implicit key: Witness.Aux[K], headTC: Lazy[TC[H]], tailTC: TC[T]
+    ): TC[FieldType[K, H] :: T] = instance {
+      s"${key.value}: ${headTC.value()} :: ${tailTC()}"
+    }
 
-    implicit val taggedIntTC: TC[Int @@ CustomTag] =
-      new TC[Int @@ CustomTag] {
-        def apply() = s"TaggedInt"
-      }
-
-    implicit val hnilTC: TC[HNil] =
-      new TC[HNil] {
-        def apply() = "HNil"
-      }
-
-    implicit def hconsTC[K <: Symbol, H, T <: HList](implicit
-      key: Witness.Aux[K],
-      headTC: Lazy[TC[H]],
-      tailTC: TC[T]
-    ): TC[FieldType[K, H] :: T] =
-      new TC[FieldType[K, H] :: T] {
-        def apply() = s"${key.value.name}: ${headTC.value()} :: ${tailTC()}"
-      }
-
-    implicit def projectTC[F, G](implicit
-      lgen: LabelledGeneric.Aux[F, G],
-      tc: Lazy[TC[G]]
-    ): TC[F] =
-      new TC[F] {
-        def apply() = s"Proj(${tc.value()})"
-      }
+    implicit def projectTC[F, G](
+      implicit lgen: LabelledGeneric.Aux[F, G], tc: Lazy[TC[G]]
+    ): TC[F] = instance {
+      s"Proj(${tc.value()})"
+    }
   }
 
   abstract class TCLowPriority {
+    def instance[T](display: String): TC[T] = new TC[T] {
+      def apply(): String = display
+    }
+
     // FIXME: Workaround #309
-    implicit def hconsTCTagged[K <: Symbol, H, HT, T <: HList](implicit
-      key: Witness.Aux[K],
-      headTC: Lazy[TC[H @@ HT]],
-      tailTC: TC[T]
-    ): TC[FieldType[K, H @@ HT] :: T] =
-      new TC[FieldType[K, H @@ HT] :: T] {
-        def apply() = s"${key.value.name}: ${headTC.value()} :: ${tailTC()}"
-      }
+    implicit def hconsTCTagged[K <: String, H, HT, T <: HList](
+      implicit key: Witness.Aux[K], headTC: Lazy[TC[H @@ HT]], tailTC: TC[T]
+    ): TC[FieldType[K, H @@ HT] :: T] = instance {
+      s"${key.value}: ${headTC.value()} :: ${tailTC()}"
+    }
   }
 }
 
@@ -173,7 +154,7 @@ class LabelledGenericTests {
     assertEquals(tapl, b1)
 
     val keys = b0.keys
-    assertEquals(Symbol("author").narrow :: Symbol("title").narrow :: Symbol("id").narrow :: Symbol("price").narrow :: HNil, keys)
+    assertEquals("author".narrow :: "title".narrow :: "id".narrow :: "price".narrow :: HNil, keys)
 
     val values = b0.values
     assertEquals("Benjamin Pierce" :: "Types and Programming Languages" :: 262162091 :: 44.11 :: HNil, values)
@@ -185,11 +166,11 @@ class LabelledGenericTests {
     val gen2 = LabelledGeneric[Private2]
     val gen3 = LabelledGeneric[Private3]
     val gen4 = LabelledGeneric[Private4]
-    val ab = Symbol("a").narrow :: Symbol("b").narrow :: HNil
+    val ab = "a".narrow :: "b".narrow :: HNil
 
     val p1 = Private1(1)
     val r1 = gen1.to(p1)
-    assertTypedEquals(Symbol("a").narrow :: HNil, r1.keys)
+    assertTypedEquals("a".narrow :: HNil, r1.keys)
     assertTypedEquals(1 :: HNil, r1.values)
     assertEquals(p1, gen1.from(r1))
 
@@ -221,7 +202,7 @@ class LabelledGenericTests {
     assertEquals(dpRecord, b0)
 
     val keys = b0.keys
-    assertEquals(Symbol("title").narrow :: Symbol("id").narrow :: Symbol("authors").narrow :: HNil, keys)
+    assertEquals("title".narrow :: "id".narrow :: "authors".narrow :: HNil, keys)
 
     val values = b0.values
     assertEquals(
@@ -236,19 +217,19 @@ class LabelledGenericTests {
 
     val b0 = gen.to(tapl)
 
-    val e1 = b0.get(Symbol("author"))
+    val e1 = b0.get("author")
     typed[String](e1)
     assertEquals("Benjamin Pierce", e1)
 
-    val e2 = b0.get(Symbol("title"))
+    val e2 = b0.get("title")
     typed[String](e2)
     assertEquals( "Types and Programming Languages", e2)
 
-    val e3 = b0.get(Symbol("id"))
+    val e3 = b0.get("id")
     typed[Int](e3)
     assertEquals(262162091, e3)
 
-    val e4 = b0.get(Symbol("price"))
+    val e4 = b0.get("price")
     typed[Double](e4)
     assertEquals(44.11, e4, Double.MinPositiveValue)
   }
@@ -259,19 +240,19 @@ class LabelledGenericTests {
 
     val b0 = gen.to(tapl)
 
-    val e1 = b0(Symbol("author"))
+    val e1 = b0("author")
     typed[String](e1)
     assertEquals("Benjamin Pierce", e1)
 
-    val e2 = b0(Symbol("title"))
+    val e2 = b0("title")
     typed[String](e2)
     assertEquals( "Types and Programming Languages", e2)
 
-    val e3 = b0(Symbol("id"))
+    val e3 = b0("id")
     typed[Int](e3)
     assertEquals(262162091, e3)
 
-    val e4 = b0(Symbol("price"))
+    val e4 = b0("price")
     typed[Double](e4)
     assertEquals(44.11, e4, Double.MinPositiveValue)
   }
@@ -305,8 +286,8 @@ class LabelledGenericTests {
 
     val b0 = gen.to(tapl)
 
-    val b1 = b0.updated(Symbol("title"), "Types and Programming Languages (2nd Ed.)")
-    val b2 = b1.updated(Symbol("price"), 46.11)
+    val b1 = b0.updated("title", "Types and Programming Languages (2nd Ed.)")
+    val b2 = b1.updated("price", 46.11)
 
     val updated = gen.from(b2)
     assertEquals(tapl2, updated)
@@ -318,8 +299,8 @@ class LabelledGenericTests {
 
     val b0 = gen.to(tapl)
 
-    val b1 = b0.updateWith(Symbol("title"))(_+" (2nd Ed.)")
-    val b2 = b1.updateWith(Symbol("price"))(_+2.0)
+    val b1 = b0.updateWith("title")(_+" (2nd Ed.)")
+    val b2 = b1.updateWith("price")(_+2.0)
 
     val updated = gen.from(b2)
     assertEquals(tapl2, updated)
@@ -331,7 +312,7 @@ class LabelledGenericTests {
     val gen2 = LabelledGeneric[ExtendedBook]
 
     val b0 = gen.to(tapl)
-    val b1 = b0 + (Symbol("inPrint") ->> true)
+    val b1 = b0 + ("inPrint" ->> true)
 
     val b2 = gen2.from(b1)
     typed[ExtendedBook](b2)
@@ -340,7 +321,7 @@ class LabelledGenericTests {
 
   @Test
   def testCoproductBasics: Unit = {
-    type TreeUnion = Union.`'Leaf -> Leaf, 'Node -> Node`.T
+    type TreeUnion = Union.`"Leaf" -> Leaf, "Node" -> Node`.T
 
     val gen = LabelledGeneric[Tree]
 
@@ -355,35 +336,35 @@ class LabelledGenericTests {
     val nccb = new NonCCB(true, 2.0)
     val ancc: AbstractNonCC = ncca
 
-    type NonCCARec = Record.`'i -> Int, 's -> String`.T
-    type NonCCBRec = Record.`'b -> Boolean, 'd -> Double`.T
-    type AbsUnion = Union.`'NonCCA -> NonCCA, 'NonCCB -> NonCCB`.T
+    type NonCCARec = Record.`"i" -> Int, "s" -> String`.T
+    type NonCCBRec = Record.`"b" -> Boolean, "d" -> Double`.T
+    type AbsUnion = Union.`"NonCCA" -> NonCCA, "NonCCB" -> NonCCB`.T
 
     val genA = LabelledGeneric[NonCCA]
     val genB = LabelledGeneric[NonCCB]
     val genAbs = LabelledGeneric[AbstractNonCC]
 
     val rA = genA.to(ncca)
-    assertTypedEquals[NonCCARec](Symbol("i") ->> 23 :: Symbol("s") ->> "foo" :: HNil, rA)
+    assertTypedEquals[NonCCARec]("i" ->> 23 :: "s" ->> "foo" :: HNil, rA)
 
     val rB = genB.to(nccb)
-    assertTypedEquals[NonCCBRec](Symbol("b") ->> true :: Symbol("d") ->> 2.0 :: HNil, rB)
+    assertTypedEquals[NonCCBRec]("b" ->> true :: "d" ->> 2.0 :: HNil, rB)
 
     val rAbs = genAbs.to(ancc)
-    val injA = Coproduct[AbsUnion](Symbol("NonCCA") ->> ncca)
+    val injA = Coproduct[AbsUnion]("NonCCA" ->> ncca)
     assertTypedEquals[AbsUnion](injA, rAbs)
 
-    val fA = genA.from(Symbol("i") ->> 13 :: Symbol("s") ->> "bar" :: HNil)
+    val fA = genA.from("i" ->> 13 :: "s" ->> "bar" :: HNil)
     typed[NonCCA](fA)
     assertEquals(13, fA.i)
     assertEquals("bar", fA.s)
 
-    val fB = genB.from(Symbol("b") ->> false :: Symbol("d") ->> 3.0 :: HNil)
+    val fB = genB.from("b" ->> false :: "d" ->> 3.0 :: HNil)
     typed[NonCCB](fB)
     assertEquals(false, fB.b)
     assertEquals(3.0, fB.d, Double.MinPositiveValue)
 
-    val injB = Coproduct[AbsUnion](Symbol("NonCCB") ->> nccb)
+    val injB = Coproduct[AbsUnion]("NonCCB" ->> nccb)
     val fAbs = genAbs.from(injB)
     typed[AbstractNonCC](fAbs)
     assertTrue(fAbs.isInstanceOf[NonCCB])
@@ -395,15 +376,15 @@ class LabelledGenericTests {
   def testNonCCWithCompanion: Unit = {
     val nccc = NonCCWithCompanion(23, "foo")
 
-    val rec = (Symbol("i") ->> 23) :: (Symbol("s") ->> "foo") :: HNil
-    type NonCCRec = Record.`'i -> Int, 's -> String`.T
+    val rec = ("i" ->> 23) :: ("s" ->> "foo") :: HNil
+    type NonCCRec = Record.`"i" -> Int, "s" -> String`.T
 
     val gen = LabelledGeneric[NonCCWithCompanion]
 
     val r = gen.to(nccc)
     assertTypedEquals[NonCCRec](rec, r)
 
-    val f = gen.from(Symbol("i") ->> 13 :: Symbol("s") ->> "bar" :: HNil)
+    val f = gen.from("i" ->> 13 :: "s" ->> "bar" :: HNil)
     typed[NonCCWithCompanion](f)
     assertEquals(13, f.i)
     assertEquals("bar", f.s)
@@ -414,15 +395,15 @@ class LabelledGenericTests {
     lazy val (a: NonCCLazy, b: NonCCLazy, c: NonCCLazy) =
       (new NonCCLazy(c, b), new NonCCLazy(a, c), new NonCCLazy(b, a))
 
-    val rec = Symbol("prev") ->> a :: Symbol("next") ->> c :: HNil
-    type LazyRec = Record.`'prev -> NonCCLazy, 'next -> NonCCLazy`.T
+    val rec = "prev" ->> a :: "next" ->> c :: HNil
+    type LazyRec = Record.`"prev" -> NonCCLazy, "next" -> NonCCLazy`.T
 
     val gen = LabelledGeneric[NonCCLazy]
 
     val rB = gen.to(b)
     assertTypedEquals[LazyRec](rec, rB)
 
-    val fD = gen.from(Symbol("prev") ->> a :: Symbol("next") ->> c :: HNil)
+    val fD = gen.from("prev" ->> a :: "next" ->> c :: HNil)
     typed[NonCCLazy](fD)
     assertEquals(a, fD.prev)
     assertEquals(c, fD.next)
@@ -452,12 +433,12 @@ class LabelledGenericTests {
 
     implicitly[TC[DummyTagged]]
 
-    type R = Record.`'i -> Int @@ CustomTag`.T
+    type R = Record.`"i" -> Int @@ CustomTag`.T
     val lgen = LabelledGeneric[Dummy]
     implicitly[lgen.Repr =:= R]
     implicitly[TC[R]]
 
-    type RT = Record.`'b -> Boolean, 'i -> Int @@ CustomTag`.T
+    type RT = Record.`"b" -> Boolean, "i" -> Int @@ CustomTag`.T
     val lgent = LabelledGeneric[DummyTagged]
     implicitly[lgent.Repr =:= RT]
     implicitly[TC[RT]]

--- a/core/src/test/scala/shapeless/lenses.scala
+++ b/core/src/test/scala/shapeless/lenses.scala
@@ -292,12 +292,12 @@ class LensTestsNat extends LensTests {
 }
 
 class LensTestsKey extends LensTests {
-  val nameLens     = lens[Person] >> Symbol("name")
-  val ageLens      = lens[Person] >> Symbol("age")
-  val addressLens  = lens[Person] >> Symbol("address")
-  val streetLens   = lens[Person] >> Symbol("address") >> Symbol("street")
-  val cityLens     = lens[Person] >> Symbol("address") >> Symbol("city")
-  val postcodeLens = lens[Person] >> Symbol("address") >> Symbol("postcode")
+  val nameLens     = lens[Person] >> "name"
+  val ageLens      = lens[Person] >> "age"
+  val addressLens  = lens[Person] >> "address"
+  val streetLens   = lens[Person] >> "address" >> "street"
+  val cityLens     = lens[Person] >> "address" >> "city"
+  val postcodeLens = lens[Person] >> "address" >> "postcode"
 }
 
 class OpticTestsDynamic extends LensTests {

--- a/core/src/test/scala/shapeless/product.scala
+++ b/core/src/test/scala/shapeless/product.scala
@@ -144,14 +144,14 @@ class ProductTests {
     // With explicit type arguments, >: or =:= to the inferred ones respectively
 
     {
-      val fooL = foo.toRecord[Record.`'i -> AnyVal, 's -> String`.T]
+      val fooL = foo.toRecord[Record.`"i" -> AnyVal, "s" -> String`.T]
       val expectedFooL = Record(i=1: AnyVal, s="b")
       equalInferredTypes(expectedFooL, fooL)
       assertTypedEquals(expectedFooL, fooL)
     }
 
     {
-      val barL = bar.toRecord[Record.`'b -> Boolean, 'f -> Foo`.T]
+      val barL = bar.toRecord[Record.`"b" -> Boolean, "f" -> Foo`.T]
       val expectedBarL = Record(b=true, f=foo)
       equalInferredTypes(expectedBarL, barL)
       assertTypedEquals(expectedBarL, barL)
@@ -318,14 +318,14 @@ class ProductTests {
     
     {
       val m = foo.toMap
-      val expected = Map(Symbol("i").narrow -> 1, Symbol("s").narrow -> "b")
+      val expected = Map("i".narrow -> 1, "s".narrow -> "b")
       equalInferredTypes(expected, m)
       assertTypedEquals(expected, m)
     }
 
     {
-      val m = foo.toMap[Symbol, Any]
-      val expected = Map[Symbol, Any](Symbol("i") -> 1, Symbol("s") -> "b")
+      val m = foo.toMap[String, Any]
+      val expected = Map[String, Any]("i" -> 1, "s" -> "b")
       equalInferredTypes(expected, m)
       assertTypedEquals(expected, m)
     }

--- a/core/src/test/scala/shapeless/records.scala
+++ b/core/src/test/scala/shapeless/records.scala
@@ -43,6 +43,10 @@ class RecordTests {
 
   case class Bar(a: Int, b: String)
 
+  type MapRec = Record.`'map -> Map[String, Int]`.T
+  type TupleRec = Record.`'tuple -> (String, Int)`.T
+  type ComplexRec = Record.`'map -> Map[String, Int], 'tuple -> (String, Int)`.T
+
   @Test
   def testGet: Unit = {
     val r1 =

--- a/core/src/test/scala/shapeless/unions.scala
+++ b/core/src/test/scala/shapeless/unions.scala
@@ -39,36 +39,34 @@ class UnionTests {
   val sB = Witness(Symbol("b"))
   type b = sB.T
 
-  type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
+  type U = Union.`"i" -> Int, "s" -> String, "b" -> Boolean`.T
 
   @Test
   def testGetLiterals: Unit = {
-    val u1 = Coproduct[U](Symbol("i") ->> 23)
-    val u2 = Coproduct[U](Symbol("s") ->> "foo")
-    val u3 = Coproduct[U](Symbol("b") ->> true)
+    val u1 = Coproduct[U]("i" ->> 23)
+    val u2 = Coproduct[U]("s" ->> "foo")
+    val u3 = Coproduct[U]("b" ->> true)
 
-    val v1 = u1.get(Symbol("i"))
+    val v1 = u1.get("i")
     typed[Option[Int]](v1)
     assertEquals(Some(23), v1)
 
-    val v2 = u2.get(Symbol("s"))
+    val v2 = u2.get("s")
     typed[Option[String]](v2)
     assertEquals(Some("foo"), v2)
 
-    val v3 = u3.get(Symbol("b"))
+    val v3 = u3.get("b")
     typed[Option[Boolean]](v3)
     assertEquals(Some(true), v3)
 
-    illTyped("""
-      u1.get(Symbol("foo"))
-    """)
+    illTyped("""u1.get("foo")""")
   }
 
   @Test
   def testSelectDynamic: Unit = {
-    val u1 = Coproduct[U](Symbol("i") ->> 23).union
-    val u2 = Coproduct[U](Symbol("s") ->> "foo").union
-    val u3 = Coproduct[U](Symbol("b") ->> true).union
+    val u1 = Coproduct[U]("i" ->> 23).union
+    val u2 = Coproduct[U]("s" ->> "foo").union
+    val u3 = Coproduct[U]("b" ->> true).union
 
     val v1 = u1.i
     typed[Option[Int]](v1)
@@ -197,21 +195,19 @@ class UnionTests {
     val u2 = Union[U](s = "foo")
     val u3 = Union[U](b = true)
 
-    val v1 = u1.get(Symbol("i"))
+    val v1 = u1.get("i")
     typed[Option[Int]](v1)
     assertEquals(Some(23), v1)
 
-    val v2 = u2.get(Symbol("s"))
+    val v2 = u2.get("s")
     typed[Option[String]](v2)
     assertEquals(Some("foo"), v2)
 
-    val v3 = u3.get(Symbol("b"))
+    val v3 = u3.get("b")
     typed[Option[Boolean]](v3)
     assertEquals(Some(true), v3)
 
-    illTyped("""
-      u1.get(Symbol("foo"))
-    """)
+    illTyped("""u1.get("foo")""")
   }
 
   @Test
@@ -220,16 +216,16 @@ class UnionTests {
     val u2 = Union[U](s = "foo")
     val u3 = Union[U](b = true)
 
-    type UF = (Witness.`'i`.T, Int) :+: (Witness.`'s`.T, String) :+: (Witness.`'b`.T, Boolean) :+: CNil
+    type UF = (Witness.`"i"`.T, Int) :+: (Witness.`"s"`.T, String) :+: (Witness.`"b"`.T, Boolean) :+: CNil
 
     {
       val f1 = u1.fields
       val f2 = u2.fields
       val f3 = u3.fields
 
-      assertTypedEquals(Coproduct[UF](Symbol("i").narrow -> 23), f1)
-      assertTypedEquals(Coproduct[UF](Symbol("s").narrow -> "foo"), f2)
-      assertTypedEquals(Coproduct[UF](Symbol("b").narrow -> true), f3)
+      assertTypedEquals(Coproduct[UF]("i".narrow -> 23), f1)
+      assertTypedEquals(Coproduct[UF]("s".narrow -> "foo"), f2)
+      assertTypedEquals(Coproduct[UF]("b".narrow -> true), f3)
     }
 
     type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
@@ -262,7 +258,7 @@ class UnionTests {
 
       type UV = Coproduct.`Int, String, Boolean`.T
 
-      assertTypedEquals(Symbol("i").narrow :: Symbol("s").narrow :: Symbol("b").narrow :: HNil, uf.keys)
+      assertTypedEquals("i".narrow :: "s".narrow :: "b".narrow :: HNil, uf.keys)
       assertTypedEquals(Coproduct[UV](23), uf.values(u1))
       assertTypedEquals(Coproduct[UV]("foo"), uf.values(u2))
       assertTypedEquals(Coproduct[UV](true), uf.values(u3))
@@ -296,19 +292,19 @@ class UnionTests {
       val m2 = u2.toMap
       val m3 = u3.toMap
 
-      assertTypedEquals(Map[Symbol, Any](Symbol("i") -> 23), m1)
-      assertTypedEquals(Map[Symbol, Any](Symbol("s") -> "foo"), m2)
-      assertTypedEquals(Map[Symbol, Any](Symbol("b") -> true), m3)
+      assertTypedEquals(Map[String, Any]("i" -> 23), m1)
+      assertTypedEquals(Map[String, Any]("s" -> "foo"), m2)
+      assertTypedEquals(Map[String, Any]("b" -> true), m3)
     }
 
     {
-      val m1 = u1.toMap[Symbol, Any]
-      val m2 = u2.toMap[Symbol, Any]
-      val m3 = u3.toMap[Symbol, Any]
+      val m1 = u1.toMap[String, Any]
+      val m2 = u2.toMap[String, Any]
+      val m3 = u3.toMap[String, Any]
 
-      assertTypedEquals(Map[Symbol, Any](Symbol("i") -> 23), m1)
-      assertTypedEquals(Map[Symbol, Any](Symbol("s") -> "foo"), m2)
-      assertTypedEquals(Map[Symbol, Any](Symbol("b") -> true), m3)
+      assertTypedEquals(Map[String, Any]("i" -> 23), m1)
+      assertTypedEquals(Map[String, Any]("s" -> "foo"), m2)
+      assertTypedEquals(Map[String, Any]("b" -> true), m3)
     }
 
     type US = Union.`"first" -> Option[Int], "second" -> Option[Boolean], "third" -> Option[String]`.T
@@ -350,7 +346,7 @@ class UnionTests {
       val u2 = Union[U](s = "foo")
       val u3 = Union[U](b = true)
 
-      type R = Union.`'i -> Boolean, 's -> String, 'b -> String`.T
+      type R = Union.`"i" -> Boolean, "s" -> String, "b" -> String`.T
 
       val res1 = u1.mapValues(f)
       val res2 = u2.mapValues(f)

--- a/examples/src/main/scala/shapeless/examples/derivation.scala
+++ b/examples/src/main/scala/shapeless/examples/derivation.scala
@@ -135,69 +135,50 @@ object TypeClassesDemoAux {
   }
 
   object Show {
-    def apply[T](implicit st: Lazy[Show[T]]): Show[T] = st.value
+    def apply[T](implicit show: Show[T]): Show[T] = show
 
-    implicit val showString: Show[String] = new Show[String] {
-      def show(t: String) = t
+    def instance[T](f: T => String): Show[T] = new Show[T] {
+      def show(value: T): String = f(value)
     }
 
-    implicit val showBoolean: Show[Boolean] = new Show[Boolean] {
-      def show(t: Boolean) = t.toString
-    }
+    implicit val showString: Show[String] = instance(identity)
+    implicit val showBoolean: Show[Boolean] = instance(_.toString)
 
     implicit def showList[A](implicit showA: Show[A]): Show[List[A]] = new Show[List[A]] {
-      def show(t: List[A]) = t.map(showA.show).mkString("List(", ", ", ")")
+      def show(t: List[A]): String = t.map(showA.show).mkString("List(", ", ", ")")
     }
 
-    implicit def deriveHNil: Show[HNil] =
-      new Show[HNil] {
-        def show(p: HNil): String = ""
+    implicit val deriveHNil: Show[HNil] = instance(_ => "")
+    implicit val deriveCNil: Show[CNil] = instance(_ => "")
+
+    implicit def deriveHCons[K <: String, V, T <: HList](
+      implicit key: Witness.Aux[K], sv: Lazy[Show[V]], st: Show[T]
+    ): Show[FieldType[K, V] :: T] = instance { case kv :: t =>
+      val head = s"${key.value} = ${sv.value.show(kv)}"
+      val tail = st.show(t)
+      if (tail.isEmpty) head else s"$head, $tail"
+    }
+
+    implicit def deriveCCons[K <: String, V, T <: Coproduct](
+      implicit key: Witness.Aux[K], sv: Lazy[Show[V]], st: Show[T]
+    ): Show[FieldType[K, V] :+: T] = instance { c =>
+      // Using match/case
+      c match {
+        case Inl(l) => s"${key.value}(${sv.value.show(l)})"
+        case Inr(r) => st.show(r)
       }
+      // Or using eliminate
+      c.eliminate(
+        l => s"${key.value}(${sv.value.show(l)})",
+        r => st.show(r)
+      )
+    }
 
-    implicit def deriveHCons[K <: Symbol, V, T <: HList]
-      (implicit
-        key: Witness.Aux[K],
-        sv: Lazy[Show[V]],
-        st: Lazy[Show[T]]
-      ): Show[FieldType[K, V] :: T] =
-        new Show[FieldType[K, V] :: T] {
-          def show(p: FieldType[K, V] :: T): String = {
-            val head = s"${key.value.name} = ${sv.value.show(p.head)}"
-            val tail = st.value.show(p.tail)
-            if(tail.isEmpty) head else s"$head, $tail"
-          }
-        }
-
-    implicit def deriveCNil: Show[CNil] =
-      new Show[CNil] {
-        def show(p: CNil): String = ""
-      }
-
-    implicit def deriveCCons[K <: Symbol, V, T <: Coproduct]
-      (implicit
-        key: Witness.Aux[K],
-        sv: Lazy[Show[V]],
-        st: Lazy[Show[T]]
-      ): Show[FieldType[K, V] :+: T] =
-        new Show[FieldType[K, V] :+: T] {
-          def show(c: FieldType[K, V] :+: T): String = {
-            //Using match/case
-            c match {
-              case Inl(l) => s"${key.value.name}(${sv.value.show(l)})"
-              case Inr(r) => st.value.show(r)
-            }
-            //Or using eliminate
-            c.eliminate(
-              l => s"${key.value.name}(${sv.value.show(l)})",
-              r => st.value.show(r)
-            )
-          }
-        }
-
-    implicit def deriveInstance[F, G](implicit gen: LabelledGeneric.Aux[F, G], sg: Lazy[Show[G]]): Show[F] =
-      new Show[F] {
-        def show(f: F) = sg.value.show(gen.to(f))
-      }
+    implicit def deriveInstance[F, G](
+      implicit gen: LabelledGeneric.Aux[F, G], sg: Lazy[Show[G]]
+    ): Show[F] = instance { f =>
+      sg.value.show(gen.to(f))
+    }
   }
 
   trait Show2[T] {

--- a/examples/src/main/scala/shapeless/examples/labelledgeneric.scala
+++ b/examples/src/main/scala/shapeless/examples/labelledgeneric.scala
@@ -39,17 +39,17 @@ object LabelledGenericExamples extends App {
   val rec = bookGen.to(tapl)
 
   // Read price field
-  val currentPrice = rec(Symbol("price"))  // Static type is Double
+  val currentPrice = rec("price")  // Static type is Double
   println("Current price is "+currentPrice)
   println
 
   // Update price field, relying on static type of currentPrice
-  val updated = bookGen.from(rec.updateWith(Symbol("price"))(_+2.0))
+  val updated = bookGen.from(rec.updateWith("price")(_ + 2.0))
   println(updated)
   println
 
   // Add a new field, map back into ExtendedBook
-  val extended = bookExtGen.from(rec + (Symbol("inPrint") ->> true)) // Static type is ExtendedBook
+  val extended = bookExtGen.from(rec + ("inPrint" ->> true)) // Static type is ExtendedBook
   println(extended)
   println
 
@@ -93,11 +93,11 @@ object OldWineNewBottles extends App {
   val toGen = LabelledGeneric[To]
 
   // Define the type of the i field by example
-  val iField = Field(Symbol("i") ->> 0)
+  val iField = Field("i" ->> 0)
 
   val align = Align[iField.F :: fromGen.Repr, toGen.Repr]
 
-  val to = toGen.from(align(Symbol("i") ->> 23 :: fromGen.to(from)))
+  val to = toGen.from(align("i" ->> 23 :: fromGen.to(from)))
   println(to)
   println
 }

--- a/examples/src/main/scala/shapeless/examples/partition.scala
+++ b/examples/src/main/scala/shapeless/examples/partition.scala
@@ -122,10 +122,10 @@ object ADTPartitionExample extends App {
   val basket = partitionRecord(fruits)
 
   // Confirm that expected record values are present (and not unexpected ones).
-  typed[List[Apple]](basket(Symbol("Apple")))
-  typed[List[Pear]](basket(Symbol("Pear")))
-  illTyped("""basket(Symbol("Burger"))""")
+  typed[List[Apple]](basket("Apple"))
+  typed[List[Pear]](basket("Pear"))
+  illTyped("""basket("Burger")""")
 
-  assert(basket(Symbol("Apple")) == expectedApples)
-  assert(basket(Symbol("Pear")) == expectedPears)
+  assert(basket("Apple") == expectedApples)
+  assert(basket("Pear") == expectedPears)
 }

--- a/examples/src/main/scala/shapeless/examples/recordsubtyping.scala
+++ b/examples/src/main/scala/shapeless/examples/recordsubtyping.scala
@@ -23,11 +23,11 @@ object recordsubtyping extends App{
   val employeeId = Record(firstName = "Jane", lastName = "Doe", title = "software engineer")
 
   val employee1 = Record(id = employeeId, city = new PopulatedCity("San Francisco", 2), company =  "Foo Inc.")
-  val employee2 = employee1.updated(Symbol("company"), "Bar Inc.")
-  val employee3 = employee1.updated(Symbol("city"), new PopulatedCity("Chernobyl", 1) )
+  val employee2 = employee1.updated("company", "Bar Inc.")
+  val employee3 = employee1.updated("city", new PopulatedCity("Chernobyl", 1) )
 
-  type PersonId = Record.`'firstName -> String, 'lastName -> String`.T
-  type Person = Record.`'id -> PersonId, 'city -> City`.T
+  type PersonId = Record.`"firstName" -> String, "lastName" -> String`.T
+  type Person = Record.`"id" -> PersonId, "city" -> City`.T
 
   val somePerson: Person = Record(id = Record(firstName = "Jane", lastName = "Doe"), city = new City("San Francisco"))
 
@@ -59,7 +59,7 @@ object recordsubtyping extends App{
 
   //transform Person structure preserving Employee shape
   //this is only possible if no nominal subtyping relation is present between the record fields ('city' in this case)
-  val noNominalSubtypingEmployee = employee1.updateWith(Symbol("city"))(c => c: City)
+  val noNominalSubtypingEmployee = employee1.updateWith("city")(c => c: City)
 
   def transform[L <: HList, X <: HList, Y <: HList, O <: HList](input: L)(transform: X => Y)
     (implicit

--- a/examples/src/main/scala/shapeless/examples/recursionschemes.scala
+++ b/examples/src/main/scala/shapeless/examples/recursionschemes.scala
@@ -23,7 +23,6 @@ import shapeless.ops.hlist.Tupler
 import shapeless.ops.union.Selector
 import shapeless.record._
 import shapeless.syntax.DynamicRecordOps
-import shapeless.tag.@@
 
 /**
  * Example adapted from the talk "Recursion Schemes by Example" by Tim Williams.
@@ -208,7 +207,7 @@ package recursionschemes {
     object F extends Dynamic {
       import shapeless.ops.record.Values
 
-      trait Extractor[K <: Symbol] {
+      trait Extractor[K <: String] {
         object as {
           def unapply[C <: Coproduct, R <: HList](c: C)(
             implicit sel: Selector.Aux[C, K, R]
@@ -228,9 +227,9 @@ package recursionschemes {
         }
       }
 
-      private val extractor = new Extractor[Symbol] { }
-      def selectDynamic(name: String): Extractor[Symbol @@ name.type] =
-        extractor.asInstanceOf[Extractor[Symbol @@ name.type]]
+      private val extractor = new Extractor[String] { }
+      def selectDynamic(name: String): Extractor[name.type] =
+        extractor.asInstanceOf[Extractor[name.type]]
     }
   }
 

--- a/examples/src/main/scala/shapeless/examples/sexp.scala
+++ b/examples/src/main/scala/shapeless/examples/sexp.scala
@@ -287,72 +287,63 @@ object SexpUserConvert {
 object SexpConvert {
   def apply[T](implicit st: Lazy[SexpConvert[T]]): SexpConvert[T] = st.value
 
-  implicit def deriveHNil: SexpConvert[HNil] =
-    new SexpConvert[HNil] {
-      def deser(s: Sexp) = if (s == SexpNil) Some(HNil) else None
-      def ser(n: HNil) = SexpNil
+  implicit val deriveHNil: SexpConvert[HNil] = new SexpConvert[HNil] {
+    def deser(s: Sexp) = if (s == SexpNil) Some(HNil) else None
+    def ser(n: HNil) = SexpNil
+  }
+
+  implicit def deriveHCons[K <: String, V, T <: HList](
+    implicit key: Witness.Aux[K], scv: Lazy[SexpConvert[V]], sct: SexpConvert[T]
+  ): SexpConvert[FieldType[K, V] :: T] = new SexpConvert[FieldType[K, V] :: T] {
+    def deser(s: Sexp): Option[FieldType[K, V] :: T] = s match {
+      case SexpProp((label, car), cdr) if label == key.value =>
+        for {
+          front <- scv.value.deser(car)
+          back <- sct.deser(cdr)
+        } yield field[K](front) :: back
+
+      case _ =>
+        println("PRODUCT MISS = " + s)
+        None
     }
 
-  implicit def deriveHCons[K <: Symbol, V, T <: HList]
-    (implicit
-      key: Witness.Aux[K],
-      scv: Lazy[SexpConvert[V]],
-      sct: Lazy[SexpConvert[T]]
-    ): SexpConvert[FieldType[K, V] :: T] =
-      new SexpConvert[FieldType[K, V] :: T] {
-        def deser(s: Sexp): Option[FieldType[K, V] :: T] = s match {
-          case SexpProp((label, car), cdr) if label == key.value.name =>
-            for {
-              front <- scv.value.deser(car)
-              back <- sct.value.deser(cdr)
-            } yield field[K](front) :: back
-
-          case _ =>
-            println("PRODUCT MISS = " + s)
-            None
-        }
-
-        def ser(ft: FieldType[K, V] :: T): Sexp = {
-          val car = SexpProp(key.value.name, scv.value.ser(ft.head))
-          sct.value.ser(ft.tail) match {
-            case SexpNil => car
-            case cdr => SexpCons(car, cdr)
-          }
-        }
+    def ser(ft: FieldType[K, V] :: T): Sexp = {
+      val car = SexpProp(key.value, scv.value.ser(ft.head))
+      sct.ser(ft.tail) match {
+        case SexpNil => car
+        case cdr => SexpCons(car, cdr)
       }
+    }
+  }
 
-  implicit def deriveCNil: SexpConvert[CNil] = new SexpConvert[CNil] {
+  implicit val deriveCNil: SexpConvert[CNil] = new SexpConvert[CNil] {
     def deser(s: Sexp): Option[CNil] = None
     def ser(t: CNil) = SexpNil
   }
 
-  implicit def deriveCCons[K <: Symbol, V, T <: Coproduct]
-    (implicit
-      key: Witness.Aux[K],
-      scv: Lazy[SexpConvert[V]],
-      sct: Lazy[SexpConvert[T]]
-    ): SexpConvert[FieldType[K, V] :+: T] =
-      new SexpConvert[FieldType[K, V] :+: T] {
-        def deser(s: Sexp): Option[FieldType[K, V] :+: T] = s match {
-          case SexpCons(SexpAtom(impl), cdr) if impl == key.value.name =>
-            scv.value.deser(cdr).map(v => Inl(field[K](v)))
-          case SexpCons(SexpAtom(impl), cdr) =>
-            sct.value.deser(s).map(Inr(_))
-          case _ =>
-            println("COPRODUCT MISS " + s)
-            None
-        }
+  implicit def deriveCCons[K <: String, V, T <: Coproduct](
+    implicit key: Witness.Aux[K], scv: Lazy[SexpConvert[V]], sct: SexpConvert[T]
+  ): SexpConvert[FieldType[K, V] :+: T] = new SexpConvert[FieldType[K, V] :+: T] {
+    def deser(s: Sexp): Option[FieldType[K, V] :+: T] = s match {
+      case SexpCons(SexpAtom(impl), cdr) if impl == key.value =>
+        scv.value.deser(cdr).map(v => Inl(field[K](v)))
+      case SexpCons(SexpAtom(impl), cdr) =>
+        sct.deser(s).map(Inr(_))
+      case _ =>
+        println("COPRODUCT MISS " + s)
+        None
+    }
 
-        def ser(lr: FieldType[K, V] :+: T): Sexp = lr match {
-          case Inl(l) => SexpCons(SexpAtom(key.value.name), scv.value.ser(l))
-          case Inr(r) => sct.value.ser(r)
-        }
-      }
+    def ser(lr: FieldType[K, V] :+: T): Sexp = lr match {
+      case Inl(l) => SexpCons(SexpAtom(key.value), scv.value.ser(l))
+      case Inr(r) => sct.ser(r)
+    }
+  }
 
-  implicit def deriveInstance[F, G]
-    (implicit gen: LabelledGeneric.Aux[F, G], sg: Lazy[SexpConvert[G]]): SexpConvert[F] =
-      new SexpConvert[F] {
-        def deser(s: Sexp): Option[F] = sg.value.deser(s).map(gen.from)
-        def ser(t: F): Sexp = sg.value.ser(gen.to(t))
-      }
+  implicit def deriveInstance[F, G](
+    implicit gen: LabelledGeneric.Aux[F, G], sg: Lazy[SexpConvert[G]]
+  ): SexpConvert[F] = new SexpConvert[F] {
+    def deser(s: Sexp): Option[F] = sg.value.deser(s).map(gen.from)
+    def ser(t: F): Sexp = sg.value.ser(gen.to(t))
+  }
 }


### PR DESCRIPTION
Best reviewed commit by commit. Also:
  * Decouple `LabelledGeneric` from `ZipWithKeys`
  * Optimize `ZipWithKeys`
  * Refactor and optimize macro based record ops
  * Fix #660 