### PR TITLE
make MirroredElemTypes type more specific

### DIFF
--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -20,7 +20,7 @@ import scala.compiletime._
 import scala.deriving._
 
 object K0 {
-  type Kind[C, O] = C { type Kind = K0.type ; type MirroredType = O ; type MirroredElemTypes }
+  type Kind[C, O] = C { type Kind = K0.type ; type MirroredType = O ; type MirroredElemTypes <: Tuple }
   type Generic[O] = Kind[Mirror, O]
   type ProductGeneric[O] = Kind[Mirror.Product, O]
   type CoproductGeneric[O] = Kind[Mirror.Sum, O]
@@ -115,7 +115,7 @@ object K0 {
 }
 
 object K1 {
-  type Kind[C, O[_]] = C { type Kind = K1.type ; type MirroredType = O ; type MirroredElemTypes[_] }
+  type Kind[C, O[_]] = C { type Kind = K1.type ; type MirroredType = O ; type MirroredElemTypes[_] <: Tuple }
   type Generic[O[_]] = Kind[Mirror, O]
   type ProductGeneric[O[_]] = Kind[Mirror.Product, O]
   type CoproductGeneric[O[_]] = Kind[Mirror.Sum, O]
@@ -201,7 +201,7 @@ object K1 {
 }
 
 object K11 {
-  type Kind[C, O[_[_]]] = C { type Kind = K11.type ; type MirroredType = O ; type MirroredElemTypes[_[_]] }
+  type Kind[C, O[_[_]]] = C { type Kind = K11.type ; type MirroredType = O ; type MirroredElemTypes[_[_]] <: Tuple }
   type Generic[O[_[_]]] = Kind[Mirror, O]
   type ProductGeneric[O[_[_]]] = Kind[Mirror.Product, O]
   type CoproductGeneric[O[_[_]]] = Kind[Mirror.Sum, O]
@@ -290,7 +290,7 @@ object K11 {
 }
 
 object K2 {
-  type Kind[C, O[_, _]] = C { type Kind = K2.type ; type MirroredType = O ; type MirroredElemTypes[_, _] }
+  type Kind[C, O[_, _]] = C { type Kind = K2.type ; type MirroredType = O ; type MirroredElemTypes[_, _] <: Tuple }
   type Generic[O[_, _]] = Kind[Mirror, O]
   type ProductGeneric[O[_, _]] = Kind[Mirror.Product, O]
   type CoproductGeneric[O[_, _]] = Kind[Mirror.Sum, O]


### PR DESCRIPTION
The `MirroredElemTypes` is expected to be a `Tuple` in the standard library.

https://github.com/lampepfl/dotty/blob/fe03ee22f107a745dd3a25b4e5bbd35856188206/library/src/scala/deriving.scala#L51-L53

The refined type `Kind` should reflect that as well.