### PR TITLE
fix scala.js crash on validation

### DIFF
--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -48,6 +48,11 @@ class HListTests {
 
   type BBBB = Boolean :: Boolean :: Boolean :: Boolean :: HNil
 
+  object mkString extends (Any -> String)(_.toString)
+  object fruit extends (Fruit -> Fruit)(f => f)
+  object incInt extends (Int >-> Int)(_ + 1)
+  object extendedChoose extends LiftU(choose)
+
   trait Fruit
   case class Apple() extends Fruit
   case class Pear() extends Fruit
@@ -129,10 +134,6 @@ class HListTests {
   val m2eim2esm2eim2eem2edArray = Array(m2iExist, m2sExist, m2iExist, m2iExist, m2dExist)
   val m2eim2esm2eim2eem2ed: M2EIM2ESM2EIM2EEM2ED = m2iExist :: m2sExist :: m2iExist :: m2iExist :: m2dExist :: HNil
 
-  object mkString extends (Any -> String)(_.toString)
-  object fruit extends (Fruit -> Fruit)(f => f)
-  object incInt extends (Int >-> Int)(_ + 1)
-  object extendedChoose extends LiftU(choose)
 
   @Test
   def testBasics: Unit = {

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -44,6 +44,9 @@ class TupleTests {
 
   type BBBB = (Boolean, Boolean, Boolean, Boolean)
 
+  object mkString extends (Any -> String)(_.toString)
+  object fruit extends (Fruit -> Fruit)(f => f)
+
   trait Fruit
   case class Apple() extends Fruit
   case class Pear() extends Fruit
@@ -117,9 +120,6 @@ class TupleTests {
   val m2eim2esm2eim2eem2edList = List(m2iExist, m2sExist, m2iExist, m2iExist, m2dExist)
   val m2eim2esm2eim2eem2edArray = Array(m2iExist, m2sExist, m2iExist, m2iExist, m2dExist)
   val m2eim2esm2eim2eem2ed = (m2iExist, m2sExist, m2iExist, m2iExist, m2dExist)
-
-  object mkString extends (Any -> String)(_.toString)
-  object fruit extends (Fruit -> Fruit)(f => f)
 
   trait incInt0 extends Poly1 {
     implicit def default[T] = at[T](t => ())


### PR DESCRIPTION
According to the issue and PR below, scala.js crashes on Mac or Windows due to the order of same name class or trait and object.

- https://github.com/scala/bug/issues/11997
- https://github.com/scala/scala/pull/9035

`Tupletests` and `HListTest` have `fruit` object and `Fruit` trait, then `validate` command crashed.
Reordering those resolve crashes.