### PR TITLE
refined if statement

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -747,7 +747,6 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
     def unapply(tpe: Type): Option[List[(TermName, Type)]] = for {
       companion <- Option(patchedCompanionSymbolOf(tpe.typeSymbol).typeSignature)
       apply = companion.member(TermName("apply"))
-      if apply.isTerm && !apply.asTerm.isOverloaded
       if apply.isMethod && !isNonGeneric(apply)
       if isAccessible(companion, apply)
       Seq(params) <- Option(apply.typeSignatureIn(companion).paramLists)
@@ -760,7 +759,6 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
     def unapply(tpe: Type): Option[List[Type]] = for {
       companion <- Option(patchedCompanionSymbolOf(tpe.typeSymbol).typeSignature)
       unapply = companion.member(TermName("unapply"))
-      if unapply.isTerm && !unapply.asTerm.isOverloaded
       if unapply.isMethod && !isNonGeneric(unapply)
       if isAccessible(companion, unapply)
       returnTpe <- unapply.asMethod.typeSignatureIn(companion).finalResultType


### PR DESCRIPTION
Firstly, `Symbol.isTerm` is always true if `Symbol.isMethod` is true, so `Symbol.isTerm && Symbol.isMethod` can be rewrriten as `Symbol.isMethod`.
Secondly, `!Symbol.asTerm.isOverloaded` is always true if `Symbol.isMethod` is true, and `asTerm` won't throw an exception because it only throw when `isTerm` is false.