### PR TITLE
Version specific Witness instances

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -537,12 +537,12 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
     }
   }
 
-  def findField(record: Type, key: Type): Option[(Type, Int)] =
+  def findField(record: Type, key: Type): Option[(Type, Type, Int)] =
     findField(unpackHList(record), key)
 
-  def findField(fields: Seq[Type], key: Type): Option[(Type, Int)] =
+  def findField(fields: Seq[Type], key: Type): Option[(Type, Type, Int)] =
     fields.iterator.zipWithIndex.collectFirst {
-      case (FieldType(k, v), i) if k =:= key => (v, i)
+      case (FieldType(k, v), i) if k =:= key => (k, v, i)
     }
 
   def appliedTypTree1(tpe: Type, param: Type, arg: TypeName): Tree = {

--- a/core/src/main/scala/shapeless/ops/records.scala
+++ b/core/src/main/scala/shapeless/ops/records.scala
@@ -60,8 +60,8 @@ package record {
         abort(s"$record is not a record type")
 
       findField(record, key) match {
-        case Some((v, i)) =>
-          q"new ${typeOf[UnsafeSelector]}($i).asInstanceOf[${reify(Selector)}.Aux[$record, $key, $v]]"
+        case Some((k, v, i)) =>
+          q"new ${typeOf[UnsafeSelector]}($i).asInstanceOf[${reify(Selector)}.Aux[$record, $k, $v]]"
         case _ =>
           abort(s"No field $key in record type $record")
       }
@@ -377,9 +377,9 @@ package record {
       val b = weakTypeOf[B]
       val fields = unpackHList(record)
       findField(fields, key) match {
-        case Some((v, i)) if v <:< a =>
-          val out = mkHListTpe(fields.updated(i, FieldType(key, b)))
-          q"new ${typeOf[UnsafeModifier]}($i).asInstanceOf[${reify(Modifier)}.Aux[$record, $key, $a, $b, $out]]"
+        case Some((k, v, i)) if v <:< a =>
+          val out = mkHListTpe(fields.updated(i, FieldType(k, b)))
+          q"new ${typeOf[UnsafeModifier]}($i).asInstanceOf[${reify(Modifier)}.Aux[$record, $k, $a, $b, $out]]"
         case _ =>
           abort(s"No field $key in record type $record")
       }
@@ -420,10 +420,10 @@ package record {
 
       val fields = unpackHList(record)
       findField(fields, key) match {
-        case Some((v, i)) =>
+        case Some((k, v, i)) =>
           val (prefix, suffix) = fields.splitAt(i)
           val out = mkHListTpe(prefix ++ suffix.tail)
-          q"new ${typeOf[UnsafeRemover]}($i).asInstanceOf[${reify(Remover)}.Aux[$record, $key, ($v, $out)]]"
+          q"new ${typeOf[UnsafeRemover]}($i).asInstanceOf[${reify(Remover)}.Aux[$record, $k, ($v, $out)]]"
         case _ =>
           abort(s"No field $key in record type $record")
       }

--- a/core/src/main/scala/shapeless/syntax/singletons.scala
+++ b/core/src/main/scala/shapeless/syntax/singletons.scala
@@ -17,13 +17,6 @@
 package shapeless
 package syntax
 
-import scala.language.experimental.macros
-
-object singleton {
-  implicit def mkSingletonOps(t: Any): SingletonOps =
-    macro SingletonTypeMacros.mkSingletonOps
-}
-
 trait SingletonOps {
   import labelled._
 
@@ -46,10 +39,11 @@ trait SingletonOps {
 }
 
 object SingletonOps {
+  type Aux[A] = SingletonOps { type T = A }
 
-  def instance[T0](w: Witness.Aux[T0]): SingletonOps { type T = T0; val witness: w.type } =
+  def instance[A](w: Witness.Aux[A]): Aux[A] =
     new SingletonOps {
-      type T = T0
-      val witness: w.type = w
+      type T = A
+      val witness = w
     }
 }

--- a/core/src/main/scala_2.13+/shapeless/syntax/singleton.scala
+++ b/core/src/main/scala_2.13+/shapeless/syntax/singleton.scala
@@ -1,0 +1,8 @@
+package shapeless.syntax
+
+import shapeless.Witness
+
+object singleton {
+  implicit def mkSingletonOps[T](t: T): SingletonOps.Aux[t.type] =
+    SingletonOps.instance[t.type](Witness(t))
+}

--- a/core/src/main/scala_2.13+/shapeless/versionspecifics.scala
+++ b/core/src/main/scala_2.13+/shapeless/versionspecifics.scala
@@ -18,6 +18,26 @@ package shapeless
 
 import scala.reflect.macros.whitebox
 
+trait WitnessInstances {
+  implicit def of[T: ValueOf]: Witness.Aux[T] =
+    Witness.mkWitness(valueOf[T])
+
+  implicit def apply[T](t: T): Witness.Aux[t.type] =
+    Witness.mkWitness[t.type](t)
+}
+
+trait WitnessWithInstances {
+  implicit def apply[TC[_], T](t: T)(implicit tc: TC[t.type]): WitnessWith.Aux[TC, t.type] { val instance: tc.type } =
+    instance[TC, t.type](t, tc)
+
+  def instance[TC[_], A](v: A, tc: TC[A]): WitnessWith.Aux[TC, A] { val instance: tc.type } =
+    new WitnessWith[TC] {
+      type T = A
+      val value: T = v
+      val instance: tc.type = tc
+    }
+}
+
 trait ScalaVersionSpecifics {
   private[shapeless] type IsRegularIterable[Repr] = collection.generic.IsIterable[Repr] { type C = Repr }
 

--- a/core/src/main/scala_2.13-/shapeless/syntax/singleton.scala
+++ b/core/src/main/scala_2.13-/shapeless/syntax/singleton.scala
@@ -1,0 +1,10 @@
+package shapeless.syntax
+
+import shapeless.SingletonTypeMacros
+
+import scala.language.experimental.macros
+
+object singleton {
+  implicit def mkSingletonOps(t: Any): SingletonOps =
+    macro SingletonTypeMacros.mkSingletonOps
+}

--- a/core/src/main/scala_2.13-/shapeless/versionspecifics.scala
+++ b/core/src/main/scala_2.13-/shapeless/versionspecifics.scala
@@ -16,11 +16,43 @@
 
 package shapeless
 
-import scala.collection.{ GenTraversableLike, GenTraversableOnce }
-import scala.collection.generic.{ CanBuildFrom, IsTraversableLike }
+import scala.collection.{GenTraversableLike, GenTraversableOnce}
+import scala.collection.generic.{CanBuildFrom, IsTraversableLike}
 import scala.collection.mutable.Builder
-
+import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
+
+trait WitnessInstances {
+  implicit def of[T]: Witness.Aux[T] =
+    macro SingletonTypeMacros.materializeImpl[T]
+
+  implicit def apply[T](t: T): Witness.Lt[T] =
+    macro SingletonTypeMacros.convertImpl
+}
+
+trait WitnessWithInstances extends WitnessWithLowPriority {
+  implicit def apply[TC[_], T](t: T): WitnessWith.Lt[TC, T] =
+    macro SingletonTypeMacros.convertInstanceImpl1[TC]
+}
+
+trait WitnessWithLowPriority {
+  implicit def apply2[H, TC2[_ <: H, _], S <: H, T](t: T): WitnessWith.Lt[({ type λ[x] = TC2[S, x] })#λ, T] =
+    macro SingletonTypeMacros.convertInstanceImpl2[H, TC2, S]
+
+  def instance[TC[_], A](v: A, tc: TC[A]): WitnessWith.Aux[TC, A] =
+    new WitnessWith[TC] {
+      type T = A
+      val value: T = v
+      val instance: TC[T] = tc
+    }
+
+  def depInstance[TC[_] <: AnyRef, A](v: A, tc: TC[A]): WitnessWith.Aux[TC, A] { val instance: tc.type } =
+    new WitnessWith[TC] {
+      type T = A
+      val value: T = v
+      val instance: tc.type = tc
+    }
+}
 
 trait ScalaVersionSpecifics extends LP0 {
   private[shapeless] type BuildFrom[-F, -E, +T] = CanBuildFrom[F, E, T]

--- a/core/src/test/scala/shapeless/singletons.scala
+++ b/core/src/test/scala/shapeless/singletons.scala
@@ -491,12 +491,12 @@ class SingletonTypesTests {
   def testWitnessThisType: Unit = {
     class ClassThis {
       val w1 = Witness(this)
-      val w2 = Witness[this.type]
+      val w2 = Witness.of[this.type]
     }
 
     object ObjectThis {
       val w1 = Witness(this)
-      val w2 = Witness[this.type]
+      val w2 = Witness.of[this.type]
     }
 
     val c = new ClassThis


### PR DESCRIPTION
Rely on `ValueOf` on 2.13.
`Nat` and `NatWith` are more difficult.