### PR TITLE
Update For Dotty 0.28.0-bin-20200904-1ab71c1-NIGHTLY

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - openjdk8
 
 scala:
-- 0.25.0-bin-20200609-a3b417b-NIGHTLY
+- 0.28.0-bin-20200904-1ab71c1-NIGHTLY
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val dottyLatestNightly = dottyLatestNightlyBuild.get
-//val dottyVersion = dottyLatestNightly 
-val dottyVersion = "0.25.0-bin-20200609-a3b417b-NIGHTLY"
-//val dottyVersion = "0.24.0-RC1"
+//val dottyVersion = dottyLatestNightly
+val dottyVersion = "0.28.0-bin-20200904-1ab71c1-NIGHTLY"
+//val dottyVersion = "0.27.0-RC1"
 
 inThisBuild(Seq(
   organization := "org.typelevel",

--- a/modules/deriving/src/main/scala/shapeless3/deriving/annotation.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/annotation.scala
@@ -129,14 +129,14 @@ object AnnotationMacros {
     val annotTpe = typeOf[A]
     val annotFlags = annotTpe.typeSymbol.flags
     if (annotFlags.is(Flags.Abstract) || annotFlags.is(Flags.Trait)) {
-      Reporting.error(s"Bad annotation type ${annotTpe.show} is abstract")
+      report.error(s"Bad annotation type ${annotTpe.show} is abstract")
       '{???}
     } else {
       val annoteeTpe = typeOf[T]
       annoteeTpe.typeSymbol.annots.find(_.tpe <:< annotTpe) match {
         case Some(tree) => '{ Annotation.mkAnnotation[A, T](${tree.seal.cast[A]}) }
         case None =>
-          Reporting.error(s"No Annotation of type ${annotTpe.show} for type ${annoteeTpe.show}")
+          report.error(s"No Annotation of type ${annotTpe.show} for type ${annoteeTpe.show}")
           '{???}
       }
     }
@@ -148,7 +148,7 @@ object AnnotationMacros {
     val annotTpe = typeOf[A]
     val annotFlags = annotTpe.typeSymbol.flags
     if (annotFlags.is(Flags.Abstract) || annotFlags.is(Flags.Trait)) {
-      Reporting.error(s"Bad annotation type ${annotTpe.show} is abstract")
+      report.error(s"Bad annotation type ${annotTpe.show} is abstract")
       '{???}
     } else {
       val r = new ReflectionUtils(qctx)
@@ -176,11 +176,11 @@ object AnnotationMacros {
             case Some(rm) =>
               mkAnnotations(rm.MirroredElemTypes.map { child => findAnnotation[A](child.typeSymbol) })
             case None =>
-              Reporting.error(s"No Annotations for sum type ${annoteeTpe.show} with no Mirror")
+              report.error(s"No Annotations for sum type ${annoteeTpe.show} with no Mirror")
               '{???}
           }
         case None =>
-          Reporting.error(s"No Annotations for non-class ${annoteeTpe.show}")
+          report.error(s"No Annotations for non-class ${annoteeTpe.show}")
           '{???}
       }
     }

--- a/modules/deriving/src/main/scala/shapeless3/deriving/reflectionutils.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/reflectionutils.scala
@@ -69,9 +69,9 @@ class ReflectionUtils[Q <: QuoteContext & Singleton](val q: Q) {
     loop(tp, Nil).reverse
   }
 
-  def low(tp: TypeOrBounds): Type = tp match {
-    case tp: Type => tp
+  def low(tp: Type): Type = tp match {
     case tp: TypeBounds => tp.low
+    case tp: Type => tp
   }
 
   def findMemberType(tp: Type, name: String): Option[Type] = tp match {

--- a/modules/typeable/src/main/scala/shapeless3/typeable/reflectionutils.scala
+++ b/modules/typeable/src/main/scala/shapeless3/typeable/reflectionutils.scala
@@ -69,9 +69,9 @@ class ReflectionUtils[Q <: QuoteContext & Singleton](val q: Q) {
     loop(tp, Nil).reverse
   }
 
-  def low(tp: TypeOrBounds): Type = tp match {
-    case tp: Type => tp
+  def low(tp: Type): Type = tp match {
     case tp: TypeBounds => tp.low
+    case tp: Type => tp
   }
 
   def findMemberType(tp: Type, name: String): Option[Type] = tp match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty"      % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty"      % "0.4.2")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.2")


### PR DESCRIPTION
* `Reporting.error` is now `report.error`
* `TypeOrBounds` was removed from dotty in [this commit](https://github.com/lampepfl/dotty/commit/6872bdbbc9b8028d73f3115b0c325ac8a57ea718).
    * That commit changed `TypeBounds` and `NoPrefix` from `scala.tasty.reflect.Reflection` to be subtypes of `Type`, where before they were not.
    * This has the consequence that pattern matches which were formerly on `TypeOrBounds` which care to discriminate on `NoPrefix` or `TypeBounds` must check these _before_ `Type`, e.g.
        ```scala
          (t: Type) match {
            case _: NoPrefix => ???
            case _: TypeBounds => ???
            case _: Type => ???
          }
        ```
* `AppliedType.apply` in dotty was replaced with an extension method on `Type` named `appliedTo`. Calls in Shapeless have been updated to reflect that.
* Updated the `sbt-dotty` plugin version
* Updated the `sbt` version