### PR TITLE
Fix match now seen as non-exhaustive.

### DIFF
--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -1906,6 +1906,7 @@ class HListTests {
 
     val is = l match {
       case i :: true :: s :: 2.0 :: HNil => (i, s)
+      case _ => sys.error("Not matched")
     }
 
     assertTypedEquals[Int](1, is._1)


### PR DESCRIPTION
This match was never exhaustive (the inferred types are widened to `Boolean`, `Double` etc.) but this is only being caught as of https://github.com/scala/scala/pull/9147.