### PR TITLE
Treat expected string as literal pattern

### DIFF
--- a/core/src/main/scala/shapeless/test/typechecking.scala
+++ b/core/src/main/scala/shapeless/test/typechecking.scala
@@ -43,7 +43,7 @@ class IllTypedMacros(val c: blackbox.Context) {
     val (expPat, expMsg) = expected match {
       case null => (null, "Expected some error.")
       case Literal(Constant(s: String)) =>
-        (Pattern.compile(s, Pattern.CASE_INSENSITIVE | Pattern.DOTALL), "Expected error matching: "+s)
+        (Pattern.compile(Pattern.quote(s), Pattern.CASE_INSENSITIVE | Pattern.DOTALL), "Expected error matching: "+s)
     }
 
     try {


### PR DESCRIPTION
This makes it easier to type-check against error strings that contain regex sensitive characters.
Without this, someone would have to manually escape such characters.