### PR TITLE
Don't try to release for 2.13.5/0.6.33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
         - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
       script:
         - sbt ci-release
-        - SCALA_JS_VERSION=0.6.33 sbt clean sonatypeBundleClean ci-release
+        - [ "$TRAVIS_SCALA_VERSION" = "2.13.5" ] || (export SCALA_JS_VERSION=0.6.33 ; sbt clean sonatypeBundleClean ci-release)
   exclude:
     - scala: 2.13.5
       env: SCALA_JS_VERSION=0.6.33

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Builds are available for Scala 2.11.x, 2.12.x and 2.13.x. The main line of devel
 shapeless 2.3.3 is Scala 2.13.2.
 
 ```scala
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.5"
 
 libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.3.3"
@@ -134,7 +134,7 @@ libraryDependencies ++= Seq(
 
 For using snapshots of Shapeless you should add,
 ```scala
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.5"
 
 libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.4.0-SNAPSHOT"


### PR DESCRIPTION
Publishing for the older ScalaJs release is orthogonal to the build matrix, so we also have to exclude the combination of 2.13.5 and 0.6.33 there too.