### PR TITLE
Loosen typeable restrictions

### DIFF
--- a/core/src/main/scala/shapeless/typeable.scala
+++ b/core/src/main/scala/shapeless/typeable.scala
@@ -468,9 +468,27 @@ class TypeableMacros(val c: blackbox.Context) extends SingletonTypeUtils {
   }
 
   private def mkCaseClassTypeable(tpe: Type): Tree = {
+    // an unsafe accessor is one that isn't a case class accessor but has an abstract type.
+    def isUnsafeAccessor(sym: TermSymbol): Boolean = {
+
+      if (sym.isCaseAccessor) {
+        false
+      } else {
+        val symType = sym.typeSignature.typeSymbol
+        val isAbstract =
+          symType.isAbstract ||           // Under Scala 2.10, isAbstract is spuriously false (macro-compat issue?)
+            (symType != NoSymbol && symType.owner == tpe.typeSymbol) // So check the owner as well
+
+        if (isAbstract) {
+          sym.isVal ||
+            sym.isVar ||
+            (sym.isParamAccessor && !(sym.accessed.isTerm && sym.accessed.asTerm.isCaseAccessor))
+        } else false
+      }
+    }
+
     val nonCaseAccessor = tpe.decls.exists {
-      case sym: TermSymbol if !sym.isCaseAccessor && (sym.isVal || sym.isVar ||
-        (sym.isParamAccessor && !(sym.accessed.isTerm && sym.accessed.asTerm.isCaseAccessor))) => true
+      case sym: TermSymbol if isUnsafeAccessor(sym) => true
       case _ => false
     }
     if (nonCaseAccessor) {

--- a/core/src/test/scala/shapeless/typeable.scala
+++ b/core/src/test/scala/shapeless/typeable.scala
@@ -659,4 +659,19 @@ class TypeableTests {
 
   }
 
+  @Test
+  def testValInNestedCaseClass: Unit = {
+    // https://github.com/milessabin/shapeless/issues/812
+    // This should compile if the issue is fixed.
+    object X {
+      case class A()
+      case class B(a: A) {
+        private[this] val aa = a
+      }
+    }
+    object Test {
+      shapeless.Typeable[X.B]
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes #812

Don't reject materializing a `Typeable` instance due to the presence of
a non-case-accessor value, unless its type is abstract.

Backport #900

