### PR TITLE
Expose CaseClassMacros as blackbox

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -295,7 +295,7 @@ trait ReprTypes {
 }
 
 trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
-  val c: whitebox.Context
+  val c: blackbox.Context
 
   import c.universe._
   import internal.constantType

--- a/core/src/main/scala/shapeless/generic1.scala
+++ b/core/src/main/scala/shapeless/generic1.scala
@@ -304,6 +304,7 @@ class IsCCons1Macros(val c: whitebox.Context) extends IsCons1Macros {
 }
 
 trait IsCons1Macros extends CaseClassMacros {
+  val c: whitebox.Context
   import c.ImplicitCandidate
   import c.internal._
   import c.universe._


### PR DESCRIPTION
`blackbox.Context` is a superclass of `whitebox.Context` so it's ok.

Backports #977
