### PR TITLE
Add mkAttributedRef specialized for SingleType

### DIFF
--- a/core/src/main/scala/shapeless/orphans.scala
+++ b/core/src/main/scala/shapeless/orphans.scala
@@ -72,12 +72,10 @@ class OrphanMacros(val c: whitebox.Context) extends CaseClassMacros {
         c.abort(c.enclosingPosition, "Backtrack")
     }
 
-    val deriver =
-      dTpe match {
-        case SingleType(pre, sym) => mkAttributedRef(pre, sym)
-        case other =>
-          c.abort(c.enclosingPosition, s"Deriver $dTpe not found")
-      }
+    val deriver = dTpe match {
+      case singleton: SingleType => mkAttributedRef(singleton)
+      case _ => c.abort(c.enclosingPosition, s"Deriver $dTpe not found")
+    }
 
     val inst = c.inferImplicitValue(appTpe, silent = true)
 


### PR DESCRIPTION
References to singleton types should refer to the getter if possible.
Fixes an issue where we would try to reference a non-existing field.

Backports #994
