### PR TITLE
Revert "Fix Lazy implicit resolution with type parameters"

### DIFF
--- a/core/src/main/scala/shapeless/lazy.scala
+++ b/core/src/main/scala/shapeless/lazy.scala
@@ -293,21 +293,17 @@ class LazyMacros(val c: whitebox.Context) extends CaseClassMacros with OpenImpli
 
       private var current = Option.empty[State]
 
-      private def typeParamsToWildcards(tpe: Type): Type = tpe.map { t =>
-        val sym = t.typeSymbol
-        if (sym.isParameter) boundedWildcardType(sym.info.asInstanceOf[TypeBounds]) else t
-      }
-
       def resolveInstance(state: State)(tpe: Type): Option[(State, Tree)] = {
         val former = State.current
         State.current = Some(state)
         val (state0, tree) =
           try {
-            val tree = c.inferImplicitValue(tpe, silent = true) orElse c.inferImplicitValue(typeParamsToWildcards(tpe), silent = true)
-            if (tree.isEmpty) {
-              tpe.typeSymbol.annotations
-                .find(_.tree.tpe =:= typeOf[_root_.scala.annotation.implicitNotFound])
-                .foreach(_ => setAnnotation(implicitNotFoundMessage(c)(tpe)))
+            val tree = c.inferImplicitValue(tpe, silent = true)
+            if(tree.isEmpty) {
+              tpe.typeSymbol.annotations.
+                find(_.tree.tpe =:= typeOf[_root_.scala.annotation.implicitNotFound]).foreach { _ =>
+                  setAnnotation(implicitNotFoundMessage(c)(tpe))
+                }
             }
             (State.current.get, tree)
           } finally {

--- a/core/src/test/scala/shapeless/lazy.scala
+++ b/core/src/test/scala/shapeless/lazy.scala
@@ -334,27 +334,3 @@ class LazyStrictTests {
     implicitly[Strict[Readable[Id]]]
   }
 }
-
-object TestLazyWithTypeParametersAndBounds {
-  trait Foo
-  case class BarFoo(i: Int) extends Foo
-
-  trait Fooer[Tpe, FooTpe] {
-    def makeFoo(obj: Tpe): FooTpe
-  }
-
-  object Fooer {
-    implicit val barFooer: Fooer[Int, BarFoo] = null
-  }
-
-  class Finder[Tpe] {
-    def find[F <: Foo](implicit fooer: Fooer[Tpe, F]) = fooer
-    def findLazy[F <: Foo](implicit fooer: Lazy[Fooer[Tpe, F]]) = fooer
-    def findNoBounds[F](implicit fooer: Lazy[Fooer[Tpe, F]]) = fooer
-  }
-
-  val intFinder = new Finder[Int]
-  intFinder.find
-  intFinder.findLazy
-  intFinder.findNoBounds
-}


### PR DESCRIPTION
Reverts milessabin/shapeless#1136

This breaks `kittens` so it doesn't pass the test of larger scale