### PR TITLE
Fix Coproduct case object singleton types

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -467,7 +467,7 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
 
         val ctor = if (isNamed) {
           if (sym.isModuleClass) {
-            sym.toTypeIn(pre)
+            singleType(pre, sym.module)
           } else {
             val subst = thisType(sym).baseType(baseSym).typeArgs.map(_.typeSymbol)
             val params = sym.typeParams

--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -1262,10 +1262,12 @@ object coproduct {
   object LiftAll {
     type Aux[F[_], In0 <: Coproduct, Out0 <: HList] = LiftAll[F, In0] {type Out = Out0}
 
-    class Curried[F[_]] {def apply[In <: Coproduct](in: In)(implicit ev: LiftAll[F, In]) = ev}
+    class Curried[F[_]] {
+      def apply[In <: Coproduct](in: In)(implicit ev: LiftAll[F, In]): Aux[F, In, ev.Out] = ev
+    }
 
-    def apply[F[_]] = new Curried[F]
-    def apply[F[_], In <: Coproduct](implicit ev: LiftAll[F, In]) = ev
+    def apply[F[_]]: Curried[F] = new Curried[F]
+    def apply[F[_], In <: Coproduct](implicit ev: LiftAll[F, In]): Aux[F, In, ev.Out] = ev
 
     implicit def liftAllCnil[F[_]]: LiftAll.Aux[F, CNil, HNil] = new LiftAll[F, CNil] {
       type Out = HNil

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -339,6 +339,9 @@ class GenericTests {
 
     val c1 = gen.from(c0)
     typed[Enum](c1)
+
+    val abc = ops.coproduct.LiftAll[Witness.Aux, gen.Repr]
+    assertEquals(List(A, B, C), abc.instances.toList.map(_.value))
   }
 
   @Test


### PR DESCRIPTION
Also don't lose type information in `LiftAll` for `Coproduct`s.