### PR TITLE
Reduce 2.12 / 2.13 Jar size by using instance constructors 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import com.typesafe.sbt.SbtGit.GitKeys._
-import com.typesafe.tools.mima.core.ProblemFilters._
 import com.typesafe.tools.mima.core._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtcrossproject.CrossProject
@@ -97,8 +96,8 @@ lazy val commonSettings = Seq(
 
   scalacOptions := scalacOptionsAll,
   Compile / compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, y)) if y == 12 => scalacOptions212
-    case Some((2, y)) if y >= 13 => scalacOptions213
+    case Some((2, 12)) => scalacOptions212
+    case Some((2, 13)) => scalacOptions213
     case _ => Nil
   }),
 

--- a/core/src/main/scala/shapeless/lazy.scala
+++ b/core/src/main/scala/shapeless/lazy.scala
@@ -344,7 +344,7 @@ class LazyMacros(val c: whitebox.Context) extends CaseClassMacros with OpenImpli
       name: String,
       dict: ListMap[TypeWrapper, Instance],
       open: List[Instance],
-      /** Types whose derivation must fail no matter what */
+      // Types whose derivation must fail no matter what
       prevent: List[TypeWrapper]
     ) {
       def addDependency(tpe: Type): State = {

--- a/core/src/main/scala/shapeless/ops/functions.scala
+++ b/core/src/main/scala/shapeless/ops/functions.scala
@@ -30,7 +30,13 @@ object function {
   }
 
   object FnToProduct extends FnToProductInstances {
+    type Aux[F, P] = FnToProduct[F] { type Out = P }
     def apply[F <: AnyRef](implicit fntop: FnToProduct[F]): Aux[F, fntop.Out] = fntop
+
+    private[shapeless] def instance[F, P](toProduct: F => P): Aux[F, P] = new FnToProduct[F] {
+      type Out = P
+      def apply(f: F) = toProduct(f)
+    }
   }
 
   /**
@@ -41,6 +47,12 @@ object function {
   trait FnFromProduct[F] extends DepFn1[F] with Serializable
     
   object FnFromProduct extends FnFromProductInstances {
+    type Aux[F, O] = FnFromProduct[F] { type Out = O }
     def apply[F](implicit fnfromp: FnFromProduct[F]): Aux[F, fnfromp.Out] = fnfromp
+
+    private[shapeless] def instance[P, F](fromProduct: P => F): Aux[P, F] = new FnFromProduct[P] {
+      type Out = F
+      def apply(f: P) = fromProduct(f)
+    }
   }
 }

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -771,13 +771,16 @@ object hlist {
   trait Tupler[L <: HList] extends DepFn1[L] with Serializable
 
   object Tupler extends TuplerInstances {
+    type Aux[L <: HList, T] = Tupler[L] { type Out = T }
     def apply[L <: HList](implicit tupler: Tupler[L]): Aux[L, tupler.Out] = tupler
 
+    private[shapeless] def instance[L <: HList, T](tuple: L => T): Aux[L, T] = new Tupler[L] {
+      type Out = T
+      def apply(l: L) = tuple(l)
+    }
+
     implicit val hnilTupler: Aux[HNil, Unit] =
-      new Tupler[HNil] {
-        type Out = Unit
-        def apply(l: HNil): Out = ()
-      }
+      instance(_ => ())
   }
 
   /**

--- a/core/src/main/scala/shapeless/sized.scala
+++ b/core/src/main/scala/shapeless/sized.scala
@@ -212,29 +212,32 @@ object AdditiveCollection extends AdditiveCollectionVersionSpecific {
   import scala.collection.immutable.Queue
   import scala.collection.LinearSeq
 
+  private[this] val instance =
+    new AdditiveCollection[Any] {}
+
   implicit def linearSeqAdditiveCollection[T]: AdditiveCollection[LinearSeq[T]] =
-    new AdditiveCollection[LinearSeq[T]] {}
+    instance.asInstanceOf[AdditiveCollection[LinearSeq[T]]]
 
   implicit def vectorAdditiveCollection[T]: AdditiveCollection[Vector[T]] =
-    new AdditiveCollection[Vector[T]] {}
+    instance.asInstanceOf[AdditiveCollection[Vector[T]]]
 
   implicit def arrayAdditiveCollection[T]: AdditiveCollection[Array[T]] =
-    new AdditiveCollection[Array[T]] {}
+    instance.asInstanceOf[AdditiveCollection[Array[T]]]
 
   implicit def stringAdditiveCollection: AdditiveCollection[String] =
-    new AdditiveCollection[String] {}
+    instance.asInstanceOf[AdditiveCollection[String]]
 
   implicit def listAdditiveCollection[T]: AdditiveCollection[List[T]] =
-    new AdditiveCollection[List[T]] {}
+    instance.asInstanceOf[AdditiveCollection[List[T]]]
 
   implicit def streamAdditiveCollection[T]: AdditiveCollection[LazyList[T]] =
-    new AdditiveCollection[LazyList[T]] {}
+    instance.asInstanceOf[AdditiveCollection[LazyList[T]]]
 
   implicit def queueAdditiveCollection[T]: AdditiveCollection[Queue[T]] =
-    new AdditiveCollection[Queue[T]] {}
+    instance.asInstanceOf[AdditiveCollection[Queue[T]]]
 
   implicit def defaultAdditiveCollection[T]: AdditiveCollection[collection.immutable.IndexedSeq[T]] =
-    new AdditiveCollection[collection.immutable.IndexedSeq[T]] {}
+    instance.asInstanceOf[AdditiveCollection[collection.immutable.IndexedSeq[T]]]
 }
 
 class DefaultToIndexedSeq[CC[_]]

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -140,18 +140,15 @@ object Boilerplate {
         |import hlist.Tupler
         |
         |trait TuplerInstances {
-        |  type Aux[L <: HList, Out0] = Tupler[L] { type Out = Out0 }
         -
-        -  implicit def hlistTupler$arity
-        -    [${`A..N`}]
-        -  : Aux[
+        -  implicit def hlistTupler$arity[
+        -    ${`A..N`}
+        -  ]: Tupler.Aux[
         -    ${`A::N`},
         -    ${`(A..N)`}
-        -  ] =
-        -    new Tupler[${`A::N`}] {
-        -      type Out = ${`(A..N)`}
-        -      def apply(l : ${`A::N`}): Out = l match { case ${`a::n`} => ${`(a..n)`} }
-        -    }        
+        -  ] = Tupler.instance { case ${`a::n`} =>
+        -    ${`(a..n)`}
+        -  }
         |}
       """
     }      
@@ -166,7 +163,9 @@ object Boilerplate {
 
       val fnType = s"(${`A..N`}) => Res"
       val hlistFnType = s"(${`A::N`}) => Res"
-      val fnBody = if (arity == 0) "fn()" else s"l match { case ${`a::n`} => fn(${`a..n`}) }" 
+      val fnBody =
+        if (arity == 0) "_ => fn()"
+        else s"{ case ${`a::n`} => fn(${`a..n`}) }"
       
       block"""
         |package ops
@@ -174,20 +173,13 @@ object Boilerplate {
         |import function.FnToProduct
         |
         |trait FnToProductInstances {
-        |  type Aux[F, Out0] = FnToProduct[F] { type Out = Out0 }
         -
-        -  implicit def fnToProduct$arity
-        -    [${`A..N,Res`}]
-        -  : Aux[
+        -  implicit def fnToProduct$arity[
+        -    ${`A..N,Res`}
+        -  ]: FnToProduct.Aux[
         -    ($fnType),
         -    $hlistFnType
-        -  ] =
-        -    new FnToProduct[$fnType] {
-        -      type Out = $hlistFnType
-        -      def apply(fn: $fnType): Out
-        -        = (l : ${`A::N`})
-        -          => $fnBody
-        -    }
+        -  ] = FnToProduct.instance(fn => $fnBody)
         |}
       """
     }
@@ -209,21 +201,16 @@ object Boilerplate {
         |import function.FnFromProduct
         |
         |trait FnFromProductInstances {
-        |  type Aux[F, Out0] = FnFromProduct[F] { type Out = Out0 }
-        |
-        -  implicit def fnFromProduct$arity
-        -    [${`A..N,Res`}]
-        -  : Aux[
+        -
+        -  implicit def fnFromProduct$arity[
+        -    ${`A..N,Res`}
+        -  ]: FnFromProduct.Aux[
         -    $hlistFnType,
         -    $fnType
-        -  ] = 
-        -    new FnFromProduct[$hlistFnType] {
-        -      type Out = $fnType
-        -      def apply(hf : $hlistFnType): Out
-        -        = (${`a:A..n:N`})
-        -          => hf(${`a::n`})
-        -    }
-        -
+        -  ] = FnFromProduct.instance { hf =>
+        -    (${`a:A..n:N`}) =>
+        -      hf(${`a::n`})
+        -  }
         |}
       """
     }
@@ -310,24 +297,20 @@ object Boilerplate {
         |trait Cases {
         |  import poly._
         |
-        -  type Case$arity[Fn, ${`A..N`}]
-        -    = Case[Fn, ${`A::N`}]
+        -  type Case$arity[Fn, ${`A..N`}] =
+        -    Case[Fn, ${`A::N`}]
         -
         -  object Case$arity {
-        -    type Aux[Fn, ${`A..N`}, Result0]
-        -      = Case[Fn, ${`A::N`}] { type Result = Result0 }
+        -    type Aux[Fn, ${`A..N`}, Result0] =
+        -      Case[Fn, ${`A::N`}] { type Result = Result0 }
         -
-        -    def apply
-        -      [Fn, ${`A..N`}, Result0]
-        -      (fn: (${`A..N`}) => Result0)
-        -    : Aux[Fn, ${`A..N`}, Result0] =
-        -      new Case[Fn, ${`A::N`}] {
-        -        type Result = Result0
-        -        val value = (l: ${`A::N`})
-        -          => l match {
-        -            case ${`a::n`} =>
-        -              fn(${`a..n`})
-        -          }
+        -    def apply[
+        -      Fn, ${`A..N`}, Result0
+        -    ](
+        -      fn: (${`A..N`}) => Result0
+        -    ): Aux[Fn, ${`A..N`}, Result0] =
+        -      Case { case ${`a::n`} =>
+        -        fn(${`a..n`})
         -      }
         -  }
         -
@@ -343,35 +326,35 @@ object Boilerplate {
     def content(tv: TemplateVals, scalaBinaryVersion: String): String = {
       import tv._
 
-      val fnBody = if (arity == 0) "fn()" else s"l match { case ${`a::n`} => fn(${`a..n`}) }" 
+      val fnBody =
+        if (arity == 0) "_ => fn()"
+        else s"{ case ${`a::n`} => fn(${`a..n`}) }"
 
       block"""
         |
         -
         -trait Poly$arity extends Poly { outer =>
-        -  type Case[${`A..N`}]
-        -    = poly.Case[this.type, ${`A::N`}]
+        -  type Case[${`A..N`}] =
+        -    poly.Case[this.type, ${`A::N`}]
         -
         -  object Case {
-        -    type Aux[${`A..N`}, Result0]
-        -      = poly.Case[outer.type, ${`A::N`}] { type Result = Result0 }
+        -    type Aux[${`A..N`}, Result0] =
+        -      poly.Case[outer.type, ${`A::N`}] { type Result = Result0 }
         -  }
         -
         -  class CaseBuilder[${`A..N`}] {
-        -    def apply[Res]
-        -      (fn: (${`A..N`}) => Res) = new Case[${`A..N`}] {
-        -      type Result = Res
-        -      val value = (l: ${`A::N`})
-        -        => $fnBody
-        -    }
+        -    def apply[Res](
+        -      fn: (${`A..N`}) => Res
+        -    ): Case.Aux[${`A..N`}, Res] =
+        -      poly.Case($fnBody)
         -  }
         -  
-        -  def at[${`A..N`}]
-        -    = new CaseBuilder[${`A..N`}]
+        -  def at[${`A..N`}] =
+        -    new CaseBuilder[${`A..N`}]
         -}
         -
         -object Poly$arity extends PolyNBuilders.Poly${arity}Builder[HNil] {
-        - val functions = HNil
+        -  val functions = HNil
         -}
         |
       """
@@ -422,17 +405,24 @@ object Boilerplate {
         - }
         -
         - object Function${arity}TypeAt {
-        -   implicit def at0[${`A..N`}, Out, Tail <: HList] = new Function${arity}TypeAt[${`A..N`}, Out, ((${`A..N`}) => Out)::Tail] {
-        -     def apply(l: ((${`A..N`}) => Out)::Tail): (${`A..N`}) => Out = {
-        -       l.head
+        -   private def instance[${`A..N`}, Out, HL <: HList](
+        -     f: HL => (${`A..N`}) => Out
+        -   ): Function${arity}TypeAt[${`A..N`}, Out, HL] =
+        -     new Function${arity}TypeAt[${`A..N`}, Out, HL] {
+        -       def apply(l: HL) = f(l)
         -     }
-        -   }
         -
-        -   implicit def atOther[${`A..N`}, Out, Tail <: HList, Head](implicit tprev: Function${arity}TypeAt[${`A..N`}, Out, Tail]) = new Function${arity}TypeAt[${`A..N`}, Out, Head::Tail] {
-        -     def apply(l: Head::Tail): (${`A..N`}) => Out = {
-        -       tprev(l.tail)
-        -     }
-        -   }
+        -   implicit def at0[
+        -     ${`A..N`}, Out, Tail <: HList
+        -   ]: Function${arity}TypeAt[${`A..N`}, Out, ((${`A..N`}) => Out) :: Tail] =
+        -     instance(_.head)
+        -
+        -   implicit def atOther[
+        -     ${`A..N`}, Out, Tail <: HList, Head
+        -   ](
+        -     implicit tprev: Function${arity}TypeAt[${`A..N`}, Out, Tail]
+        -   ): Function${arity}TypeAt[${`A..N`}, Out, Head :: Tail] =
+        -     instance(l => tprev(l.tail))
         - }
         |}
       """
@@ -462,30 +452,27 @@ object Boilerplate {
     def content(tv: TemplateVals, scalaBinaryVersion: String): String = {
       import tv._
 
-      val implicitArgs = (synTypes map(a => s"cast$a:Typeable[$a]")) mkString ", "
-      val enumerators = synTypes.zipWithIndex map { case (a,idx) => s"_ <- p._${idx+1}.cast[$a]" } mkString "; "
-      val castVals = (synTypes map(a => s"$${cast$a.describe}")) mkString ", "
+      val implicitArgs = synTypes.map(a => s"cast$a:Typeable[$a]").mkString(", ")
+      val enumerators = synTypes.zipWithIndex.map { case (a, i) => s"_ <- p._${i+1}.cast[$a]" }.mkString("; ")
+      val castVals = synTypes.map(a => s"$${cast$a.describe}").mkString(", ")
 
       block"""
         |
         |trait TupleTypeableInstances {
         |  import syntax.typeable._
-        |
-        -  implicit def tuple${arity}Typeable
-        -    [${`A..N`}]
-        -    (implicit $implicitArgs)
-        -  = new Typeable[${`(A..N)`}] {
-        -    def cast(t : Any) : Option[${`(A..N)`}] = {
-        -      if(t == null) None
-        -      else if(t.isInstanceOf[${`(_.._)`}]) {
-        -        val p = t.asInstanceOf[${`(_.._)`}]
-        -        for($enumerators)
-        -        yield t.asInstanceOf[${`(A..N)`}]
-        -      } else None
-        -    }
-        -    override def describe = s"($castVals)"
-        -  }
         -
+        -  implicit def tuple${arity}Typeable[
+        -    ${`A..N`}
+        -  ](
+        -    implicit $implicitArgs
+        -  ): Typeable[${`(A..N)`}] =
+        -    Typeable.instance(s"($castVals)") {
+        -      case p: ${`(_.._)`} =>
+        -        for ($enumerators)
+        -          yield p.asInstanceOf[${`(A..N)`}]
+        -      case _ =>
+        -        None
+        -    }
         |}
       """
     }        
@@ -569,6 +556,6 @@ object Boilerplate {
         -}
         |
       """
-    }      
+    }
   }
 }


### PR DESCRIPTION
Generate less anonymous classes for implicit instances,
esp. for tuple and function instances which are code generated.

Note: this slightly increases the Jar size on 2.11 because it doesn't translate to `LambdaMetaFactory`