### PR TITLE
Fix Coproduct case object singleton types

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -433,7 +433,7 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
 
         val ctor = if (isNamed) {
           if (sym.isModuleClass) {
-            sym.toTypeIn(pre)
+            singleType(pre, sym.module)
           } else {
             val subst = thisType(sym).baseType(baseSym).typeArgs.map(_.typeSymbol)
             val params = sym.typeParams

--- a/core/src/main/scala/shapeless/ops/coproduct.scala
+++ b/core/src/main/scala/shapeless/ops/coproduct.scala
@@ -1277,10 +1277,12 @@ object coproduct {
   object LiftAll {
     type Aux[F[_], In0 <: Coproduct, Out0 <: HList] = LiftAll[F, In0] {type Out = Out0}
 
-    class Curried[F[_]] {def apply[In <: Coproduct](in: In)(implicit ev: LiftAll[F, In]) = ev}
+    class Curried[F[_]] {
+      def apply[In <: Coproduct](in: In)(implicit ev: LiftAll[F, In]): Aux[F, In, ev.Out] = ev
+    }
 
-    def apply[F[_]] = new Curried[F]
-    def apply[F[_], In <: Coproduct](implicit ev: LiftAll[F, In]) = ev
+    def apply[F[_]]: Curried[F] = new Curried[F]
+    def apply[F[_], In <: Coproduct](implicit ev: LiftAll[F, In]): Aux[F, In, ev.Out] = ev
 
     implicit def liftAllCnil[F[_]]: LiftAll.Aux[F, CNil, HNil] = new LiftAll[F, CNil] {
       type Out = HNil

--- a/core/src/test/scala/shapeless/coproduct.scala
+++ b/core/src/test/scala/shapeless/coproduct.scala
@@ -1883,6 +1883,7 @@ class CoproductTests {
 
   @Test
   def testReify: Unit = {
+    import GenericTestsAux._
     import syntax.singleton._
 
     assertTypedEquals(HNil, Reify[CNil].apply())
@@ -1892,6 +1893,9 @@ class CoproductTests {
 
     val s2 = Coproduct.`"a", 1, "b", true`
     assertEquals("a".narrow :: 1.narrow :: "b".narrow :: true.narrow :: HNil, Reify[s2.T].apply())
+
+    val gen = Generic[Enum]
+    assertEquals(A :: B :: C :: HNil, Reify[gen.Repr].apply())
 
     illTyped("Reify[String :+: Int :+: CNil]")
     illTyped("""Reify[String :+: Coproduct.`"a", 1, "b", true`.T]""")

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -339,6 +339,9 @@ class GenericTests {
 
     val c1 = gen.from(c0)
     typed[Enum](c1)
+
+    val abc = ops.coproduct.LiftAll[Witness.Aux, gen.Repr]
+    assertEquals(List(A, B, C), abc.instances.toList.map(_.value))
   }
 
   @Test


### PR DESCRIPTION
Also don't lose type information in `LiftAll` for `Coproduct`s.
And add a regression test for `Reify`.

Forward port #1152 and #1157 