### PR TITLE
Fix subtle pickle compatibility problem with type aliases

### DIFF
--- a/core/src/main/scala/shapeless/ops/functions.scala
+++ b/core/src/main/scala/shapeless/ops/functions.scala
@@ -30,7 +30,6 @@ object function {
   }
 
   object FnToProduct extends FnToProductInstances {
-    type Aux[F, P] = FnToProduct[F] { type Out = P }
     def apply[F <: AnyRef](implicit fntop: FnToProduct[F]): Aux[F, fntop.Out] = fntop
 
     private[shapeless] def instance[F, P](toProduct: F => P): Aux[F, P] = new FnToProduct[F] {
@@ -47,7 +46,6 @@ object function {
   trait FnFromProduct[F] extends DepFn1[F] with Serializable
     
   object FnFromProduct extends FnFromProductInstances {
-    type Aux[F, O] = FnFromProduct[F] { type Out = O }
     def apply[F](implicit fnfromp: FnFromProduct[F]): Aux[F, fnfromp.Out] = fnfromp
 
     private[shapeless] def instance[P, F](fromProduct: P => F): Aux[P, F] = new FnFromProduct[P] {

--- a/core/src/main/scala/shapeless/ops/hlists.scala
+++ b/core/src/main/scala/shapeless/ops/hlists.scala
@@ -771,7 +771,6 @@ object hlist {
   trait Tupler[L <: HList] extends DepFn1[L] with Serializable
 
   object Tupler extends TuplerInstances {
-    type Aux[L <: HList, T] = Tupler[L] { type Out = T }
     def apply[L <: HList](implicit tupler: Tupler[L]): Aux[L, tupler.Out] = tupler
 
     private[shapeless] def instance[L <: HList, T](tuple: L => T): Aux[L, T] = new Tupler[L] {

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -140,10 +140,11 @@ object Boilerplate {
         |import hlist.Tupler
         |
         |trait TuplerInstances {
+        |  type Aux[L <: HList, T] = Tupler[L] { type Out = T }
         -
         -  implicit def hlistTupler$arity[
         -    ${`A..N`}
-        -  ]: Tupler.Aux[
+        -  ]: Aux[
         -    ${`A::N`},
         -    ${`(A..N)`}
         -  ] = Tupler.instance { case ${`a::n`} =>
@@ -173,10 +174,11 @@ object Boilerplate {
         |import function.FnToProduct
         |
         |trait FnToProductInstances {
+        |  type Aux[F, P] = FnToProduct[F] { type Out = P }
         -
         -  implicit def fnToProduct$arity[
         -    ${`A..N,Res`}
-        -  ]: FnToProduct.Aux[
+        -  ]: Aux[
         -    ($fnType),
         -    $hlistFnType
         -  ] = FnToProduct.instance(fn => $fnBody)
@@ -201,10 +203,11 @@ object Boilerplate {
         |import function.FnFromProduct
         |
         |trait FnFromProductInstances {
+        |  type Aux[F, O] = FnFromProduct[F] { type Out = O }
         -
         -  implicit def fnFromProduct$arity[
         -    ${`A..N,Res`}
-        -  ]: FnFromProduct.Aux[
+        -  ]: Aux[
         -    $hlistFnType,
         -    $fnType
         -  ] = FnFromProduct.instance { hf =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 scalacOptions += "-deprecation"
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.30"
 
-addSbtPlugin("com.typesafe"                      % "sbt-mima-plugin"       % "0.8.1")
+addSbtPlugin("com.typesafe"                      % "sbt-mima-plugin"       % "0.9.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-osgi"              % "0.9.6")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"         % "0.10.0")
 addSbtPlugin("com.geirsson"                      % "sbt-ci-release"        % "1.5.7")


### PR DESCRIPTION
Move `Aux` type aliases back to the parent traits of
`Tupler`, `FnFromProduct` and `FnToProduct`.
Also bump MiMa version to 0.9.0.