### PR TITLE
Add Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ boilerplate][syb] and [higher rank polymorphism][higherrank] in Scala. Since the
 experimental project into a library which, while still testing the limits of what's possible in Scala, is being used
 widely in production systems wherever there are arities to be abstracted over and boilerplate to be scrapped.
 
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/bSQBZA3Ced)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/milessabin/shapeless)
 [![Maven Central](https://img.shields.io/maven-central/v/com.chuusai/shapeless_2.13.svg)](https://maven-badges.herokuapp.com/maven-central/com.chuusai/shapeless_2.13)
 [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.8.svg)](https://www.scala-js.org)


### PR DESCRIPTION
Making the Discord support channel more visible by adding a badge to #doobie that never expires :)

This is how it looks like:

![Screen Shot 2021-05-14 at 00 32 06](https://user-images.githubusercontent.com/33580722/118195627-dbe99f80-b44b-11eb-9b4c-e6b5722adbfc.png)
