### PR TITLE
Revert source breaking change in TupleOps

### DIFF
--- a/core/src/main/scala/shapeless/syntax/std/tuples.scala
+++ b/core/src/main/scala/shapeless/syntax/std/tuples.scala
@@ -21,18 +21,16 @@ package std
 import shapeless.ops.hlist.ProductToHList
 
 trait LowPriorityTuple {
-  @deprecated("Ambiguous with productOps", "2.3.5")
-  def productTupleOps[P <: Product](p: P): TupleOps[P] = new TupleOps(p)
+  implicit def productTupleOps[P <: Product](p: P): TupleOps[P] = new TupleOps(p)
 }
 
 object tuple extends LowPriorityTuple {
-  @deprecated("Redundant with tupleOps", "2.3.5")
-  def unitTupleOps(u: Unit): TupleOps[Unit] = new TupleOps(u)
+  implicit def unitTupleOps(u: Unit): TupleOps[Unit] = new TupleOps(u)
 
   // Duplicated here from shapeless.HList so that explicit imports of tuple._ don't
   // clobber the conversion to HListOps.
   implicit def hlistOps[L <: HList](l : L) : HListOps[L] = new HListOps(l)
-  implicit def tupleOps[P: IsTuple](p: P): TupleOps[P] = new TupleOps(p)
+  private[shapeless] def tupleOps[P: IsTuple](p: P): TupleOps[P] = new TupleOps(p)
 }
 
 final class TupleOps[T](t: T) extends Serializable {

--- a/core/src/test/scala/shapeless/tuples.scala
+++ b/core/src/test/scala/shapeless/tuples.scala
@@ -1463,7 +1463,7 @@ class TupleTests {
 
   @Test
   def testPropagation: Unit = {
-    def useHead[P: IsTuple: IsComposite](p: P) = p.head
+    def useHead[P <: Product: IsComposite](p: P) = p.head
     val h = useHead((23, "foo", true))
     typed[Int](h)
   }
@@ -1972,12 +1972,5 @@ class TupleTests {
     illTyped("""
       (23, "foo").align[(String, String)]
     """)
-  }
-
-  @Test
-  def testCompatibilityWithProductSyntax: Unit = {
-    import syntax.std.product._
-    assertEquals(List(2, "a"), Foo(2, "a").to[List])
-    assertEquals(List(2, "a"), (2, "a").to[List])
   }
 }


### PR DESCRIPTION
Users might be using `TupleOps` in a generic context where they have `<: Product` but not `: IsTuple`.
Propagating the bound might force downstream libraries to break binary compatibility which is not good.

Reverts #1132 