### PR TITLE
The shapeless-3 README includes an incorrect build.sbt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ shapeless 3 is available for Scala 3.0.0. To include the deriving module in
 your project add the following to your build,
 
 ```
-libraryDependencies ++= Seq("org.typelevel" % "shapeless3-deriving" % "3.0.0")
+libraryDependencies ++= Seq("org.typelevel" %% "shapeless3-deriving" % "3.0.0")
 ```
 
 ## Finding out more about the project


### PR DESCRIPTION
The README docs for the sbt dependency is missing the Scala version. Changing `%` to `%%` corrects this problem.

Before:

```
[warn] 	Note: Unresolved dependencies path:
[error] stack trace is suppressed; run last update for the full output
[error] (update) sbt.librarymanagement.ResolveException: Error downloading org.typelevel:shapeless3-deriving:3.0.0
[error]   Not found
[error]   Not found
[error]   not found: /Users/username/.ivy2/localorg.typelevel/shapeless3-deriving/3.0.0/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/org/typelevel/shapeless3-deriving/3.0.0/shapeless3-deriving-3.0.0.pom
```

After
```
[info] Fetching artifacts of
https://repo1.maven.org/maven2/org/typelevel/shapeless3-deriving_3/3.0.0/shapeless3-deriving_3-3.0.0.jar
  100.0% [##########] 115.9 KiB (283.3 KiB / s)
```