### PR TITLE
Optimize sized.ToHList and ToSizedHList

### DIFF
--- a/core/src/main/scala_2.13+/shapeless/ops/traversables.scala
+++ b/core/src/main/scala_2.13+/shapeless/ops/traversables.scala
@@ -79,16 +79,14 @@ object traversable {
         type Out = Out0
       }
 
-    implicit def instance[CC[T] <: Iterable[T], A, N <: Nat](
+    implicit def instance[CC[T] <: Iterable[T], A, N <: Nat, O <: HList](
       implicit gt: IsRegularIterable[CC[A]],
       ac: AdditiveCollection[CC[A]],
       ti: ToInt[N],
-      th: ToHList[CC[A], N]
-    ): Aux[CC, A, N, Option[th.Out]] =
-      new ToSizedHList[CC, A, N] {
-        type Out = Option[th.Out]
-        def apply(as: CC[A]): Out =
-          as.sized[N].map(_.toHList)
-      }
+      th: ToHList.Aux[CC[A], N, O]
+    ): Aux[CC, A, N, Option[O]] = new ToSizedHList[CC, A, N] {
+      type Out = Option[O]
+      def apply(as: CC[A]): Out = as.sized[N].map(th.apply)
+    }
   }
 }

--- a/core/src/test/scala/shapeless/hlist.scala
+++ b/core/src/test/scala/shapeless/hlist.scala
@@ -18,7 +18,6 @@ package shapeless
 
 import org.junit.Test
 import org.junit.Assert._
-
 import test._
 import testutil._
 


### PR DESCRIPTION
 * Use type parameters and `Aux` instead of path-dependent types
 * Optimize runtime by replacing direct recursion with `foldRight`

Fixes #1181