### PR TITLE
Optimize sized.ToHList and ToSizedHList

### DIFF
--- a/core/src/main/scala/shapeless/ops/sizeds.scala
+++ b/core/src/main/scala/shapeless/ops/sizeds.scala
@@ -17,6 +17,8 @@
 package shapeless
 package ops
 
+import shapeless.ops.hlist.Fill
+
 object sized {
   /**
    * Type class supporting conversion of this `Sized` to an `HList` whose elements have the same type as in `Repr`.
@@ -29,19 +31,17 @@ object sized {
   }
 
   object ToHList {
-    type Aux[Repr, L <: Nat, Out0 <: HList] = ToHList[Repr, L] { type Out = Out0 }
+    type Aux[-Repr, L <: Nat, O <: HList] = ToHList[Repr, L] {
+      type Out = O
+    }
 
-    implicit val emptySizedToHList: Aux[Any, Nat._0, HNil] =
-      new ToHList[Any, Nat._0] {
-        type Out = HNil
-        def apply(s: Sized[Any, Nat._0]) = HNil
-      }
-
-    implicit def nonEmptySizedToHList[Repr, L <: Nat]
-      (implicit itl: IsRegularIterable[Repr], ev: AdditiveCollection[Repr], ts: ToHList[Repr, L]): Aux[Repr, Succ[L], itl.A :: ts.Out] =
-        new ToHList[Repr, Succ[L]] {
-          type Out = itl.A :: ts.Out
-          def apply(s: Sized[Repr, Succ[L]]) = s.head :: ts(s.tail)
-        }
+    implicit def instance[Repr, T, N <: Nat, O <: HList](
+      implicit itl: IsRegularIterable[Repr] { type A = T },
+      fill: Fill.Aux[N, T, O]
+    ): Aux[Repr, N, O] = new ToHList[Repr, N] {
+      type Out = O
+      def apply(s: Sized[Repr, N]): O =
+        itl(s.unsized).foldRight[HList](HNil)(_ :: _).asInstanceOf[O]
+    }
   }
 }

--- a/core/src/main/scala/shapeless/ops/traversables.scala
+++ b/core/src/main/scala/shapeless/ops/traversables.scala
@@ -81,18 +81,14 @@ object traversable {
         type Out = Out0
       }
 
-    implicit def instance[CC[T] <: Iterable[T], A, N <: Nat](
+    implicit def instance[CC[T] <: Iterable[T], A, N <: Nat, O <: HList](
       implicit gt: IsRegularIterable[CC[A]],
-               ac: AdditiveCollection[CC[A]],
-               ti: ToInt[N], 
-               th: ToHList[CC[A], N]
-    ): Aux[CC, A, N, Option[th.Out]] =
-      new ToSizedHList[CC, A, N] {
-        type Out = Option[th.Out]
-        def apply(as: CC[A]): Out =
-          as.sized[N].map(_.toHList)
-      }
-
+      ac: AdditiveCollection[CC[A]],
+      ti: ToInt[N],
+      th: ToHList.Aux[CC[A], N, O]
+    ): Aux[CC, A, N, Option[O]] = new ToSizedHList[CC, A, N] {
+      type Out = Option[O]
+      def apply(as: CC[A]): Out = as.sized[N].map(th.apply)
+    }
   }
-
 }


### PR DESCRIPTION
 * Use type parameters and `Aux` instead of path-dependent types
 * Optimize runtime by replacing direct recursion with `foldRight`

Forward port #1182 