### PR TITLE
Fix Generic instance for case classes with implicit arguments

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -874,7 +874,7 @@ trait CaseClassMacros extends ReprTypes with CaseClassMacrosVersionSpecifics {
           }
         val nonCaseParamLists: List[List[Tree]] = List.fill(numNonCaseParamLists(tpe))(Nil)
         new CtorDtor {
-          def construct(args: List[Tree]): Tree = q"${companionRef(tpe)}(...${args :: nonCaseParamLists})"
+          def construct(args: List[Tree]): Tree = q"${companionRef(tpe)}[..${tpe.typeArgs}](...${args :: nonCaseParamLists})"
           def binding: (Tree, List[Tree]) = (pattern, elems.map { case (binder, tpe) => narrow(q"$binder", tpe) })
           def reprBinding: (Tree, List[Tree]) = (reprPattern, elems.map { case (binder, tpe) => narrow1(q"$binder", tpe) })
         }

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -1354,3 +1354,16 @@ object HigherKinded {
 
   Generic[Pipo[Id]]
 }
+
+object CaseClassWithImplicits {
+  // https://github.com/milessabin/shapeless/issues/1189
+  trait ATypeClass[T]
+
+  case class AnUnrelatedCaseClass[T](v: T)
+
+  case class ACaseClassWithContextBound[T: ATypeClass]()
+  implicit def instance[T: ATypeClass]: ATypeClass[AnUnrelatedCaseClass[T]] = new ATypeClass[AnUnrelatedCaseClass[T]] {}
+
+  def shouldCompile[T: ATypeClass]
+  : Generic.Aux[ACaseClassWithContextBound[T], HNil] = Generic[ACaseClassWithContextBound[T]]
+}


### PR DESCRIPTION
The pull request fixed #1189 and added the test case referred in that issue.

Root cause of the bug:
The materialized `Generic` instances calls the CompanionObject's `apply` method without type parameters in the constructor. If the scala compiler cannot infer some type parameter, it cannot collect the correct implicit arguments.

Fix:
Let the constructor call the `apply` method with type parameters.



