### PR TITLE
Remove unnecessary asInstanceOf call

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -1066,7 +1066,7 @@ class GenericMacros(val c: whitebox.Context) extends CaseClassMacros {
     val (p, ts) = ctorDtor.binding
     val to = cq"$p => ${mkHListValue(ts)}.asInstanceOf[$repr]"
     val (rp, rts) = ctorDtor.reprBinding
-    val from = cq"$rp => ${ctorDtor.construct(rts)}.asInstanceOf[$tpe]"
+    val from = cq"$rp => ${ctorDtor.construct(rts)}"
     q"$generic.instance[$tpe, $repr]({ case $to }, { case $from })"
   }
 

--- a/core/src/test/scala_2.13+/shapeless/GenericTests213.scala
+++ b/core/src/test/scala_2.13+/shapeless/GenericTests213.scala
@@ -1,0 +1,13 @@
+package shapeless
+
+import shapeless.test.illTyped
+
+object GenericTests213 {
+  case class WrongApplySignature private(value: String)
+  object WrongApplySignature {
+    // We can't replace the synthetic `apply` method on Scala 2.11
+    def apply(v: String): Either[String, WrongApplySignature] = Left("No ways")
+  }
+
+  illTyped("Generic[WrongApplySignature]")
+}


### PR DESCRIPTION
Looks like it was necessary for some older version of Scala 2.13

Fixes #1194