### PR TITLE
Remove unnecessary asInstanceOf call

### DIFF
--- a/core/src/main/scala/shapeless/generic.scala
+++ b/core/src/main/scala/shapeless/generic.scala
@@ -969,7 +969,7 @@ class GenericMacros(val c: whitebox.Context) extends CaseClassMacros {
     val (p, ts) = ctorDtor.binding
     val to = cq"$p => ${mkHListValue(ts)}.asInstanceOf[$repr]"
     val (rp, rts) = ctorDtor.reprBinding
-    val from = cq"$rp => ${ctorDtor.construct(rts)}.asInstanceOf[$tpe]"
+    val from = cq"$rp => ${ctorDtor.construct(rts)}"
     q"$generic.instance[$tpe, $repr]({ case $to }, { case $from })"
   }
 

--- a/core/src/test/scala/shapeless/generic.scala
+++ b/core/src/test/scala/shapeless/generic.scala
@@ -1290,14 +1290,18 @@ object PrivateCtorDefns {
   sealed trait PublicFamily
   case class PublicChild() extends PublicFamily
   private case class PrivateChild() extends PublicFamily
+
+  case class WrongApplySignature private(value: String)
+  object WrongApplySignature {
+    def apply(v: String): Either[String, WrongApplySignature] = Left("No ways")
+  }
 }
 
 object PrivateCtor {
   import PrivateCtorDefns._
 
-  illTyped("""
-  Generic[Access.PublicFamily]
-  """)
+  illTyped("Generic[Access.PublicFamily]")
+  illTyped("Generic[WrongApplySignature]")
 }
 
 object Thrift {


### PR DESCRIPTION
Looks like it was necessary for some older version of Scala 2.13

Forward port #1197 