### PR TITLE
Concrete return type for `MkFieldLens.mkFieldLens`

### DIFF
--- a/core/shared/src/main/scala/shapeless/lenses.scala
+++ b/core/shared/src/main/scala/shapeless/lenses.scala
@@ -248,10 +248,10 @@ object MkFieldLens {
   implicit def mkFieldLens[A, K, R <: HList, B]
     (implicit
       mkGen: MkLabelledGenericLens.Aux[A, R],
-      mkLens: MkRecordSelectLens[R, K]): Aux[A, K, mkLens.Elem] =
+      mkLens: MkRecordSelectLens.Aux[R, K, B]): Aux[A, K, B] =
         new MkFieldLens[A, K] {
-          type Elem = mkLens.Elem
-          def apply(): Lens[A, mkLens.Elem] = mkLens() compose mkGen()
+          type Elem = B
+          def apply(): Lens[A, B] = mkLens() compose mkGen()
         }
 }
 


### PR DESCRIPTION
Fixes #1323