### PR TITLE
Bring README into line with Typelevel organisation Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@ all, regardless of level of experience, gender, gender identity and expression,
 sexual orientation, disability, personal appearance, body size, race,
 ethnicity, age, religion, nationality, or other such characteristics.
 
-Everyone is expected to follow the [Scala Code of Conduct] when discussing the
+Everyone is expected to follow the [Typelevel Code of Conduct] when discussing the
 project on the available communication channels. If you are being harassed,
 please contact us immediately so that we can support you.
 
@@ -14,6 +14,6 @@ please contact us immediately so that we can support you.
 Any questions, concerns, or moderation requests please contact a member of the
 project.
 
-- Miles Sabin: [gitter](https://gitter.im/milessabin) | [twitter](https://twitter.com/milessabin) | [email](mailto:miles@milessabin.com)
+- Miles Sabin: [email](mailto:miles@milessabin.com)
 
-[Scala Code of Conduct]: https://www.scala-lang.org/conduct/
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Moors and Odersky, [Type Classes as Object and Implicits][tcoi] is useful backgr
 
 ## Participation
 
-The shapeless project supports the [Scala Code of Conduct][codeofconduct] and wants all of its
+The shapeless project supports the [Typelevel Code of Conduct][codeofconduct] and wants all of its
 channels (mailing list, Gitter, IRC, github, etc.) to be welcoming environments for everyone.
 
 Whilst shapeless is a somewhat "advanced" Scala library, it is a lot more approachable than many people think.
@@ -69,7 +69,7 @@ Contributors are usually available to field questions, give advice and discuss i
 and for people wanting to take their first steps at contributing we have a selection of open issues flagged up as
 being [good candidates to take on][goodfirstissue]. No contribution is too small, and guidance is always available.
 
-[codeofconduct]: https://www.scala-lang.org/conduct/
+[codeofconduct]: https://typelevel.org/code-of-conduct.html
 [goodfirstissue]: https://github.com/milessabin/shapeless/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 
 ## Using shapeless


### PR DESCRIPTION
Typelevel has reverted to the Typelevel Code of Conduct organisation wide. This PR updates the README to align with that.